### PR TITLE
add build cache and fail test retry

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,7 +75,7 @@ jobs:
                 RetryResults.xcresult \
                 --output-path TestResults.xcresult
           else
-            cp InitialResults.xcresult TestResults.xcresult
+            cp -R InitialResults.xcresult TestResults.xcresult
           fi
 
       - uses: kishikawakatsumi/xcresulttool@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,27 +9,74 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       
-      - name: Xcode Cache
-        if: ${{ !startsWith(github.event.pull_request.base.ref, 'release-') }}
+      - name: Xcode Cache # 캐시 사용
+        if: ${{ !startsWith(github.event.pull_request.base.ref, 'release-') }} # release 브랜치는 캐시 사용하지 않음
         uses: actions/cache@v4
         with:
           path: |
             ~/Library/Developer/Xcode/DerivedData
             .build
           key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
-
-      - name: Test
+          
+      - name: Prebuild before test # 테스트 전에 빌드
         run: |
-            xcodebuild test \
+            xcodebuild build-for-testing \
+                -project Hackle.xcodeproj \
+                -scheme Hackle-Package \
+                -destination 'platform=iOS Simulator,name=iPhone 15,OS=latest' \
+                -quiet
+
+      - name: Test # 테스트. 첫 실패 시 계속 진행
+        continue-on-error: true
+        run: |
+            xcodebuild test-without-building \
                 -project Hackle.xcodeproj \
                 -scheme Hackle-Package \
                 -destination 'platform=iOS Simulator,name=iPhone 15,OS=latest' \
                 -retry-tests-on-failure \
-                -test-iterations 3 \
-                -parallel-testing-enabled YES \
-                -parallel-testing-worker-count 2 \
-                -resultBundlePath TestResults \
+                -test-iterations 2 \
+                -parallel-testing-enabled NO \
+                -resultBundlePath InitialResults \
                 -quiet
+                
+      - name: Extract Failed Tests # 실패 테스트 식별 (jq 기본 설치 활용)
+        if: ${{ failure() }}
+        run: |
+          FAILED_TESTS=$(xcrun xcresulttool get --path InitialResults.xcresult --format json |
+            jq -r '
+              [.. | 
+              select(.testStatus? == "Failure") |
+              .identifier._value // empty] |
+              join(",")
+          ')
+          
+          echo "FAILED_TESTS=$FAILED_TESTS" >> $GITHUB_ENV
+          echo "Failed tests: $FAILED_TESTS"
+    
+      - name: Retry when failed # 2번째에서 1번 더 실행
+        if: ${{ failure() && env.FAILED_TESTS != '' }}
+        run: |
+          xcodebuild test-without-building \
+              -project Hackle.xcodeproj \
+              -scheme Hackle-Package \
+              -destination 'platform=iOS Simulator,name=iPhone 15,OS=latest' \
+              -only-testing:"${{ env.FAILED_TESTS }}" \
+              -retry-tests-on-failure \
+              -test-iterations 2 \
+              -resultBundlePath RetryResults \
+              -quiet
+              
+      - name: Merge Results # 결과 병합
+        if: always()
+        run: |
+          if [ -f RetryResults.xcresult ]; then
+            xcrun xcresulttool merge \
+                InitialResults.xcresult \
+                RetryResults.xcresult \
+                --output-path TestResults.xcresult
+          else
+            cp InitialResults.xcresult TestResults.xcresult
+          fi
 
       - uses: kishikawakatsumi/xcresulttool@v1
         name: Test Result

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,7 @@ name: Test
 
 on:
   pull_request:
+  
 jobs:
   ios-sdk-test:
     runs-on: macos-latest
@@ -9,19 +10,14 @@ jobs:
       - uses: actions/checkout@v3
       
       - name: Xcode Cache
+        if: ${{ !startsWith(github.event.pull_request.base.ref, 'release-') }}
         uses: actions/cache@v4
         with:
           path: |
             ~/Library/Developer/Xcode/DerivedData
             .build
           key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
-            
-      # 릴리즈 브랜치일 경우 빌드 캐시 제거
-      - name: Release Branch Clean
-        if: ${{ startsWith(github.event.pull_request.base.ref, 'release-') }}
-        run: |
-            rm -rf ~/Library/Developer/Xcode/DerivedData/*
-            rm -rf .build/*
+
       - name: Test
         run: |
             xcodebuild test \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
         if: ${{ startsWith(github.event.pull_request.base.ref, 'release-') }}
         run: |
             rm -rf ~/Library/Developer/Xcode/DerivedData/*
- 
+            rm -rf .build/*
       - name: Test
         run: |
             xcodebuild test \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,9 +8,33 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       
+      - name: Xcode Cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/Library/Developer/Xcode/DerivedData
+            .build
+          key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
+            
+      # 릴리즈 브랜치일 경우 빌드 캐시 제거
+      - name: Release Branch Clean
+        if: ${{ startsWith(github.event.pull_request.base.ref, 'release-') }}
+        run: |
+            rm -rf ~/Library/Developer/Xcode/DerivedData/*
+ 
       - name: Test
-        run:  xcodebuild clean test -project Hackle.xcodeproj -scheme Hackle-Package -destination 'platform=iOS Simulator,name=iPhone 15,OS=latest' -resultBundlePath TestResults
-        
+        run: |
+            xcodebuild test \
+                -project Hackle.xcodeproj \
+                -scheme Hackle-Package \
+                -destination 'platform=iOS Simulator,name=iPhone 15,OS=latest' \
+                -retry-tests-on-failure \
+                -test-iterations 3 \
+                -parallel-testing-enabled YES \
+                -parallel-testing-worker-count 2 \
+                -resultBundlePath TestResults \
+                -quiet
+
       - uses: kishikawakatsumi/xcresulttool@v1
         name: Test Result
         with:


### PR DESCRIPTION
## 개요
- Test 워크플로우 개선

## 작업 내용
### 캐시 도입
- release-* 브랜치를 제외하고는 기존 캐시를 이용한 증분 빌드를 실행하여 빠르게 테스트 시도하도록 개선

### 재시도 도입
1. 테스트가 먼저 실패한 경우 전체 테스트를 재시도
2. 재시도 후에도 실패한 테스트가 있으면 실패한 테스트만 최대 2회 재시도
3. 그 후 결과 출력

### 병렬 테스트 비활성화
- 테스트 안정성을 위해 명시적으로 병렬 테스트 비활성화

