### PR TITLE
[HACKLE-9333] Change UIApplication.shared reference indirectly

### DIFF
--- a/Sources/Hackle/UI/ExplorerUI/HackleUserExplorerView.swift
+++ b/Sources/Hackle/UI/ExplorerUI/HackleUserExplorerView.swift
@@ -54,11 +54,11 @@ class HackleUserExplorerView {
 
     private func getKeyWindow() -> UIWindow? {
         if #available(iOS 13, *) {
-            return UIApplication.shared.windows.first { window in
+            return UIUtils.application.windows.first { window in
                 window.isKeyWindow
             }
         } else {
-            return UIApplication.shared.keyWindow
+            return UIUtils.application.keyWindow
         }
     }
 
@@ -100,7 +100,7 @@ class HackleUserExplorerView {
             }
             return min(size.width, size.height)
         } else {
-            let size = UIApplication.shared.statusBarFrame.size
+            let size = UIUtils.application.statusBarFrame.size
             return min(size.width, size.height)
         }
     }

--- a/Sources/Hackle/UI/Internal/HackleUIUtils.swift
+++ b/Sources/Hackle/UI/Internal/HackleUIUtils.swift
@@ -12,7 +12,7 @@ import UIKit
 class UIUtils {
 
     static var application: UIApplication {
-        UIApplication.shared
+        UIApplication.value(forKeyPath: #keyPath(UIApplication.shared)) as! UIApplication
     }
 
     static var interfaceOrientation: UIInterfaceOrientation {
@@ -42,11 +42,11 @@ class UIUtils {
 
     static var keyWindow: UIWindow? {
         if #available(iOS 13, *) {
-            return UIApplication.shared.windows.first { window in
+            return application.windows.first { window in
                 window.isKeyWindow
             }
         } else {
-            return UIApplication.shared.keyWindow
+            return application.keyWindow
         }
     }
 


### PR DESCRIPTION
### Summary

- Changed `UIApplication.shared` reference code to indirectly (`UIApplication.shared` cannot reference inside extension on iOS 13+)