### PR TITLE
2.36.0

### DIFF
--- a/Hackle.podspec
+++ b/Hackle.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 spec.name          = "Hackle"
 spec.module_name   = "Hackle"
-spec.version       = "2.35.0"
+spec.version       = "2.36.0"
 spec.summary       = "Hackle Sdk for iOS"
 spec.homepage      = "https://www.hackle.io"
 spec.license       = { :type => "Apache License, Version 2.0", :file => "LICENSE" }

--- a/Hackle.xcodeproj/project.pbxproj
+++ b/Hackle.xcodeproj/project.pbxproj
@@ -341,6 +341,7 @@
 		EE5A78FC2ADCEF97005A0F9E /* workspace_cohorts.json in Resources */ = {isa = PBXBuildFile; fileRef = EE5A78FB2ADCEF97005A0F9E /* workspace_cohorts.json */; };
 		EE5A78FE2ADCF1B5005A0F9E /* MockUserListener.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE5A78FD2ADCF1B5005A0F9E /* MockUserListener.swift */; };
 		EE5A79002ADCF248005A0F9E /* MockUserCohortFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE5A78FF2ADCF248005A0F9E /* MockUserCohortFetcher.swift */; };
+		EE60C0A32C37B13300830F0A /* Updated.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE60C0A22C37B13300830F0A /* Updated.swift */; };
 		EE668AEA2BC3E042003D3E15 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = EE668AE92BC3E042003D3E15 /* PrivacyInfo.xcprivacy */; };
 		EE6F8F2B29D496D10037C482 /* ExperimentExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE6F8F2A29D496D10037C482 /* ExperimentExtensions.swift */; };
 		EE750E2D2ADE704400DCE34F /* MockHackleCore.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE750E2C2ADE704400DCE34F /* MockHackleCore.swift */; };
@@ -392,6 +393,7 @@
 		EE86377729ED312F000268DC /* ExperimentConditionMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE86377629ED312F000268DC /* ExperimentConditionMatcher.swift */; };
 		EE929D8B2BFFAC70003B7596 /* UserEventFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE929D8A2BFFAC70003B7596 /* UserEventFilter.swift */; };
 		EE929D8D2BFFACD7003B7596 /* DedupUserEventFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE929D8C2BFFACD7003B7596 /* DedupUserEventFilter.swift */; };
+		EE93FF8E2C37F1C1008A317D /* IdentifierSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE93FF8D2C37F1C1008A317D /* IdentifierSpecs.swift */; };
 		EE9E49102B6B6F0000436530 /* EvaluatorContextSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE9E490F2B6B6F0000436530 /* EvaluatorContextSpecs.swift */; };
 		EEA01CB42A3069B000E0C021 /* InAppMessagePresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEA01CB32A3069B000E0C021 /* InAppMessagePresenter.swift */; };
 		EEA01CB62A3069C400E0C021 /* InAppMessageDeterminer.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEA01CB52A3069C400E0C021 /* InAppMessageDeterminer.swift */; };
@@ -459,7 +461,7 @@
 		EEDC58712ACBD807001E73DB /* PollingSynchronizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEDC58702ACBD807001E73DB /* PollingSynchronizer.swift */; };
 		EEDC58732ACBD80B001E73DB /* CompositeSynchronizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEDC58722ACBD80B001E73DB /* CompositeSynchronizer.swift */; };
 		EEDC58762ACBD82E001E73DB /* PollingSynchronizerSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEDC58752ACBD82D001E73DB /* PollingSynchronizerSpecs.swift */; };
-		EEDC58782ACBD835001E73DB /* DefaultCompositeSynchronizerSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEDC58772ACBD835001E73DB /* DefaultCompositeSynchronizerSpecs.swift */; };
+		EEDC58782ACBD835001E73DB /* CompositeSynchronizerSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEDC58772ACBD835001E73DB /* CompositeSynchronizerSpecs.swift */; };
 		EEDC587A2ACBD90E001E73DB /* MockSynchronizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEDC58792ACBD90E001E73DB /* MockSynchronizer.swift */; };
 		EEDC587C2ACBDA78001E73DB /* WorkspaceManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEDC587B2ACBDA78001E73DB /* WorkspaceManager.swift */; };
 		EEDC587E2ACBDA88001E73DB /* WorkspaceManagerSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEDC587D2ACBDA88001E73DB /* WorkspaceManagerSpecs.swift */; };
@@ -853,6 +855,7 @@
 		EE5A78FB2ADCEF97005A0F9E /* workspace_cohorts.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = workspace_cohorts.json; sourceTree = "<group>"; };
 		EE5A78FD2ADCF1B5005A0F9E /* MockUserListener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockUserListener.swift; sourceTree = "<group>"; };
 		EE5A78FF2ADCF248005A0F9E /* MockUserCohortFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockUserCohortFetcher.swift; sourceTree = "<group>"; };
+		EE60C0A22C37B13300830F0A /* Updated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Updated.swift; sourceTree = "<group>"; };
 		EE668AE92BC3E042003D3E15 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		EE6F8F2A29D496D10037C482 /* ExperimentExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperimentExtensions.swift; sourceTree = "<group>"; };
 		EE750E2C2ADE704400DCE34F /* MockHackleCore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockHackleCore.swift; sourceTree = "<group>"; };
@@ -904,6 +907,7 @@
 		EE86377629ED312F000268DC /* ExperimentConditionMatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperimentConditionMatcher.swift; sourceTree = "<group>"; };
 		EE929D8A2BFFAC70003B7596 /* UserEventFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserEventFilter.swift; sourceTree = "<group>"; };
 		EE929D8C2BFFACD7003B7596 /* DedupUserEventFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DedupUserEventFilter.swift; sourceTree = "<group>"; };
+		EE93FF8D2C37F1C1008A317D /* IdentifierSpecs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentifierSpecs.swift; sourceTree = "<group>"; };
 		EE9E490F2B6B6F0000436530 /* EvaluatorContextSpecs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EvaluatorContextSpecs.swift; sourceTree = "<group>"; };
 		EEA01CB32A3069B000E0C021 /* InAppMessagePresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppMessagePresenter.swift; sourceTree = "<group>"; };
 		EEA01CB52A3069C400E0C021 /* InAppMessageDeterminer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppMessageDeterminer.swift; sourceTree = "<group>"; };
@@ -968,7 +972,7 @@
 		EEDC58702ACBD807001E73DB /* PollingSynchronizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PollingSynchronizer.swift; sourceTree = "<group>"; };
 		EEDC58722ACBD80B001E73DB /* CompositeSynchronizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompositeSynchronizer.swift; sourceTree = "<group>"; };
 		EEDC58752ACBD82D001E73DB /* PollingSynchronizerSpecs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PollingSynchronizerSpecs.swift; sourceTree = "<group>"; };
-		EEDC58772ACBD835001E73DB /* DefaultCompositeSynchronizerSpecs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultCompositeSynchronizerSpecs.swift; sourceTree = "<group>"; };
+		EEDC58772ACBD835001E73DB /* CompositeSynchronizerSpecs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompositeSynchronizerSpecs.swift; sourceTree = "<group>"; };
 		EEDC58792ACBD90E001E73DB /* MockSynchronizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSynchronizer.swift; sourceTree = "<group>"; };
 		EEDC587B2ACBDA78001E73DB /* WorkspaceManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceManager.swift; sourceTree = "<group>"; };
 		EEDC587D2ACBDA88001E73DB /* WorkspaceManagerSpecs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceManagerSpecs.swift; sourceTree = "<group>"; };
@@ -1468,6 +1472,7 @@
 				EE29D8F629CD825300B1FEAA /* Scheduler.swift */,
 				EE29D8F729CD825300B1FEAA /* SdkVersion.swift */,
 				EE5A78DC2ADAEC83005A0F9E /* Base64.swift */,
+				EE60C0A22C37B13300830F0A /* Updated.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -1869,6 +1874,7 @@
 			children = (
 				EE29D9EB29CD82C100B1FEAA /* MockUserManager.swift */,
 				EE5A78FD2ADCF1B5005A0F9E /* MockUserListener.swift */,
+				EE93FF8D2C37F1C1008A317D /* IdentifierSpecs.swift */,
 				EE5A78FF2ADCF248005A0F9E /* MockUserCohortFetcher.swift */,
 				EE29D9ED29CD82C100B1FEAA /* DefaultUserManagerSpecs.swift */,
 				EEDC58642ACB241D001E73DB /* HackleUserSpecs.swift */,
@@ -2443,7 +2449,7 @@
 		EEDC58742ACBD818001E73DB /* Sync */ = {
 			isa = PBXGroup;
 			children = (
-				EEDC58772ACBD835001E73DB /* DefaultCompositeSynchronizerSpecs.swift */,
+				EEDC58772ACBD835001E73DB /* CompositeSynchronizerSpecs.swift */,
 				EEDC58752ACBD82D001E73DB /* PollingSynchronizerSpecs.swift */,
 				EEDC58792ACBD90E001E73DB /* MockSynchronizer.swift */,
 				EE5A78DE2ADBE8E0005A0F9E /* SynchronizerSpecs.swift */,
@@ -2780,6 +2786,7 @@
 				7E4666342B3021E400B3CDCF /* NotificationClickAction.swift in Sources */,
 				EE929D8D2BFFACD7003B7596 /* DedupUserEventFilter.swift in Sources */,
 				EE29D99429CD825400B1FEAA /* OperatorMatcher.swift in Sources */,
+				EE60C0A32C37B13300830F0A /* Updated.swift in Sources */,
 				EE29D99A29CD825500B1FEAA /* ContainerResolver.swift in Sources */,
 				EE29D94A29CD825400B1FEAA /* MetricRegistry.swift in Sources */,
 				EE29D94629CD825400B1FEAA /* FlushMetric.swift in Sources */,
@@ -3075,6 +3082,7 @@
 				EEF895A62A4A6BA800722CF6 /* DefaultInAppMessageEventMatcherSpecs.swift in Sources */,
 				EE29DA5729CD82C200B1FEAA /* HackleTimer.swift in Sources */,
 				EEAC3F3D2B9D6A8800DC498E /* MockPushTokenManager.swift in Sources */,
+				EE93FF8E2C37F1C1008A317D /* IdentifierSpecs.swift in Sources */,
 				EEF8959C2A49B87B00722CF6 /* DefaultInAppMessageDeterminerSpecs.swift in Sources */,
 				EEF895B52A4AD96D00722CF6 /* AppStateManagerStub.swift in Sources */,
 				EE750E2D2ADE704400DCE34F /* MockHackleCore.swift in Sources */,
@@ -3142,7 +3150,7 @@
 				EE543CD92C099D9D00F64BFA /* DefaultAppStateManagerSpecs.swift in Sources */,
 				7E9DDDB82B30355C006ACFDA /* NotificationDataSpecs.swift in Sources */,
 				EE29DA6129CD82C200B1FEAA /* MetricSpecs.swift in Sources */,
-				EEDC58782ACBD835001E73DB /* DefaultCompositeSynchronizerSpecs.swift in Sources */,
+				EEDC58782ACBD835001E73DB /* CompositeSynchronizerSpecs.swift in Sources */,
 				EE543CD72C099D9300F64BFA /* MockLifecycleListener.swift in Sources */,
 				EE29DA9729CD82C200B1FEAA /* ExperimentFlowEvaluatorSpecs.swift in Sources */,
 				7E9065C12B5E666300FE6E52 /* DefaultWorkspaceConfigRepositorySpecs.swift in Sources */,

--- a/Sources/Hackle/Core/Engagement/EngagementManager.swift
+++ b/Sources/Hackle/Core/Engagement/EngagementManager.swift
@@ -44,7 +44,7 @@ class EngagementManager: ScreenListener, LifecycleListener {
     }
 
     private func publish(engagement: Engagement, user: User, timestamp: Date) {
-        Log.debug("EngagementManager.onEngagement(engagement: \(engagement))")
+        Log.debug("EngagementManager.publish(engagement: \(engagement))")
         for listener in listeners {
             listener.onEngagement(engagement: engagement, user: user, timestamp: timestamp)
         }
@@ -59,6 +59,7 @@ class EngagementManager: ScreenListener, LifecycleListener {
     }
 
     func onLifecycle(lifecycle: Lifecycle, timestamp: Date) {
+        Log.debug("EngagementManager.onLifecycle(lifecycle: \(lifecycle))")
         switch lifecycle {
         case .didBecomeActive:
             startEngagement(timestamp: timestamp)

--- a/Sources/Hackle/Core/Event/UserEventProcessor.swift
+++ b/Sources/Hackle/Core/Event/UserEventProcessor.swift
@@ -143,6 +143,7 @@ class DefaultUserEventProcessor: UserEventProcessor, AppStateListener {
     }
 
     func onState(state: AppState, timestamp: Date) {
+        Log.debug("UserEventProcessor.onState(state: \(state))")
         switch state {
         case .foreground:
             start()

--- a/Sources/Hackle/Core/Lifecycle/AppStateManager.swift
+++ b/Sources/Hackle/Core/Lifecycle/AppStateManager.swift
@@ -31,16 +31,13 @@ class DefaultAppStateManager: AppStateManager, LifecycleListener {
     }
 
     private func onState(state: AppState, timestamp: Date) {
-        queue.async { [weak self] in
-            guard let self = self else {
-                return
-            }
+        queue.async {
             self.publish(state: state, timestamp: timestamp)
         }
     }
 
     private func publish(state: AppState, timestamp: Date) {
-        Log.debug("AppStateManager.onState(state: \(state))")
+        Log.debug("AppStateManager.publish(state: \(state))")
         for listener in listeners {
             listener.onState(state: state, timestamp: timestamp)
         }
@@ -48,6 +45,7 @@ class DefaultAppStateManager: AppStateManager, LifecycleListener {
     }
 
     func onLifecycle(lifecycle: Lifecycle, timestamp: Date) {
+        Log.debug("AppStateManager.onLifecycle(lifecycle: \(lifecycle))")
         switch lifecycle {
         case .didBecomeActive:
             onState(state: .foreground, timestamp: timestamp)

--- a/Sources/Hackle/Core/Lifecycle/LifecycleManager.swift
+++ b/Sources/Hackle/Core/Lifecycle/LifecycleManager.swift
@@ -73,7 +73,7 @@ class LifecycleManager: LifecyclePublisher {
 
 
     private func publish(lifecycle: Lifecycle, timestamp: Date) {
-        Log.debug("LifecycleManager.onLifecycle(lifecycle: \(lifecycle))")
+        Log.debug("LifecycleManager.publish(lifecycle: \(lifecycle))")
         for listener in listeners {
             listener.onLifecycle(lifecycle: lifecycle, timestamp: timestamp)
         }

--- a/Sources/Hackle/Core/Metrics/Push/PushMetricRegistry.swift
+++ b/Sources/Hackle/Core/Metrics/Push/PushMetricRegistry.swift
@@ -24,6 +24,7 @@ class PushMetricRegistry: MetricRegistry, AppStateListener {
     }
 
     final func onState(state: AppState, timestamp: Date) {
+        Log.debug("PushMetricRegistry.onState(state: \(state))")
         switch state {
         case .foreground:
             start()

--- a/Sources/Hackle/Core/Model/InAppMessage.swift
+++ b/Sources/Hackle/Core/Model/InAppMessage.swift
@@ -136,11 +136,13 @@ extension InAppMessage {
     }
 
     enum DisplayType: String, Codable {
+        case none = "NONE"
         case modal = "MODAL"
         case banner = "BANNER"
     }
 
     enum LayoutType: String, Codable {
+        case none = "NONE"
         case imageText = "IMAGE_TEXT"
         case imageOnly = "IMAGE_ONLY"
         case textOnly = "TEXT_ONLY"

--- a/Sources/Hackle/Core/Monitoring/Metric/MonitoringMetricRegistry.swift
+++ b/Sources/Hackle/Core/Monitoring/Metric/MonitoringMetricRegistry.swift
@@ -29,6 +29,7 @@ class MonitoringMetricRegistry: MetricRegistry, AppStateListener {
     }
 
     func onState(state: AppState, timestamp: Date) {
+        Log.debug("MonitoringMetricRegistry.onState(state: \(state))")
         switch state {
         case .foreground: return
         case .background:

--- a/Sources/Hackle/Core/Screen/ScreenManager.swift
+++ b/Sources/Hackle/Core/Screen/ScreenManager.swift
@@ -39,20 +39,21 @@ class DefaultScreenManager: ScreenManager, LifecycleListener {
     }
 
     private func publishStart(previousScreen: Screen?, screen: Screen, user: User, timestamp: Date) {
-        Log.debug("ScreenManager.onScreenStarted(previousScreen: \(previousScreen?.description ?? "nil"), currentScreen: \(screen))")
+        Log.debug("ScreenManager.publishStart(previousScreen: \(previousScreen?.description ?? "nil"), currentScreen: \(screen))")
         for listener in listeners {
             listener.onScreenStarted(previousScreen: previousScreen, currentScreen: screen, user: user, timestamp: timestamp)
         }
     }
 
     private func publishEnd(screen: Screen, user: User, timestamp: Date) {
-        Log.debug("ScreenManager.onScreenEnded(screen: \(screen))")
+        Log.debug("ScreenManager.publishEnd(screen: \(screen))")
         for listener in listeners {
             listener.onScreenEnded(screen: screen, user: user, timestamp: timestamp)
         }
     }
 
     func onLifecycle(lifecycle: Lifecycle, timestamp: Date) {
+        Log.debug("ScreenManager.onLifecycle(lifecycle: \(lifecycle))")
         switch lifecycle {
         case .didBecomeActive(let top):
             guard let top = top else {

--- a/Sources/Hackle/Core/Session/SessionManager.swift
+++ b/Sources/Hackle/Core/Session/SessionManager.swift
@@ -91,10 +91,10 @@ class DefaultSessionManager: SessionManager, AppStateListener, UserListener {
             return
         }
 
+        Log.debug("SessionManager.publishEnd(session: \(oldSession.id))")
         for listener in sessionListeners {
             listener.onSessionEnded(session: oldSession, user: user, timestamp: lastEventTime)
         }
-        Log.debug("Session ended [$\(oldSession.id)]")
     }
 
     @discardableResult
@@ -105,16 +105,15 @@ class DefaultSessionManager: SessionManager, AppStateListener, UserListener {
 
         updateLastEventTime(timestamp: timestamp)
 
+        Log.debug("SessionManager.publishStart(session: \(newSession.id))")
         for listener in sessionListeners {
             listener.onSessionStarted(session: newSession, user: user, timestamp: timestamp)
         }
-        Log.debug("Session started [\(newSession.id)]")
         return newSession
     }
 
     private func saveSession(session: Session) {
         keyValueRepository.putString(key: DefaultSessionManager.SESSION_ID_KEY, value: session.id)
-        Log.debug("Session saved [\(session.id)]")
     }
 
     private func loadSession() {
@@ -133,6 +132,7 @@ class DefaultSessionManager: SessionManager, AppStateListener, UserListener {
     }
 
     func onState(state: AppState, timestamp: Date) {
+        Log.debug("SessionManager.onState(state: \(state))")
         switch state {
         case .foreground:
             startNewSessionIfNeeded(user: userManager.currentUser, timestamp: timestamp)

--- a/Sources/Hackle/Core/Sync/PollingSynchronizer.swift
+++ b/Sources/Hackle/Core/Sync/PollingSynchronizer.swift
@@ -42,12 +42,12 @@ class PollingSynchronizer: CompositeSynchronizer, AppStateListener {
             return
         }
 
-        lock.write { [weak self] in
-            if self?.pollingJob != nil {
+        lock.write {
+            if pollingJob != nil {
                 return
             }
 
-            self?.pollingJob = self?.scheduler.schedulePeriodically(delay: interval, period: interval, task: poll)
+            pollingJob = scheduler.schedulePeriodically(delay: interval, period: interval, task: poll)
             Log.info("PollingSynchronizer started polling. Poll every \(interval)s")
         }
     }
@@ -56,14 +56,15 @@ class PollingSynchronizer: CompositeSynchronizer, AppStateListener {
         if interval == HackleConfig.NO_POLLING {
             return
         }
-        lock.write { [weak self] in
-            self?.pollingJob?.cancel()
-            self?.pollingJob = nil
+        lock.write {
+            pollingJob?.cancel()
+            pollingJob = nil
             Log.info("PollingSynchronizer stopped polling.")
         }
     }
 
     func onState(state: AppState, timestamp: Date) {
+        Log.debug("PollingSynchronizer.onState(state: \(state))")
         switch state {
         case .foreground:
             start()

--- a/Sources/Hackle/Core/Sync/PollingSynchronizer.swift
+++ b/Sources/Hackle/Core/Sync/PollingSynchronizer.swift
@@ -1,23 +1,16 @@
-//
-//  PollingSynchronizer.swift
-//  Hackle
-//
-//  Created by yong on 2023/10/02.
-//
-
 import Foundation
 
 
-class PollingSynchronizer: CompositeSynchronizer, AppStateListener {
+class PollingSynchronizer: Synchronizer, AppStateListener {
 
     private let lock: ReadWriteLock = ReadWriteLock(label: "io.hackle.PollingSynchronizer.Lock")
 
-    private let delegate: CompositeSynchronizer
+    private let delegate: Synchronizer
     private let scheduler: Scheduler
     private let interval: TimeInterval
     private var pollingJob: ScheduledJob? = nil
 
-    init(delegate: CompositeSynchronizer, scheduler: Scheduler, interval: TimeInterval) {
+    init(delegate: Synchronizer, scheduler: Scheduler, interval: TimeInterval) {
         self.delegate = delegate
         self.scheduler = scheduler
         self.interval = interval
@@ -25,10 +18,6 @@ class PollingSynchronizer: CompositeSynchronizer, AppStateListener {
 
     func sync(completion: @escaping (Result<(), Error>) -> ()) {
         delegate.sync(completion: completion)
-    }
-
-    func syncOnly(type: SynchronizerType, completion: @escaping (Result<(), Error>) -> ()) {
-        delegate.syncOnly(type: type, completion: completion)
     }
 
     private func poll() {

--- a/Sources/Hackle/Core/User/Identifier.swift
+++ b/Sources/Hackle/Core/User/Identifier.swift
@@ -1,10 +1,3 @@
-//
-//  Identifiers.swift
-//  Hackle
-//
-//  Created by yong on 2023/10/03.
-//
-
 import Foundation
 
 enum IdentifierType: String, Codable {
@@ -44,10 +37,11 @@ extension Identifiers {
     }
 
     func contains(identifier: Identifier) -> Bool {
-        guard let identifierValue = self[identifier.type] else {
-            return false
-        }
-        return identifierValue == identifier.value
+        contains(type: identifier.type, value: identifier.value)
+    }
+
+    func contains(type: String, value: String) -> Bool {
+        value == self[type]
     }
 }
 

--- a/Sources/Hackle/Core/User/UserManager.swift
+++ b/Sources/Hackle/Core/User/UserManager.swift
@@ -202,10 +202,10 @@ class DefaultUserManager: UserManager, AppStateListener {
     }
 
     private func changeUser(oldUser: User, newUser: User, timestamp: Date) {
+        Log.debug("UserManager.publishUserUpdated()")
         for listener in userListeners {
             listener.onUserUpdated(oldUser: oldUser, newUser: newUser, timestamp: timestamp)
         }
-        Log.debug("User changed")
     }
 
     private func loadUser() -> User? {
@@ -232,6 +232,7 @@ class DefaultUserManager: UserManager, AppStateListener {
     }
 
     func onState(state: AppState, timestamp: Date) {
+        Log.debug("UserManager.onState(state: \(state))")
         switch state {
         case .foreground: return
         case .background: saveUser(user: currentUser)

--- a/Sources/Hackle/Core/User/UserManager.swift
+++ b/Sources/Hackle/Core/User/UserManager.swift
@@ -1,10 +1,3 @@
-//
-//  UserManager.swift
-//  Hackle
-//
-//  Created by yong on 2022/12/16.
-//
-
 import Foundation
 
 
@@ -19,19 +12,21 @@ protocol UserManager: Synchronizer {
     func toHackleUser(user: User) -> HackleUser
 
     @discardableResult
-    func setUser(user: User) -> User
+    func setUser(user: User) -> Updated<User>
 
     @discardableResult
-    func setUserId(userId: String?) -> User
+    func setUserId(userId: String?) -> Updated<User>
 
     @discardableResult
-    func setDeviceId(deviceId: String) -> User
+    func setDeviceId(deviceId: String) -> Updated<User>
 
     @discardableResult
-    func updateProperties(operations: PropertyOperations) -> User
+    func updateProperties(operations: PropertyOperations) -> Updated<User>
 
     @discardableResult
-    func resetUser() -> User
+    func resetUser() -> Updated<User>
+
+    func syncIfNeeded(updated: Updated<User>, completion: @escaping () -> ())
 }
 
 class DefaultUserManager: UserManager, AppStateListener {
@@ -80,6 +75,8 @@ class DefaultUserManager: UserManager, AppStateListener {
         Log.debug("UserManager initialized [\(currentUser)]")
     }
 
+    // HackleUser resolve
+
     func resolve(user: User?) -> HackleUser {
         guard let user else {
             return toHackleUser(context: currentContext)
@@ -88,40 +85,12 @@ class DefaultUserManager: UserManager, AppStateListener {
         let context = lock.write {
             updateUser(user: user)
         }
-        return toHackleUser(context: context)
+        return toHackleUser(context: context.current)
     }
 
     func toHackleUser(user: User) -> HackleUser {
         let context = context.with(user: user)
         return toHackleUser(context: context)
-    }
-
-    func sync(completion: @escaping (Result<(), Error>) -> ()) {
-        sync(user: currentUser, completion: completion)
-    }
-
-    private func sync(user: User, completion: @escaping (Result<(), Error>) -> ()) {
-        cohortFetcher.fetch(user: user) { [weak self] result in
-            guard let self = self else {
-                completion(.failure(HackleError.error("Failed to user sync: instance deallocated")))
-                return
-            }
-            self.handle(result: result, completion: completion)
-        }
-    }
-
-    private func handle(result: Result<UserCohorts, Error>, completion: @escaping (Result<(), Error>) -> ()) {
-        switch result {
-        case .success(let cohorts):
-            lock.write {
-                context = context.update(cohorts: cohorts)
-            }
-            completion(.success(()))
-            return
-        case .failure(let error):
-            completion(.failure(error))
-            return
-        }
     }
 
     private func toHackleUser(context: UserContext) -> HackleUser {
@@ -139,55 +108,114 @@ class DefaultUserManager: UserManager, AppStateListener {
             .build()
     }
 
-    func setUser(user: User) -> User {
-        lock.write {
-            updateUser(user: user).user
+    // Sync
+
+    func sync(completion: @escaping (Result<(), Error>) -> ()) {
+        sync(user: currentUser, completion: completion)
+    }
+
+    private func sync(user: User, completion: @escaping (Result<(), Error>) -> ()) {
+        cohortFetcher.fetch(user: user) { [weak self] result in
+            guard let self = self else {
+                completion(.failure(HackleError.error("Failed to user sync: instance deallocated")))
+                return
+            }
+            self.handle(result: result, completion: completion)
         }
     }
 
-    func setUserId(userId: String?) -> User {
-        lock.write {
-            updateUser(user: context.user.toBuilder().userId(userId).build()).user
+    func syncIfNeeded(updated: Updated<User>, completion: @escaping () -> ()) {
+        guard hasNewIdentifiers(previousUser: updated.previous, currentUser: updated.current) else {
+            completion()
+            return
+        }
+        sync(completion: completion)
+    }
+
+    private func hasNewIdentifiers(previousUser: User, currentUser: User) -> Bool {
+        let previousIdentifiers = previousUser.resolvedIdentifiers
+        let currentIdentifiers = currentUser.resolvedIdentifiers
+
+        return currentIdentifiers.contains { type, value in
+            !previousIdentifiers.contains(type: type, value: value)
         }
     }
 
-    func setDeviceId(deviceId: String) -> User {
-        lock.write {
-            updateUser(user: context.user.toBuilder().deviceId(deviceId).build()).user
+    private func handle(result: Result<UserCohorts, Error>, completion: @escaping (Result<(), Error>) -> ()) {
+        switch result {
+        case .success(let cohorts):
+            lock.write {
+                context = context.update(cohorts: cohorts)
+            }
+            completion(.success(()))
+            return
+        case .failure(let error):
+            completion(.failure(error))
+            return
         }
     }
 
-    func resetUser() -> User {
+    // User update
+
+    func setUser(user: User) -> Updated<User> {
+        lock.write {
+            updateUser(user: user).map { it in
+                it.user
+            }
+        }
+    }
+
+    func setUserId(userId: String?) -> Updated<User> {
+        lock.write {
+            updateUser(user: context.user.toBuilder().userId(userId).build()).map { it in
+                it.user
+            }
+        }
+    }
+
+    func setDeviceId(deviceId: String) -> Updated<User> {
+        lock.write {
+            updateUser(user: context.user.toBuilder().deviceId(deviceId).build()).map { it in
+                it.user
+            }
+        }
+    }
+
+    func resetUser() -> Updated<User> {
         lock.write {
             let context = updateContext { _ in
                 defaultUser
             }
-            return context.user
+            return context.map { it in
+                it.user
+            }
         }
     }
 
-    func updateProperties(operations: PropertyOperations) -> User {
+    func updateProperties(operations: PropertyOperations) -> Updated<User> {
         lock.write {
-            operateProperties(operations: operations)
+            operateProperties(operations: operations).map { it in
+                it.user
+            }
         }
     }
 
-    private func updateUser(user: User) -> UserContext {
+    private func updateUser(user: User) -> Updated<UserContext> {
         updateContext { currentUser in
             user.with(device: device).mergeWith(other: currentUser)
         }
     }
 
-    private func operateProperties(operations: PropertyOperations) -> User {
-        let context = updateContext { currentUser in
+    private func operateProperties(operations: PropertyOperations) -> Updated<UserContext> {
+        updateContext { currentUser in
             let properties = operations.operate(base: currentUser.properties)
             return currentUser.with(properties: properties)
         }
-        return context.user
     }
 
-    private func updateContext(updater: (User) -> User) -> UserContext {
-        let oldUser = context.user
+    private func updateContext(updater: (User) -> User) -> Updated<UserContext> {
+        let oldContext = context
+        let oldUser = oldContext.user
         let newUser = updater(oldUser)
 
         let newContext = context.with(user: newUser)
@@ -197,8 +225,8 @@ class DefaultUserManager: UserManager, AppStateListener {
             changeUser(oldUser: oldUser, newUser: newUser, timestamp: Date())
         }
 
-        Log.debug("UserContext updated: \(newContext)")
-        return newContext
+        saveUser(user: newUser)
+        return Updated(previous: oldContext, current: newContext)
     }
 
     private func changeUser(oldUser: User, newUser: User, timestamp: Date) {

--- a/Sources/Hackle/Core/Utilities/SdkVersion.swift
+++ b/Sources/Hackle/Core/Utilities/SdkVersion.swift
@@ -5,5 +5,5 @@
 import Foundation
 
 class SdkVersion {
-    static let CURRENT = "2.35.0"
+    static let CURRENT = "2.36.0"
 }

--- a/Sources/Hackle/Core/Utilities/Updated.swift
+++ b/Sources/Hackle/Core/Utilities/Updated.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+class Updated<T> {
+
+    let previous: T
+    let current: T
+
+    init(previous: T, current: T) {
+        self.previous = previous
+        self.current = current
+    }
+}
+
+extension Updated {
+    func map<R>(_ transform: (T) -> R) -> Updated<R> {
+        Updated<R>(previous: transform(previous), current: transform(current))
+    }
+}

--- a/Sources/Hackle/UI/InAppMessageUI/InAppMessageUI.swift
+++ b/Sources/Hackle/UI/InAppMessageUI/InAppMessageUI.swift
@@ -41,7 +41,6 @@ class HackleInAppMessageUI: NSObject, InAppMessagePresenter {
 
         // Message View
         guard let messageView = createMessageView(context: context) else {
-            Log.error("Failed to create InAppMessageView [\(context.message.layout.displayType)]")
             return
         }
 

--- a/Sources/Hackle/UI/InAppMessageUI/InAppMessageUIExt.swift
+++ b/Sources/Hackle/UI/InAppMessageUI/InAppMessageUIExt.swift
@@ -1,10 +1,3 @@
-//
-//  InAppMessageUIExt.swift
-//  Hackle
-//
-//  Created by yong on 2023/06/12.
-//
-
 import Foundation
 import UIKit
 
@@ -12,6 +5,8 @@ extension HackleInAppMessageUI {
 
     func createMessageView(context: InAppMessagePresentationContext) -> InAppMessageView? {
         switch (context.message.layout.displayType, context.message.layout.layoutType) {
+        case (.none, _):
+            return nil
         case (.modal, _):
             let attributes = ModalView.Attributes(orientation: InAppMessage.Orientation(UIUtils.interfaceOrientation))
             return ModalView(context: context, attributes: attributes)
@@ -28,6 +23,7 @@ extension HackleInAppMessageUI {
             }
             return BannerImageView(context: context, alignment: alignment, attributes: .defaults)
         default:
+            Log.error("Failed to create InAppMessageView [\(context.message.layout.displayType), \(context.message.layout.layoutType)]")
             return nil
         }
     }

--- a/Tests/HackleTests/Core/Sync/MockSynchronizer.swift
+++ b/Tests/HackleTests/Core/Sync/MockSynchronizer.swift
@@ -9,13 +9,10 @@ import Foundation
 import Mockery
 @testable import Hackle
 
-class MockSynchronizer: Mock, CompositeSynchronizer {
+class MockSynchronizer: Mock, Synchronizer {
     override init() {
         super.init()
         every(syncMock).answers { completion in
-            completion(.success(()))
-        }
-        every(syncOnlyMock).answers { type, completion in
             completion(.success(()))
         }
     }
@@ -25,12 +22,4 @@ class MockSynchronizer: Mock, CompositeSynchronizer {
     func sync(completion: @escaping (Result<(), Error>) -> ()) {
         call(syncMock, args: completion)
     }
-
-    lazy var syncOnlyMock = MockFunction(self, syncOnly)
-
-    func syncOnly(type: SynchronizerType, completion: @escaping (Result<(), Error>) -> ()) {
-        call(syncOnlyMock, args: (type, completion))
-    }
 }
-
-

--- a/Tests/HackleTests/Core/Sync/PollingSynchronizerSpecs.swift
+++ b/Tests/HackleTests/Core/Sync/PollingSynchronizerSpecs.swift
@@ -1,10 +1,3 @@
-//
-//  PollingSynchronizerSpecs.swift
-//  HackleTests
-//
-//  Created by yong on 2023/10/02.
-//
-
 import Foundation
 import Nimble
 import Quick
@@ -26,23 +19,6 @@ class PollingSynchronizerSpecs: QuickSpec {
                 // then
                 verify(exactly: 1) {
                     delegate.syncMock
-                }
-            }
-        }
-
-        describe("sync only") {
-            it("delegate") {
-                // given
-                let delegate = MockSynchronizer()
-                let sut = PollingSynchronizer(delegate: delegate, scheduler: Schedulers.dispatch(), interval: 10)
-
-                // when
-                sut.syncOnly(type: .cohort) {
-                }
-
-                // then
-                verify(exactly: 1) {
-                    delegate.syncOnlyMock
                 }
             }
         }

--- a/Tests/HackleTests/Core/Sync/SynchronizerSpecs.swift
+++ b/Tests/HackleTests/Core/Sync/SynchronizerSpecs.swift
@@ -26,33 +26,10 @@ class SynchronizerSpecs: QuickSpec {
                 }
             }
         }
-
-        describe("CompositeSynchronizerExtensions") {
-            describe("CompositeSynchronizer.sync(() -> ())") {
-                it("success") {
-                    let counter = CumulativeMetricRegistry().counter(name: "counter")
-                    let sut = SynchronizerStub(.success(()))
-                    sut.syncOnly(type: .workspace) {
-                        counter.increment()
-                    }
-                    expect(counter.count()) == 1
-                }
-
-                it("failure") {
-                    let counter = CumulativeMetricRegistry().counter(name: "counter")
-                    let sut = SynchronizerStub(.failure(HackleError.error("fail")))
-                    sut.syncOnly(type: .workspace) {
-                        counter.increment()
-                    }
-                    expect(counter.count()) == 1
-                }
-            }
-        }
     }
 }
 
-
-class SynchronizerStub: CompositeSynchronizer {
+class SynchronizerStub: Synchronizer {
 
     private let result: Result<Void, Error>
 
@@ -61,10 +38,6 @@ class SynchronizerStub: CompositeSynchronizer {
     }
 
     func sync(completion: @escaping (Result<(), Error>) -> ()) {
-        completion(result)
-    }
-
-    func syncOnly(type: SynchronizerType, completion: @escaping (Result<(), Error>) -> ()) {
         completion(result)
     }
 }

--- a/Tests/HackleTests/Core/User/IdentifierSpecs.swift
+++ b/Tests/HackleTests/Core/User/IdentifierSpecs.swift
@@ -1,0 +1,14 @@
+import Foundation
+import Quick
+import Nimble
+@testable import Hackle
+
+class IdentifierSpecs: QuickSpec {
+    override func spec() {
+        it("contains") {
+            expect(["a": "b"].contains(type: "a", value: "b")) == true
+            expect(["a": "b"].contains(type: "a", value: "a")) == false
+            expect(["a": "b"].contains(type: "b", value: "b")) == false
+        }
+    }
+}

--- a/Tests/HackleTests/HackleAppSpec.swift
+++ b/Tests/HackleTests/HackleAppSpec.swift
@@ -89,10 +89,9 @@ class HackleAppSpecs: QuickSpec {
                     userManager.setUserMock
                 }
                 verify(exactly: 1) {
-                    synchronizer.syncOnlyMock
+                    userManager.syncIfNeededMock
                 }
                 expect(userManager.setUserMock.firstInvokation().arguments).to(beIdenticalTo(user))
-                expect(synchronizer.syncOnlyMock.firstInvokation().arguments.0) == .cohort
             }
 
             it("completion") {
@@ -112,10 +111,9 @@ class HackleAppSpecs: QuickSpec {
                     userManager.setUserIdMock
                 }
                 verify(exactly: 1) {
-                    synchronizer.syncOnlyMock
+                    userManager.syncIfNeededMock
                 }
                 expect(userManager.setUserIdMock.firstInvokation().arguments) == "user_id"
-                expect(synchronizer.syncOnlyMock.firstInvokation().arguments.0) == .cohort
             }
 
             it("completion") {
@@ -134,10 +132,9 @@ class HackleAppSpecs: QuickSpec {
                     userManager.setDeviceIdMock
                 }
                 verify(exactly: 1) {
-                    synchronizer.syncOnlyMock
+                    userManager.syncIfNeededMock
                 }
                 expect(userManager.setDeviceIdMock.firstInvokation().arguments) == "device_id"
-                expect(synchronizer.syncOnlyMock.firstInvokation().arguments.0) == .cohort
             }
 
             it("completion") {
@@ -159,10 +156,9 @@ class HackleAppSpecs: QuickSpec {
                     core.trackMock
                 }
                 verify(exactly: 1) {
-                    synchronizer.syncOnlyMock
+                    userManager.syncIfNeededMock
                 }
                 expect(core.trackMock.firstInvokation().arguments.0.key) == "$properties"
-                expect(synchronizer.syncOnlyMock.firstInvokation().arguments.0) == .cohort
             }
             it("completion") {
                 var count = 0
@@ -183,7 +179,7 @@ class HackleAppSpecs: QuickSpec {
                     core.trackMock
                 }
                 verify(exactly: 0) {
-                    synchronizer.syncOnlyMock
+                    userManager.syncIfNeededMock
                 }
                 expect(userManager.updatePropertiesMock.firstInvokation().arguments.asDictionary()[.set] as? [String: Int]) == ["age": 42]
                 expect(core.trackMock.firstInvokation().arguments.0.key) == "$properties"
@@ -209,7 +205,7 @@ class HackleAppSpecs: QuickSpec {
                     core.trackMock
                 }
                 verify(exactly: 0) {
-                    synchronizer.syncOnlyMock
+                    userManager.syncIfNeededMock
                 }
                 expect(core.trackMock.firstInvokation().arguments.0.key) == "$properties"
                 expect(core.trackMock.firstInvokation().arguments.0.properties?["$set"] as? [String: Int]) == ["age": 42]


### PR DESCRIPTION
### Added
- Supports unexposed control group for in-app message A/B testing
- Synchronize cohorts only when identifiers are updated