### PR TITLE
[Incident-234] cfboolean check

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,7 @@ jobs:
         name: Test Result
         with:
           path: TestResults.xcresult
+          upload-bundles: 'never'
         if: success() || failure()
       - name: Comment PR
         uses: thollander/actions-comment-pull-request@v2

--- a/Sources/Hackle/Core/Utilities/Objects.swift
+++ b/Sources/Hackle/Core/Utilities/Objects.swift
@@ -10,7 +10,7 @@ class Objects {
     }
 
     static func asIntOrNull(_ value: Any) -> Int64? {
-        if CFGetTypeID(value as CFTypeRef) != CFNumberGetTypeID() {
+        if isBoolType(value) {
             return nil
         }
         
@@ -30,7 +30,7 @@ class Objects {
     }
 
     static func asDoubleOrNil(_ value: Any) -> Double? {
-        if CFGetTypeID(value as CFTypeRef) != CFNumberGetTypeID() {
+        if isBoolType(value) {
             return nil
         }
         
@@ -46,12 +46,19 @@ class Objects {
         if let swiftBool = value as? Bool {
             return swiftBool
         }
-        
-        if CFGetTypeID(value as CFTypeRef) == CFBooleanGetTypeID() {
-            return (value as! CFBoolean) == kCFBooleanTrue
-        }
-            
         return nil
+    }
+    
+    static func isBoolType(_ value: Any) -> Bool {
+        let isBool = value is Bool
+        let isNSNumberType = isNSNumberType(value)
+        return isBool && !isNSNumberType
+    }
+
+    static func isNSNumberType(_ value: Any) -> Bool {
+        let valueType = type(of: value)
+        let nsNumberType = type(of: NSNumber(value: 0))
+        return valueType == nsNumberType
     }
 }
 

--- a/Sources/Hackle/Core/Utilities/Objects.swift
+++ b/Sources/Hackle/Core/Utilities/Objects.swift
@@ -10,6 +10,10 @@ class Objects {
     }
 
     static func asIntOrNull(_ value: Any) -> Int64? {
+        if CFGetTypeID(value as CFTypeRef) != CFNumberGetTypeID() {
+            return nil
+        }
+        
         switch value {
         case is Int: return Int64(value as! Int)
         case is Int8: return Int64(value as! Int8)
@@ -26,6 +30,10 @@ class Objects {
     }
 
     static func asDoubleOrNil(_ value: Any) -> Double? {
+        if CFGetTypeID(value as CFTypeRef) != CFNumberGetTypeID() {
+            return nil
+        }
+        
         switch value {
         case is Double: return Double(value as! Double)
         case is Float: return Double(value as! Float)
@@ -35,10 +43,15 @@ class Objects {
     }
 
     static func asBoolOrNil(_ value: Any) -> Bool? {
-        guard let value = value as? Bool else {
-            return nil
+        if let swiftBool = value as? Bool {
+            return swiftBool
         }
-        return value
+        
+        if CFGetTypeID(value as CFTypeRef) == CFBooleanGetTypeID() {
+            return (value as! CFBoolean) == kCFBooleanTrue
+        }
+            
+        return nil
     }
 }
 

--- a/Sources/Hackle/Core/Utilities/Objects.swift
+++ b/Sources/Hackle/Core/Utilities/Objects.swift
@@ -43,6 +43,10 @@ class Objects {
     }
 
     static func asBoolOrNil(_ value: Any) -> Bool? {
+        if !isBoolType(value) {
+            return nil
+        }
+        
         if let swiftBool = value as? Bool {
             return swiftBool
         }

--- a/Tests/HackleTests/Core/Evaluation/Match/ValueMatcherSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Match/ValueMatcherSpecs.swift
@@ -4,38 +4,57 @@ import Nimble
 import Mockery
 @testable import Hackle
 
-
 class ValueMatcherSpecs: QuickSpec {
+
+    private func v(_ value: Any) -> Any {
+        let tmp = ["tmp": value]
+        let data = Json.serialize(tmp)!
+        let dict = try! JSONSerialization.jsonObject(with: data) as! [String: Any]
+        return dict["tmp"]!
+    }
+
+    private func verify(sut: ValueMatcher, userValue: Any, matchValue: HackleValue, expected: Bool) {
+        let matcher = InMatcher()
+        let v1 = userValue
+        let a1 = sut.matches(operatorMatcher: matcher, userValue: v1, matchValue: matchValue)
+        expect(a1).to(equal(expected))
+
+        let v2 = v(userValue)
+        let a2 = sut.matches(operatorMatcher: matcher, userValue: v2, matchValue: matchValue)
+        expect(a2).to(equal(expected))
+    }
+
     override func spec() {
 
         describe("StringMatcher") {
             let sut = StringMatcher()
 
             it("string type match") {
-                expect(sut.matches(operatorMatcher: InMatcher(), userValue: "42", matchValue: HackleValue(value: "42"))).to(beTrue())
+                self.verify(sut: sut, userValue: "42", matchValue: HackleValue(value: "42"), expected: true)
+                self.verify(sut: sut, userValue: "42", matchValue: HackleValue(value: "42"), expected: true)
             }
 
             it("number 타입이면 캐스팅 후 match") {
-                expect(sut.matches(operatorMatcher: InMatcher(), userValue: "42", matchValue: HackleValue(value: 42))).to(beTrue())
-                expect(sut.matches(operatorMatcher: InMatcher(), userValue: 42, matchValue: HackleValue(value: "42"))).to(beTrue())
-                expect(sut.matches(operatorMatcher: InMatcher(), userValue: 42, matchValue: HackleValue(value: 42))).to(beTrue())
+                self.verify(sut: sut, userValue: "42", matchValue: HackleValue(value: 42), expected: true)
+                self.verify(sut: sut, userValue: 42, matchValue: HackleValue(value: "42"), expected: true)
+                self.verify(sut: sut, userValue: 42, matchValue: HackleValue(value: 42), expected: true)
             }
-            
+
             it("bool 타입이면 캐스팅 후 match") {
-                expect(sut.matches(operatorMatcher: InMatcher(), userValue: "true", matchValue: HackleValue(value: true))).to(beTrue())
-                expect(sut.matches(operatorMatcher: InMatcher(), userValue: true, matchValue: HackleValue(value: "true"))).to(beTrue())
-                expect(sut.matches(operatorMatcher: InMatcher(), userValue: true, matchValue: HackleValue(value: true))).to(beTrue())
-                expect(sut.matches(operatorMatcher: InMatcher(), userValue: "false", matchValue: HackleValue(value: false))).to(beTrue())
-                expect(sut.matches(operatorMatcher: InMatcher(), userValue: false, matchValue: HackleValue(value: "false"))).to(beTrue())
-                expect(sut.matches(operatorMatcher: InMatcher(), userValue: false, matchValue: HackleValue(value: false))).to(beTrue())
-                
-                expect(sut.matches(operatorMatcher: InMatcher(), userValue: true, matchValue: HackleValue(value: "TRUE"))).to(beFalse())
-                expect(sut.matches(operatorMatcher: InMatcher(), userValue: false, matchValue: HackleValue(value: "FALSE"))).to(beFalse())
+                self.verify(sut: sut, userValue: "true", matchValue: HackleValue(value: true), expected: true)
+                self.verify(sut: sut, userValue: true, matchValue: HackleValue(value: "true"), expected: true)
+                self.verify(sut: sut, userValue: true, matchValue: HackleValue(value: true), expected: true)
+                self.verify(sut: sut, userValue: "false", matchValue: HackleValue(value: false), expected: true)
+                self.verify(sut: sut, userValue: false, matchValue: HackleValue(value: "false"), expected: true)
+                self.verify(sut: sut, userValue: false, matchValue: HackleValue(value: false), expected: true)
+
+                self.verify(sut: sut, userValue: true, matchValue: HackleValue(value: "TRUE"), expected: false)
+                self.verify(sut: sut, userValue: false, matchValue: HackleValue(value: "FALSE"), expected: false)
             }
 
             it("지원하지 않는 type") {
-                expect(sut.matches(operatorMatcher: InMatcher(), userValue: true, matchValue: HackleValue(value: "1"))).to(beFalse())
-                expect(sut.matches(operatorMatcher: InMatcher(), userValue: "1", matchValue: HackleValue(value: true))).to(beFalse())
+                self.verify(sut: sut, userValue: true, matchValue: HackleValue(value: "1"), expected: false)
+                self.verify(sut: sut, userValue: "1", matchValue: HackleValue(value: true), expected: false)
             }
         }
 
@@ -44,28 +63,28 @@ class ValueMatcherSpecs: QuickSpec {
             let sut = NumberMatcher()
 
             it("number type") {
-                expect(sut.matches(operatorMatcher: InMatcher(), userValue: 42, matchValue: HackleValue(value: 42))).to(beTrue())
-                expect(sut.matches(operatorMatcher: InMatcher(), userValue: 42.1, matchValue: HackleValue(value: 42.1))).to(beTrue())
-                expect(sut.matches(operatorMatcher: InMatcher(), userValue: 42.0, matchValue: HackleValue(value: 42))).to(beTrue())
-                expect(sut.matches(operatorMatcher: InMatcher(), userValue: 42, matchValue: HackleValue(value: 42.0))).to(beTrue())
-                expect(sut.matches(operatorMatcher: InMatcher(), userValue: 0, matchValue: HackleValue(value: 0.0))).to(beTrue())
+                self.verify(sut: sut, userValue: 42, matchValue: HackleValue(value: 42), expected: true)
+                self.verify(sut: sut, userValue: 42.1, matchValue: HackleValue(value: 42.1), expected: true)
+                self.verify(sut: sut, userValue: 42.0, matchValue: HackleValue(value: 42), expected: true)
+                self.verify(sut: sut, userValue: 42, matchValue: HackleValue(value: 42.0), expected: true)
+                self.verify(sut: sut, userValue: 0, matchValue: HackleValue(value: 0.0), expected: true)
             }
 
             it("string type 이면 캐스팅후 match") {
-                expect(sut.matches(operatorMatcher: InMatcher(), userValue: "42", matchValue: HackleValue(value: "42"))).to(beTrue())
-                expect(sut.matches(operatorMatcher: InMatcher(), userValue: "42", matchValue: HackleValue(value: 42))).to(beTrue())
-                expect(sut.matches(operatorMatcher: InMatcher(), userValue: 42, matchValue: HackleValue(value: "42"))).to(beTrue())
+                self.verify(sut: sut, userValue: "42", matchValue: HackleValue(value: "42"), expected: true)
+                self.verify(sut: sut, userValue: "42", matchValue: HackleValue(value: 42), expected: true)
+                self.verify(sut: sut, userValue: 42, matchValue: HackleValue(value: "42"), expected: true)
 
-                expect(sut.matches(operatorMatcher: InMatcher(), userValue: "42.42", matchValue: HackleValue(value: "42.42"))).to(beTrue())
-                expect(sut.matches(operatorMatcher: InMatcher(), userValue: "42.42", matchValue: HackleValue(value: 42.42))).to(beTrue())
-                expect(sut.matches(operatorMatcher: InMatcher(), userValue: 42.42, matchValue: HackleValue(value: "42.42"))).to(beTrue())
+                self.verify(sut: sut, userValue: "42.42", matchValue: HackleValue(value: "42.42"), expected: true)
+                self.verify(sut: sut, userValue: "42.42", matchValue: HackleValue(value: 42.42), expected: true)
+                self.verify(sut: sut, userValue: 42.42, matchValue: HackleValue(value: "42.42"), expected: true)
             }
 
             it("지원하지 않는 type") {
-                expect(sut.matches(operatorMatcher: InMatcher(), userValue: true, matchValue: HackleValue(value: true))).to(beFalse())
-                expect(sut.matches(operatorMatcher: InMatcher(), userValue: true, matchValue: HackleValue(value: 1))).to(beFalse())
-                expect(sut.matches(operatorMatcher: InMatcher(), userValue: 1, matchValue: HackleValue(value: true))).to(beFalse())
-                expect(sut.matches(operatorMatcher: InMatcher(), userValue: "42a", matchValue: HackleValue(value: 42))).to(beFalse())
+                self.verify(sut: sut, userValue: true, matchValue: HackleValue(value: true), expected: false)
+                self.verify(sut: sut, userValue: true, matchValue: HackleValue(value: 1), expected: false)
+                self.verify(sut: sut, userValue: 1, matchValue: HackleValue(value: true), expected: false)
+                self.verify(sut: sut, userValue: "42a", matchValue: HackleValue(value: 42), expected: false)
             }
         }
 
@@ -74,34 +93,34 @@ class ValueMatcherSpecs: QuickSpec {
             let sut = BoolMatcher()
 
             it("userValue, matchValue가 Bool 타입이면 OperatorMatcher의 일치 결과로 평가한다") {
-                expect(sut.matches(operatorMatcher: InMatcher(), userValue: true, matchValue: HackleValue(value: true))).to(beTrue())
-                expect(sut.matches(operatorMatcher: InMatcher(), userValue: false, matchValue: HackleValue(value: false))).to(beTrue())
-                expect(sut.matches(operatorMatcher: InMatcher(), userValue: true, matchValue: HackleValue(value: false))).to(beFalse())
-                expect(sut.matches(operatorMatcher: InMatcher(), userValue: false, matchValue: HackleValue(value: true))).to(beFalse())
+                self.verify(sut: sut, userValue: true, matchValue: HackleValue(value: true), expected: true)
+                self.verify(sut: sut, userValue: false, matchValue: HackleValue(value: false), expected: true)
+                self.verify(sut: sut, userValue: true, matchValue: HackleValue(value: false), expected: false)
+                self.verify(sut: sut, userValue: false, matchValue: HackleValue(value: true), expected: false)
             }
 
             it("userValue가 Bool타입이 아니면 false") {
-                expect(sut.matches(operatorMatcher: InMatcher(), userValue: "string", matchValue: HackleValue(value: true))).to(beFalse())
-                expect(sut.matches(operatorMatcher: InMatcher(), userValue: 1, matchValue: HackleValue(value: true))).to(beFalse())
+                self.verify(sut: sut, userValue: "string", matchValue: HackleValue(value: true), expected: false)
+                self.verify(sut: sut, userValue: 1, matchValue: HackleValue(value: true), expected: false)
             }
 
             it("userValue가 Bool타입이지만 matchValue가 Bool타입이 아니면 false") {
-                expect(sut.matches(operatorMatcher: InMatcher(), userValue: true, matchValue: HackleValue(value: 1))).to(beFalse())
-                expect(sut.matches(operatorMatcher: InMatcher(), userValue: true, matchValue: HackleValue(value: "string"))).to(beFalse())
+                self.verify(sut: sut, userValue: true, matchValue: HackleValue(value: 1), expected: false)
+                self.verify(sut: sut, userValue: true, matchValue: HackleValue(value: "string"), expected: false)
             }
-            
-            it("userValue 혹은 matchValue가 String타입이지만 true이거나 false이면 BoolMatcher의 일치 결과로 평가한다.") {
-                expect(sut.matches(operatorMatcher: InMatcher(), userValue: "true", matchValue: HackleValue(value: true))).to(beTrue())
-                expect(sut.matches(operatorMatcher: InMatcher(), userValue: "false", matchValue: HackleValue(value: false))).to(beTrue())
-                expect(sut.matches(operatorMatcher: InMatcher(), userValue: true, matchValue: HackleValue(value: "true"))).to(beTrue())
-                expect(sut.matches(operatorMatcher: InMatcher(), userValue: false, matchValue: HackleValue(value: "false"))).to(beTrue())
 
-                expect(sut.matches(operatorMatcher: InMatcher(), userValue: "TRUE", matchValue: HackleValue(value: true))).to(beFalse())
-                expect(sut.matches(operatorMatcher: InMatcher(), userValue: "FALSE", matchValue: HackleValue(value: false))).to(beFalse())
-                expect(sut.matches(operatorMatcher: InMatcher(), userValue: true, matchValue: HackleValue(value: "TRUE"))).to(beFalse())
-                expect(sut.matches(operatorMatcher: InMatcher(), userValue: false, matchValue: HackleValue(value: "FALSE"))).to(beFalse())
-                expect(sut.matches(operatorMatcher: InMatcher(), userValue: "FALSE", matchValue: HackleValue(value: true))).to(beFalse())
-                expect(sut.matches(operatorMatcher: InMatcher(), userValue: "true", matchValue: HackleValue(value: false))).to(beFalse())
+            it("userValue 혹은 matchValue가 String타입이지만 true이거나 false이면 BoolMatcher의 일치 결과로 평가한다.") {
+                self.verify(sut: sut, userValue: "true", matchValue: HackleValue(value: true), expected: true)
+                self.verify(sut: sut, userValue: "false", matchValue: HackleValue(value: false), expected: true)
+                self.verify(sut: sut, userValue: true, matchValue: HackleValue(value: "true"), expected: true)
+                self.verify(sut: sut, userValue: false, matchValue: HackleValue(value: "false"), expected: true)
+
+                self.verify(sut: sut, userValue: "TRUE", matchValue: HackleValue(value: true), expected: false)
+                self.verify(sut: sut, userValue: "FALSE", matchValue: HackleValue(value: false), expected: false)
+                self.verify(sut: sut, userValue: true, matchValue: HackleValue(value: "TRUE"), expected: false)
+                self.verify(sut: sut, userValue: false, matchValue: HackleValue(value: "FALSE"), expected: false)
+                self.verify(sut: sut, userValue: "FALSE", matchValue: HackleValue(value: true), expected: false)
+                self.verify(sut: sut, userValue: "true", matchValue: HackleValue(value: false), expected: false)
             }
         }
 
@@ -110,16 +129,16 @@ class ValueMatcherSpecs: QuickSpec {
             let sut = VersionMatcher()
 
             it("userValue, matchValue가 Version 타입이면 OperatorMatcher의 일치 결과로 평가한다") {
-                expect(sut.matches(operatorMatcher: InMatcher(), userValue: "1.0.0", matchValue: HackleValue(value: "1.0.0"))).to(beTrue())
-                expect(sut.matches(operatorMatcher: InMatcher(), userValue: "1.0.0", matchValue: HackleValue(value: "2.0.0"))).to(beFalse())
+                self.verify(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: "1.0.0"), expected: true)
+                self.verify(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: "2.0.0"), expected: false)
             }
 
             it("userValue가 Version 타입이 아니면 false") {
-                expect(sut.matches(operatorMatcher: InMatcher(), userValue: 1.0, matchValue: HackleValue(value: "1.0.0"))).to(beFalse())
+                self.verify(sut: sut, userValue: 1.0, matchValue: HackleValue(value: "1.0.0"), expected: false)
             }
 
             it("userValue가 Version 타입이지만 matchValue가 Version 타입이 아니면 false") {
-                expect(sut.matches(operatorMatcher: InMatcher(), userValue: "1.0.0", matchValue: HackleValue(value: 1.0))).to(beFalse())
+                self.verify(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: 1.0), expected: false)
             }
 
             func v(_ version: String) -> Version {

--- a/Tests/HackleTests/Core/Evaluation/Match/ValueMatcherSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Match/ValueMatcherSpecs.swift
@@ -55,6 +55,8 @@ class ValueMatcherSpecs: QuickSpec {
             it("지원하지 않는 type") {
                 self.verify(sut: sut, userValue: true, matchValue: HackleValue(value: "1"), expected: false)
                 self.verify(sut: sut, userValue: "1", matchValue: HackleValue(value: true), expected: false)
+                self.verify(sut: sut, userValue: false, matchValue: HackleValue(value: "0"), expected: false)
+                self.verify(sut: sut, userValue: "0", matchValue: HackleValue(value: false), expected: false)
             }
         }
 
@@ -121,6 +123,22 @@ class ValueMatcherSpecs: QuickSpec {
                 self.verify(sut: sut, userValue: false, matchValue: HackleValue(value: "FALSE"), expected: false)
                 self.verify(sut: sut, userValue: "FALSE", matchValue: HackleValue(value: true), expected: false)
                 self.verify(sut: sut, userValue: "true", matchValue: HackleValue(value: false), expected: false)
+            }
+            
+            it("bool all type checker") {
+                self.verify(sut: sut, userValue: true, matchValue: HackleValue(value: true), expected: true)
+                self.verify(sut: sut, userValue: true, matchValue: HackleValue(value: 1), expected: false)
+                self.verify(sut: sut, userValue: true, matchValue: HackleValue(value: "true"), expected: true)
+                self.verify(sut: sut, userValue: 1, matchValue: HackleValue(value: true), expected: false)
+                self.verify(sut: sut, userValue: true, matchValue: HackleValue(value: true), expected: true)
+                self.verify(sut: sut, userValue: "true", matchValue: HackleValue(value: true), expected: true)
+                
+                self.verify(sut: sut, userValue: false, matchValue: HackleValue(value: false), expected: true)
+                self.verify(sut: sut, userValue: false, matchValue: HackleValue(value: 0), expected: false)
+                self.verify(sut: sut, userValue: false, matchValue: HackleValue(value: "false"), expected: true)
+                self.verify(sut: sut, userValue: 0, matchValue: HackleValue(value: false), expected: false)
+                self.verify(sut: sut, userValue: false, matchValue: HackleValue(value: false), expected: true)
+                self.verify(sut: sut, userValue: "false", matchValue: HackleValue(value: false), expected: true)
             }
         }
 

--- a/Tests/HackleTests/Core/Model/HackleValueSpecs.swift
+++ b/Tests/HackleTests/Core/Model/HackleValueSpecs.swift
@@ -32,6 +32,10 @@ class HackleValueSpecs: QuickSpec {
             expect(HackleValue(value: 1).asDouble()) == 1
             expect(HackleValue.int(0).intOrNil) == 0
             expect(HackleValue(value: 0).asDouble()) == 0
+            
+            expect(HackleValue(value: Int64.max).intOrNil) == Int64.max
+            expect(HackleValue(value: Int64.min).intOrNil) == Int64.min
+     
         }
 
         it("doubleValue") {
@@ -132,6 +136,27 @@ class HackleValueSpecs: QuickSpec {
             expect(HackleValue(value: v(1)).asBool()).to(beNil())
             expect(HackleValue(value: v(1)).asDouble()) == 1
             expect(HackleValue(value: v(0)).asDouble()) == 0
+        }
+        
+        it("check is boolean") {
+            let cfBooleanTrue: CFBoolean = true as CFBoolean // like 1
+            let cfBooleanFalse: CFBoolean = false as CFBoolean // like 0
+            
+            expect(Objects.isBoolType(true)) == true
+            expect(Objects.isBoolType(false)) == true
+           
+            expect(Objects.isBoolType(cfBooleanTrue)) == true
+            expect(Objects.isBoolType(cfBooleanFalse)) == true
+            
+            expect(Objects.isBoolType(0)) == false
+            expect(Objects.isBoolType(1)) == false
+            expect(Objects.isBoolType(999)) == false
+            
+            expect(Objects.isBoolType(NSNumber(0))) == false
+            expect(Objects.isBoolType(NSNumber(1))) == false
+            
+            expect(Objects.isBoolType(NSNumber(true))) == true
+            expect(Objects.isBoolType(NSNumber(false))) == true
         }
     }
 }

--- a/Tests/HackleTests/Core/Model/HackleValueSpecs.swift
+++ b/Tests/HackleTests/Core/Model/HackleValueSpecs.swift
@@ -115,5 +115,23 @@ class HackleValueSpecs: QuickSpec {
             expect(String(data: try! JSONEncoder().encode(HackleValue.double(42.25)), encoding: .utf8)) == "42.25"
             expect(String(data: try! JSONEncoder().encode(HackleValue.bool(true)), encoding: .utf8)) == "true"
         }
+        
+        it("check boolean in json case") {
+            func v(_ value: Any) -> Any {
+                let tmp = ["tmp": value]
+                let data = Json.serialize(tmp)!
+                let dict = try! JSONSerialization.jsonObject(with: data) as! [String: Any]
+                return dict["tmp"]!
+            }
+            
+            expect(HackleValue(value: v(true)).asBool()) == true
+            expect(HackleValue(value: v(false)).asBool()) == false
+            expect(HackleValue(value: v("true")).asBool()) == true
+            expect(HackleValue(value: v("false")).asBool()) == false
+            expect(HackleValue(value: v(0)).asBool()).to(beNil())
+            expect(HackleValue(value: v(1)).asBool()).to(beNil())
+            expect(HackleValue(value: v(1)).asDouble()) == 1
+            expect(HackleValue(value: v(0)).asDouble()) == 0
+        }
     }
 }

--- a/Tests/HackleTests/Core/Model/HackleValueSpecs.swift
+++ b/Tests/HackleTests/Core/Model/HackleValueSpecs.swift
@@ -138,6 +138,8 @@ class HackleValueSpecs: QuickSpec {
             expect(HackleValue(value: v(0)).asDouble()) == 0
             expect(HackleValue(value: v(NSNumber(true))).asBool()) == true
             expect(HackleValue(value: v(NSNumber(false))).asBool()) == false
+            expect(HackleValue(value: v(NSNumber(true))).asDouble()).to(beNil())
+            expect(HackleValue(value: v(NSNumber(false))).asDouble()).to(beNil())
             expect(HackleValue(value: v(NSNumber(0))).asDouble()) == 0
             expect(HackleValue(value: v(NSNumber(1))).asDouble()) == 1
             expect(HackleValue(value: v(NSNumber(0))).asBool()).to(beNil())

--- a/Tests/HackleTests/Core/Model/HackleValueSpecs.swift
+++ b/Tests/HackleTests/Core/Model/HackleValueSpecs.swift
@@ -136,6 +136,12 @@ class HackleValueSpecs: QuickSpec {
             expect(HackleValue(value: v(1)).asBool()).to(beNil())
             expect(HackleValue(value: v(1)).asDouble()) == 1
             expect(HackleValue(value: v(0)).asDouble()) == 0
+            expect(HackleValue(value: v(NSNumber(true))).asBool()) == true
+            expect(HackleValue(value: v(NSNumber(false))).asBool()) == false
+            expect(HackleValue(value: v(NSNumber(0))).asDouble()) == 0
+            expect(HackleValue(value: v(NSNumber(1))).asDouble()) == 1
+            expect(HackleValue(value: v(NSNumber(0))).asBool()).to(beNil())
+            expect(HackleValue(value: v(NSNumber(1))).asBool()).to(beNil())
         }
         
         it("check is boolean") {
@@ -157,6 +163,11 @@ class HackleValueSpecs: QuickSpec {
             
             expect(Objects.isBoolType(NSNumber(true))) == true
             expect(Objects.isBoolType(NSNumber(false))) == true
+            
+            expect(Objects.asBoolOrNil(NSNumber(0))).to(beNil())
+            expect(Objects.asBoolOrNil(NSNumber(1))).to(beNil())
+            expect(Objects.asBoolOrNil(NSNumber(true))) == true
+            expect(Objects.asBoolOrNil(NSNumber(false))) == false
         }
     }
 }

--- a/Tests/HackleTests/Core/Model/HackleValueSpecs.swift
+++ b/Tests/HackleTests/Core/Model/HackleValueSpecs.swift
@@ -27,6 +27,11 @@ class HackleValueSpecs: QuickSpec {
             expect(HackleValue.double(42.42).intOrNil) == 42
             expect(HackleValue.bool(true).intOrNil).to(beNil())
             expect(HackleValue.null.intOrNil).to(beNil())
+        
+            expect(HackleValue.int(1).intOrNil) == 1
+            expect(HackleValue(value: 1).asDouble()) == 1
+            expect(HackleValue.int(0).intOrNil) == 0
+            expect(HackleValue(value: 0).asDouble()) == 0
         }
 
         it("doubleValue") {
@@ -35,6 +40,11 @@ class HackleValueSpecs: QuickSpec {
             expect(HackleValue.double(42.42).doubleOrNil) == 42.42
             expect(HackleValue.bool(true).doubleOrNil).to(beNil())
             expect(HackleValue.null.doubleOrNil).to(beNil())
+            
+            expect(HackleValue.double(1).doubleOrNil) == 1
+            expect(HackleValue(value: 1).asDouble()) == 1
+            expect(HackleValue.double(0).doubleOrNil) == 0
+            expect(HackleValue(value: 0).asDouble()) == 0
         }
 
         it("boolValue") {
@@ -64,6 +74,16 @@ class HackleValueSpecs: QuickSpec {
             expect(HackleValue(value: "42").asDouble()) == 42.0
             expect(HackleValue(value: "42.0").asDouble()) == 42.0
             expect(HackleValue(value: "42.42").asDouble()) == 42.42
+            
+            expect(HackleValue.int(1).boolOrNil).to(beNil())
+            expect(HackleValue(value: 1).asBool()).to(beNil())
+            expect(HackleValue.int(0).boolOrNil).to(beNil())
+            expect(HackleValue(value: 0).asBool()).to(beNil())
+            
+            expect(HackleValue.string("1").asBool()).to(beNil())
+            expect(HackleValue.string("0").asBool()).to(beNil())
+            expect(HackleValue(value: "1").asBool()).to(beNil())
+            expect(HackleValue(value: "0").asBool()).to(beNil())
         }
         
         it("asBool") {
@@ -74,6 +94,11 @@ class HackleValueSpecs: QuickSpec {
             expect(HackleValue(value: "FALSE").asBool()).to(beNil())
             expect(HackleValue(value: "trues").asBool()).to(beNil())
             expect(HackleValue(value: "strings").asBool()).to(beNil())
+            
+            let cfBooleanTrue: CFBoolean = true as CFBoolean // like 1
+            let cfBooleanFalse: CFBoolean = false as CFBoolean // like 0
+            expect(HackleValue(value: cfBooleanTrue).asBool()) == true
+            expect(HackleValue(value: cfBooleanFalse).asBool()) == false
         }
 
         it("decode") {


### PR DESCRIPTION
## 개요
* CFBoolean 값이 int로 치환되는 버그를 픽스했습니다.

## 버그 픽스
### 타입 체크 버그 픽스
* [`Sources/Hackle/Core/Utilities/Objects.swift`](diffhunk://#diff-fca3e82a4d986c9ce99da6f49ad58b5ea3dc6844cdc2f01001f7144014dbaf72R13-R16): `asIntOrNull` 및 `asDoubleOrNil` 메서드에서 `CFNumber`에 대한 유형 검사를 추가했으며, `asBoolOrNil` 메서드에서 `CFBoolean`에 대한 유형 검사를 추가했습니다. [[1]](diffhunk://#diff-fca3e82a4d986c9ce99da6f49ad58b5ea3dc6844cdc2f01001f7144014dbaf72R13-R16) [[2]](diffhunk://#diff-fca3e82a4d986c9ce99da6f49ad58b5ea3dc6844cdc2f01001f7144014dbaf72R33-R36) [[3]](diffhunk://#diff-fca3e82a4d986c9ce99da6f49ad58b5ea3dc6844cdc2f01001f7144014dbaf72L38-R54)
