### PR TITLE
operator exist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ xcuserdata
 .github/workflows/.idea
 Hackle.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
 .index-build
+
+.qodo

--- a/Sources/Hackle/Core/Evaluation/Match/EventConditionMatcher.swift
+++ b/Sources/Hackle/Core/Evaluation/Match/EventConditionMatcher.swift
@@ -22,9 +22,7 @@ class EventConditionMatcher: ConditionMatcher {
         guard let eventRequest = request as? EvaluatorEventRequest else {
             return false
         }
-        guard let eventValue = try eventValueResolver.resolveOrNil(event: eventRequest.event, key: condition.key) else {
-            return false
-        }
+        let eventValue = try eventValueResolver.resolveOrNil(event: eventRequest.event, key: condition.key)
         return valueOperatorMatcher.matches(userValue: eventValue, match: condition.match)
     }
 }

--- a/Sources/Hackle/Core/Evaluation/Match/OperatorMatcher.swift
+++ b/Sources/Hackle/Core/Evaluation/Match/OperatorMatcher.swift
@@ -1,153 +1,108 @@
 import Foundation
 
 protocol OperatorMatcher {
-    func matches(userValue: String, matchValue: String) -> Bool
-    func matches(userValue: Double, matchValue: Double) -> Bool
-    func matches(userValue: Bool, matchValue: Bool) -> Bool
-    func matches(userValue: Version, matchValue: Version) -> Bool
+    func matches(valueMatcher: ValueMatcher, userValue: Any?, matchValue: [HackleValue]) -> Bool
 }
 
 class InMatcher: OperatorMatcher {
-    func matches(userValue: String, matchValue: String) -> Bool {
-        userValue == matchValue
-    }
-
-    func matches(userValue: Double, matchValue: Double) -> Bool {
-        userValue == matchValue
-    }
-
-    func matches(userValue: Bool, matchValue: Bool) -> Bool {
-        userValue == matchValue
-    }
-
-    func matches(userValue: Version, matchValue: Version) -> Bool {
-        userValue == matchValue
+    func matches(valueMatcher: ValueMatcher, userValue: Any?, matchValue: [HackleValue]) -> Bool {
+        guard let userValue = userValue as? String else {
+            return false
+        }
+        
+        return matchValue.contains { it in
+            valueMatcher.inMatch(userValue: userValue, matchValue: it)
+        }
     }
 }
 
 class ContainsMatcher: OperatorMatcher {
-    func matches(userValue: String, matchValue: String) -> Bool {
-        userValue.contains(matchValue)
-    }
-
-    func matches(userValue: Double, matchValue: Double) -> Bool {
-        false
-    }
-
-    func matches(userValue: Bool, matchValue: Bool) -> Bool {
-        false
-    }
-
-    func matches(userValue: Version, matchValue: Version) -> Bool {
-        false
+    func matches(valueMatcher: ValueMatcher, userValue: Any?, matchValue: [HackleValue]) -> Bool {
+        guard let userValue = userValue as? String else {
+            return false
+        }
+        
+        return matchValue.contains { it in
+            valueMatcher.containsMatch(userValue: userValue, matchValue: it)
+        }
     }
 }
 
 class StartsWithMatcher: OperatorMatcher {
-    func matches(userValue: String, matchValue: String) -> Bool {
-        userValue.hasPrefix(matchValue)
-    }
-
-    func matches(userValue: Double, matchValue: Double) -> Bool {
-        false
-    }
-
-    func matches(userValue: Bool, matchValue: Bool) -> Bool {
-        false
-    }
-
-    func matches(userValue: Version, matchValue: Version) -> Bool {
-        false
+    func matches(valueMatcher: ValueMatcher, userValue: Any?, matchValue: [HackleValue]) -> Bool {
+        guard let userValue = userValue as? String else {
+            return false
+        }
+        
+        return matchValue.contains { it in
+            valueMatcher.startsWithMatch(userValue: userValue, matchValue: it)
+        }
     }
 }
 
 class EndsWithMatcher: OperatorMatcher {
-    func matches(userValue: String, matchValue: String) -> Bool {
-        userValue.hasSuffix(matchValue)
-    }
-
-    func matches(userValue: Double, matchValue: Double) -> Bool {
-        false
-    }
-
-    func matches(userValue: Bool, matchValue: Bool) -> Bool {
-        false
-    }
-
-    func matches(userValue: Version, matchValue: Version) -> Bool {
-        false
+    func matches(valueMatcher: ValueMatcher, userValue: Any?, matchValue: [HackleValue]) -> Bool {
+        guard let userValue = userValue as? String else {
+            return false
+        }
+        
+        return matchValue.contains { it in
+            valueMatcher.endsWithMatch(userValue: userValue, matchValue: it)
+        }
     }
 }
 
 class GreaterThanMatcher: OperatorMatcher {
-    func matches(userValue: String, matchValue: String) -> Bool {
-        userValue > matchValue
-    }
-
-    func matches(userValue: Double, matchValue: Double) -> Bool {
-        userValue > matchValue
-    }
-
-    func matches(userValue: Bool, matchValue: Bool) -> Bool {
-        false
-    }
-
-    func matches(userValue: Version, matchValue: Version) -> Bool {
-        userValue > matchValue
+    func matches(valueMatcher: ValueMatcher, userValue: Any?, matchValue: [HackleValue]) -> Bool {
+        guard let userValue = userValue as? String else {
+            return false
+        }
+        
+        return matchValue.contains { it in
+            valueMatcher.greaterThanMatch(userValue: userValue, matchValue: it)
+        }
     }
 }
 
 class GreaterThanOrEqualToMatcher: OperatorMatcher {
-    func matches(userValue: String, matchValue: String) -> Bool {
-        userValue >= matchValue
-    }
-
-    func matches(userValue: Double, matchValue: Double) -> Bool {
-        userValue >= matchValue
-    }
-
-    func matches(userValue: Bool, matchValue: Bool) -> Bool {
-        false
-    }
-
-    func matches(userValue: Version, matchValue: Version) -> Bool {
-        userValue >= matchValue
+    func matches(valueMatcher: ValueMatcher, userValue: Any?, matchValue: [HackleValue]) -> Bool {
+        guard let userValue = userValue as? String else {
+            return false
+        }
+        
+        return matchValue.contains { it in
+            valueMatcher.greaterThanOrEqualMatch(userValue: userValue, matchValue: it)
+        }
     }
 }
 
 class LessThanMatcher: OperatorMatcher {
-    func matches(userValue: String, matchValue: String) -> Bool {
-        userValue < matchValue
-    }
-
-    func matches(userValue: Double, matchValue: Double) -> Bool {
-        userValue < matchValue
-    }
-
-    func matches(userValue: Bool, matchValue: Bool) -> Bool {
-        false
-    }
-
-    func matches(userValue: Version, matchValue: Version) -> Bool {
-        userValue < matchValue
+    func matches(valueMatcher: ValueMatcher, userValue: Any?, matchValue: [HackleValue]) -> Bool {
+        guard let userValue = userValue as? String else {
+            return false
+        }
+        
+        return matchValue.contains { it in
+            valueMatcher.lessThanMatch(userValue: userValue, matchValue: it)
+        }
     }
 }
 
 class LessThanOrEqualToMatcher: OperatorMatcher {
-    func matches(userValue: String, matchValue: String) -> Bool {
-        userValue <= matchValue
+    func matches(valueMatcher: ValueMatcher, userValue: Any?, matchValue: [HackleValue]) -> Bool {
+        guard let userValue = userValue as? String else {
+            return false
+        }
+        
+        return matchValue.contains { it in
+            valueMatcher.lessThanOrEqualMatch(userValue: userValue, matchValue: it)
+        }
     }
+}
 
-    func matches(userValue: Double, matchValue: Double) -> Bool {
-        userValue <= matchValue
-    }
-
-    func matches(userValue: Bool, matchValue: Bool) -> Bool {
-        false
-    }
-
-    func matches(userValue: Version, matchValue: Version) -> Bool {
-        userValue <= matchValue
+class ExistsMatcher: OperatorMatcher {
+    func matches(valueMatcher: ValueMatcher, userValue: Any?, matchValue: [HackleValue]) -> Bool {
+        userValue != nil
     }
 }
 
@@ -161,6 +116,7 @@ class OperatorMatcherFactory {
     private let greaterThanOrEqualToMatcher = GreaterThanOrEqualToMatcher()
     private let lessThanMatcher = LessThanMatcher()
     private let lessThanOrEqualToMatcher = LessThanOrEqualToMatcher()
+    private let existsMatcher = ExistsMatcher()
 
     func getMatcher(_ matchOperator: Target.Match.Operator) -> OperatorMatcher {
         switch matchOperator {
@@ -172,6 +128,7 @@ class OperatorMatcherFactory {
         case .gte: return greaterThanOrEqualToMatcher
         case .lt: return lessThanMatcher
         case .lte: return lessThanOrEqualToMatcher
+        case .exists: return existsMatcher
         }
     }
 }

--- a/Sources/Hackle/Core/Evaluation/Match/OperatorMatcher.swift
+++ b/Sources/Hackle/Core/Evaluation/Match/OperatorMatcher.swift
@@ -1,107 +1,107 @@
 import Foundation
 
 protocol OperatorMatcher {
-    func matches(valueMatcher: ValueMatcher, userValue: Any?, matchValue: [HackleValue]) -> Bool
+    func matches(valueMatcher: ValueMatcher, userValue: Any?, matchValues: [HackleValue]) -> Bool
 }
 
 class InMatcher: OperatorMatcher {
-    func matches(valueMatcher: ValueMatcher, userValue: Any?, matchValue: [HackleValue]) -> Bool {
+    func matches(valueMatcher: ValueMatcher, userValue: Any?, matchValues: [HackleValue]) -> Bool {
         guard let userValue = userValue else {
             return false
         }
         
-        return matchValue.contains { it in
+        return matchValues.contains { it in
             valueMatcher.inMatch(userValue: userValue, matchValue: it)
         }
     }
 }
 
 class ContainsMatcher: OperatorMatcher {
-    func matches(valueMatcher: ValueMatcher, userValue: Any?, matchValue: [HackleValue]) -> Bool {
+    func matches(valueMatcher: ValueMatcher, userValue: Any?, matchValues: [HackleValue]) -> Bool {
         guard let userValue = userValue else {
             return false
         }
         
-        return matchValue.contains { it in
+        return matchValues.contains { it in
             valueMatcher.containsMatch(userValue: userValue, matchValue: it)
         }
     }
 }
 
 class StartsWithMatcher: OperatorMatcher {
-    func matches(valueMatcher: ValueMatcher, userValue: Any?, matchValue: [HackleValue]) -> Bool {
+    func matches(valueMatcher: ValueMatcher, userValue: Any?, matchValues: [HackleValue]) -> Bool {
         guard let userValue = userValue else {
             return false
         }
         
-        return matchValue.contains { it in
+        return matchValues.contains { it in
             valueMatcher.startsWithMatch(userValue: userValue, matchValue: it)
         }
     }
 }
 
 class EndsWithMatcher: OperatorMatcher {
-    func matches(valueMatcher: ValueMatcher, userValue: Any?, matchValue: [HackleValue]) -> Bool {
+    func matches(valueMatcher: ValueMatcher, userValue: Any?, matchValues: [HackleValue]) -> Bool {
         guard let userValue = userValue else {
             return false
         }
         
-        return matchValue.contains { it in
+        return matchValues.contains { it in
             valueMatcher.endsWithMatch(userValue: userValue, matchValue: it)
         }
     }
 }
 
 class GreaterThanMatcher: OperatorMatcher {
-    func matches(valueMatcher: ValueMatcher, userValue: Any?, matchValue: [HackleValue]) -> Bool {
+    func matches(valueMatcher: ValueMatcher, userValue: Any?, matchValues: [HackleValue]) -> Bool {
         guard let userValue = userValue else {
             return false
         }
         
-        return matchValue.contains { it in
+        return matchValues.contains { it in
             valueMatcher.greaterThanMatch(userValue: userValue, matchValue: it)
         }
     }
 }
 
 class GreaterThanOrEqualToMatcher: OperatorMatcher {
-    func matches(valueMatcher: ValueMatcher, userValue: Any?, matchValue: [HackleValue]) -> Bool {
+    func matches(valueMatcher: ValueMatcher, userValue: Any?, matchValues: [HackleValue]) -> Bool {
         guard let userValue = userValue else {
             return false
         }
         
-        return matchValue.contains { it in
+        return matchValues.contains { it in
             valueMatcher.greaterThanOrEqualMatch(userValue: userValue, matchValue: it)
         }
     }
 }
 
 class LessThanMatcher: OperatorMatcher {
-    func matches(valueMatcher: ValueMatcher, userValue: Any?, matchValue: [HackleValue]) -> Bool {
+    func matches(valueMatcher: ValueMatcher, userValue: Any?, matchValues: [HackleValue]) -> Bool {
         guard let userValue = userValue else {
             return false
         }
         
-        return matchValue.contains { it in
+        return matchValues.contains { it in
             valueMatcher.lessThanMatch(userValue: userValue, matchValue: it)
         }
     }
 }
 
 class LessThanOrEqualToMatcher: OperatorMatcher {
-    func matches(valueMatcher: ValueMatcher, userValue: Any?, matchValue: [HackleValue]) -> Bool {
+    func matches(valueMatcher: ValueMatcher, userValue: Any?, matchValues: [HackleValue]) -> Bool {
         guard let userValue = userValue else {
             return false
         }
         
-        return matchValue.contains { it in
+        return matchValues.contains { it in
             valueMatcher.lessThanOrEqualMatch(userValue: userValue, matchValue: it)
         }
     }
 }
 
 class ExistsMatcher: OperatorMatcher {
-    func matches(valueMatcher: ValueMatcher, userValue: Any?, matchValue: [HackleValue]) -> Bool {
+    func matches(valueMatcher: ValueMatcher, userValue: Any?, matchValues: [HackleValue]) -> Bool {
         userValue != nil
     }
 }

--- a/Sources/Hackle/Core/Evaluation/Match/OperatorMatcher.swift
+++ b/Sources/Hackle/Core/Evaluation/Match/OperatorMatcher.swift
@@ -6,7 +6,7 @@ protocol OperatorMatcher {
 
 class InMatcher: OperatorMatcher {
     func matches(valueMatcher: ValueMatcher, userValue: Any?, matchValue: [HackleValue]) -> Bool {
-        guard let userValue = userValue as? String else {
+        guard let userValue = userValue else {
             return false
         }
         
@@ -18,7 +18,7 @@ class InMatcher: OperatorMatcher {
 
 class ContainsMatcher: OperatorMatcher {
     func matches(valueMatcher: ValueMatcher, userValue: Any?, matchValue: [HackleValue]) -> Bool {
-        guard let userValue = userValue as? String else {
+        guard let userValue = userValue else {
             return false
         }
         
@@ -30,7 +30,7 @@ class ContainsMatcher: OperatorMatcher {
 
 class StartsWithMatcher: OperatorMatcher {
     func matches(valueMatcher: ValueMatcher, userValue: Any?, matchValue: [HackleValue]) -> Bool {
-        guard let userValue = userValue as? String else {
+        guard let userValue = userValue else {
             return false
         }
         
@@ -42,7 +42,7 @@ class StartsWithMatcher: OperatorMatcher {
 
 class EndsWithMatcher: OperatorMatcher {
     func matches(valueMatcher: ValueMatcher, userValue: Any?, matchValue: [HackleValue]) -> Bool {
-        guard let userValue = userValue as? String else {
+        guard let userValue = userValue else {
             return false
         }
         
@@ -54,7 +54,7 @@ class EndsWithMatcher: OperatorMatcher {
 
 class GreaterThanMatcher: OperatorMatcher {
     func matches(valueMatcher: ValueMatcher, userValue: Any?, matchValue: [HackleValue]) -> Bool {
-        guard let userValue = userValue as? String else {
+        guard let userValue = userValue else {
             return false
         }
         
@@ -66,7 +66,7 @@ class GreaterThanMatcher: OperatorMatcher {
 
 class GreaterThanOrEqualToMatcher: OperatorMatcher {
     func matches(valueMatcher: ValueMatcher, userValue: Any?, matchValue: [HackleValue]) -> Bool {
-        guard let userValue = userValue as? String else {
+        guard let userValue = userValue else {
             return false
         }
         
@@ -78,7 +78,7 @@ class GreaterThanOrEqualToMatcher: OperatorMatcher {
 
 class LessThanMatcher: OperatorMatcher {
     func matches(valueMatcher: ValueMatcher, userValue: Any?, matchValue: [HackleValue]) -> Bool {
-        guard let userValue = userValue as? String else {
+        guard let userValue = userValue else {
             return false
         }
         
@@ -90,7 +90,7 @@ class LessThanMatcher: OperatorMatcher {
 
 class LessThanOrEqualToMatcher: OperatorMatcher {
     func matches(valueMatcher: ValueMatcher, userValue: Any?, matchValue: [HackleValue]) -> Bool {
-        guard let userValue = userValue as? String else {
+        guard let userValue = userValue else {
             return false
         }
         

--- a/Sources/Hackle/Core/Evaluation/Match/UserConditionMatcher.swift
+++ b/Sources/Hackle/Core/Evaluation/Match/UserConditionMatcher.swift
@@ -18,9 +18,7 @@ class UserConditionMatcher: ConditionMatcher {
     }
 
     func matches(request: EvaluatorRequest, context: EvaluatorContext, condition: Target.Condition) throws -> Bool {
-        guard let userValue = try userValueResolver.resolveOrNil(user: request.user, key: condition.key) else {
-            return false
-        }
+        let userValue = try userValueResolver.resolveOrNil(user: request.user, key: condition.key)
         return valueOperatorMatcher.matches(userValue: userValue, match: condition.match)
     }
 }

--- a/Sources/Hackle/Core/Evaluation/Match/ValueMatcher.swift
+++ b/Sources/Hackle/Core/Evaluation/Match/ValueMatcher.swift
@@ -187,7 +187,7 @@ class BoolMatcher: ValueMatcher {
 
 class VersionMatcher: ValueMatcher {
     func inMatch(userValue: Any, matchValue: HackleValue) -> Bool {
-        guard let userValue = Version.tryParse(value: userValue),
+        guard let userValue = HackleValue(value: userValue).asVersion(),
               let matchValue = Version.tryParse(value: matchValue.stringOrNil) else {
             return false
         }
@@ -208,7 +208,7 @@ class VersionMatcher: ValueMatcher {
     }
     
     func greaterThanMatch(userValue: Any, matchValue: HackleValue) -> Bool {
-        guard let userValue = Version.tryParse(value: userValue),
+        guard let userValue = HackleValue(value: userValue).asVersion(),
               let matchValue = Version.tryParse(value: matchValue.stringOrNil) else {
             return false
         }
@@ -217,7 +217,7 @@ class VersionMatcher: ValueMatcher {
     }
     
     func greaterThanOrEqualMatch(userValue: Any, matchValue: HackleValue) -> Bool {
-        guard let userValue = Version.tryParse(value: userValue),
+        guard let userValue = HackleValue(value: userValue).asVersion(),
               let matchValue = Version.tryParse(value: matchValue.stringOrNil) else {
             return false
         }
@@ -226,7 +226,7 @@ class VersionMatcher: ValueMatcher {
     }
     
     func lessThanMatch(userValue: Any, matchValue: HackleValue) -> Bool {
-        guard let userValue = Version.tryParse(value: userValue),
+        guard let userValue = HackleValue(value: userValue).asVersion(),
               let matchValue = Version.tryParse(value: matchValue.stringOrNil) else {
             return false
         }
@@ -235,7 +235,7 @@ class VersionMatcher: ValueMatcher {
     }
     
     func lessThanOrEqualMatch(userValue: Any, matchValue: HackleValue) -> Bool {
-        guard let userValue = Version.tryParse(value: userValue),
+        guard let userValue = HackleValue(value: userValue).asVersion(),
               let matchValue = Version.tryParse(value: matchValue.stringOrNil) else {
             return false
         }

--- a/Sources/Hackle/Core/Evaluation/Match/ValueMatcher.swift
+++ b/Sources/Hackle/Core/Evaluation/Match/ValueMatcher.swift
@@ -1,52 +1,282 @@
 import Foundation
 
 protocol ValueMatcher {
-    func matches(operatorMatcher: OperatorMatcher, userValue: Any, matchValue: HackleValue) -> Bool
+    func inMatch(userValue: Any, matchValue: HackleValue) -> Bool
+    func containsMatch(userValue: Any, matchValue: HackleValue) -> Bool
+    func startsWithMatch(userValue: Any, matchValue: HackleValue) -> Bool
+    func endsWithMatch(userValue: Any, matchValue: HackleValue) -> Bool
+    func greaterThanMatch(userValue: Any, matchValue: HackleValue) -> Bool
+    func greaterThanOrEqualMatch(userValue: Any, matchValue: HackleValue) -> Bool
+    func lessThanMatch(userValue: Any, matchValue: HackleValue) -> Bool
+    func lessThanOrEqualMatch(userValue: Any, matchValue: HackleValue) -> Bool
 }
 
 class StringMatcher: ValueMatcher {
-    func matches(operatorMatcher: OperatorMatcher, userValue: Any, matchValue: HackleValue) -> Bool {
+    func inMatch(userValue: Any, matchValue: HackleValue) -> Bool {
         guard let userValue: String = HackleValue(value: userValue).asString(),
               let matchValue: String = matchValue.asString() else {
             return false
         }
-        return operatorMatcher.matches(userValue: userValue, matchValue: matchValue)
+        
+        return userValue == matchValue
+    }
+    
+    func containsMatch(userValue: Any, matchValue: HackleValue) -> Bool {
+        guard let userValue: String = HackleValue(value: userValue).asString(),
+              let matchValue: String = matchValue.asString() else {
+            return false
+        }
+        
+        return userValue.contains(matchValue)
+    }
+    
+    func startsWithMatch(userValue: Any, matchValue: HackleValue) -> Bool {
+        guard let userValue: String = HackleValue(value: userValue).asString(),
+              let matchValue: String = matchValue.asString() else {
+            return false
+        }
+        
+        return userValue.hasPrefix(matchValue)
+    }
+    
+    func endsWithMatch(userValue: Any, matchValue: HackleValue) -> Bool {
+        guard let userValue: String = HackleValue(value: userValue).asString(),
+              let matchValue: String = matchValue.asString() else {
+            return false
+        }
+        
+        return userValue.hasSuffix(matchValue)
+    }
+    
+    func greaterThanMatch(userValue: Any, matchValue: HackleValue) -> Bool {
+        guard let userValue: String = HackleValue(value: userValue).asString(),
+              let matchValue: String = matchValue.asString() else {
+            return false
+        }
+        
+        return userValue > matchValue
+    }
+    
+    func greaterThanOrEqualMatch(userValue: Any, matchValue: HackleValue) -> Bool {
+        guard let userValue: String = HackleValue(value: userValue).asString(),
+              let matchValue: String = matchValue.asString() else {
+            return false
+        }
+        
+        return userValue >= matchValue
+    }
+    
+    func lessThanMatch(userValue: Any, matchValue: HackleValue) -> Bool {
+        guard let userValue: String = HackleValue(value: userValue).asString(),
+              let matchValue: String = matchValue.asString() else {
+            return false
+        }
+        
+        return userValue < matchValue
+    }
+    
+    func lessThanOrEqualMatch(userValue: Any, matchValue: HackleValue) -> Bool {
+        guard let userValue: String = HackleValue(value: userValue).asString(),
+              let matchValue: String = matchValue.asString() else {
+            return false
+        }
+        
+        return userValue <= matchValue
     }
 }
 
 class NumberMatcher: ValueMatcher {
-    func matches(operatorMatcher: OperatorMatcher, userValue: Any, matchValue: HackleValue) -> Bool {
+    func inMatch(userValue: Any, matchValue: HackleValue) -> Bool {
         guard let userValue: Double = HackleValue(value: userValue).asDouble(),
               let matchValue: Double = matchValue.asDouble() else {
             return false
         }
-        return operatorMatcher.matches(userValue: userValue, matchValue: matchValue)
+        
+        return userValue == matchValue
+    }
+    
+    func containsMatch(userValue: Any, matchValue: HackleValue) -> Bool {
+        return false
+    }
+    
+    func startsWithMatch(userValue: Any, matchValue: HackleValue) -> Bool {
+        return false
+    }
+    
+    func endsWithMatch(userValue: Any, matchValue: HackleValue) -> Bool {
+        return false
+    }
+    
+    func greaterThanMatch(userValue: Any, matchValue: HackleValue) -> Bool {
+        guard let userValue: Double = HackleValue(value: userValue).asDouble(),
+              let matchValue: Double = matchValue.asDouble() else {
+            return false
+        }
+        
+        return userValue > matchValue
+    }
+    
+    func greaterThanOrEqualMatch(userValue: Any, matchValue: HackleValue) -> Bool {
+        guard let userValue: Double = HackleValue(value: userValue).asDouble(),
+              let matchValue: Double = matchValue.asDouble() else {
+            return false
+        }
+        
+        return userValue >= matchValue
+    }
+    
+    func lessThanMatch(userValue: Any, matchValue: HackleValue) -> Bool {
+        guard let userValue: Double = HackleValue(value: userValue).asDouble(),
+              let matchValue: Double = matchValue.asDouble() else {
+            return false
+        }
+        
+        return userValue < matchValue
+    }
+    
+    func lessThanOrEqualMatch(userValue: Any, matchValue: HackleValue) -> Bool {
+        guard let userValue: Double = HackleValue(value: userValue).asDouble(),
+              let matchValue: Double = matchValue.asDouble() else {
+            return false
+        }
+        
+        return userValue <= matchValue
     }
 }
 
 class BoolMatcher: ValueMatcher {
-    func matches(operatorMatcher: OperatorMatcher, userValue: Any, matchValue: HackleValue) -> Bool {
+    func inMatch(userValue: Any, matchValue: HackleValue) -> Bool {
         guard let userValue: Bool = HackleValue(value: userValue).asBool(),
               let matchValue: Bool = matchValue.asBool() else {
             return false
         }
-        return operatorMatcher.matches(userValue: userValue, matchValue: matchValue)
+        
+        return userValue == matchValue
     }
+    
+    func containsMatch(userValue: Any, matchValue: HackleValue) -> Bool {
+        return false
+    }
+    
+    func startsWithMatch(userValue: Any, matchValue: HackleValue) -> Bool {
+        return false
+    }
+    
+    func endsWithMatch(userValue: Any, matchValue: HackleValue) -> Bool {
+        return false
+    }
+    
+    func greaterThanMatch(userValue: Any, matchValue: HackleValue) -> Bool {
+        return false
+    }
+    
+    func greaterThanOrEqualMatch(userValue: Any, matchValue: HackleValue) -> Bool {
+        return false
+    }
+    
+    func lessThanMatch(userValue: Any, matchValue: HackleValue) -> Bool {
+        return false
+    }
+    
+    func lessThanOrEqualMatch(userValue: Any, matchValue: HackleValue) -> Bool {
+        return false
+    }
+    
+    
 }
 
 class VersionMatcher: ValueMatcher {
-    func matches(operatorMatcher: OperatorMatcher, userValue: Any, matchValue: HackleValue) -> Bool {
+    func inMatch(userValue: Any, matchValue: HackleValue) -> Bool {
         guard let userValue = Version.tryParse(value: userValue),
               let matchValue = Version.tryParse(value: matchValue.stringOrNil) else {
             return false
         }
-        return operatorMatcher.matches(userValue: userValue, matchValue: matchValue)
+        
+        return userValue == matchValue
     }
+    
+    func containsMatch(userValue: Any, matchValue: HackleValue) -> Bool {
+        return false
+    }
+    
+    func startsWithMatch(userValue: Any, matchValue: HackleValue) -> Bool {
+        return false
+    }
+    
+    func endsWithMatch(userValue: Any, matchValue: HackleValue) -> Bool {
+        return false
+    }
+    
+    func greaterThanMatch(userValue: Any, matchValue: HackleValue) -> Bool {
+        guard let userValue = Version.tryParse(value: userValue),
+              let matchValue = Version.tryParse(value: matchValue.stringOrNil) else {
+            return false
+        }
+        
+        return userValue > matchValue
+    }
+    
+    func greaterThanOrEqualMatch(userValue: Any, matchValue: HackleValue) -> Bool {
+        guard let userValue = Version.tryParse(value: userValue),
+              let matchValue = Version.tryParse(value: matchValue.stringOrNil) else {
+            return false
+        }
+        
+        return userValue >= matchValue
+    }
+    
+    func lessThanMatch(userValue: Any, matchValue: HackleValue) -> Bool {
+        guard let userValue = Version.tryParse(value: userValue),
+              let matchValue = Version.tryParse(value: matchValue.stringOrNil) else {
+            return false
+        }
+        
+        return userValue < matchValue
+    }
+    
+    func lessThanOrEqualMatch(userValue: Any, matchValue: HackleValue) -> Bool {
+        guard let userValue = Version.tryParse(value: userValue),
+              let matchValue = Version.tryParse(value: matchValue.stringOrNil) else {
+            return false
+        }
+        
+        return userValue <= matchValue
+    }
+    
+    
 }
 
 class NoneMatcher: ValueMatcher {
-    func matches(operatorMatcher: OperatorMatcher, userValue: Any, matchValue: HackleValue) -> Bool {
-        false
+    func inMatch(userValue: Any, matchValue: HackleValue) -> Bool {
+        return false
+    }
+    
+    func containsMatch(userValue: Any, matchValue: HackleValue) -> Bool {
+        return false
+    }
+    
+    func startsWithMatch(userValue: Any, matchValue: HackleValue) -> Bool {
+        return false
+    }
+    
+    func endsWithMatch(userValue: Any, matchValue: HackleValue) -> Bool {
+        return false
+    }
+    
+    func greaterThanMatch(userValue: Any, matchValue: HackleValue) -> Bool {
+        return false
+    }
+    
+    func greaterThanOrEqualMatch(userValue: Any, matchValue: HackleValue) -> Bool {
+        return false
+    }
+    
+    func lessThanMatch(userValue: Any, matchValue: HackleValue) -> Bool {
+        return false
+    }
+    
+    func lessThanOrEqualMatch(userValue: Any, matchValue: HackleValue) -> Bool {
+        return false
     }
 }
 

--- a/Sources/Hackle/Core/Evaluation/Match/ValueOperatorMatcher.swift
+++ b/Sources/Hackle/Core/Evaluation/Match/ValueOperatorMatcher.swift
@@ -39,9 +39,7 @@ class DefaultValueOperatorMatcher: ValueOperatorMatcher {
         valueMatcher: ValueMatcher,
         operatorMatcher: OperatorMatcher
     ) -> Bool {
-        match.values.contains { it in
-            valueMatcher.matches(operatorMatcher: operatorMatcher, userValue: userValue, matchValue: it)
-        }
+        return operatorMatcher.matches(valueMatcher: valueMatcher, userValue: userValue, matchValue: match.values)
     }
 
     private func arrayMatches(

--- a/Sources/Hackle/Core/Evaluation/Match/ValueOperatorMatcher.swift
+++ b/Sources/Hackle/Core/Evaluation/Match/ValueOperatorMatcher.swift
@@ -39,7 +39,7 @@ class DefaultValueOperatorMatcher: ValueOperatorMatcher {
         valueMatcher: ValueMatcher,
         operatorMatcher: OperatorMatcher
     ) -> Bool {
-        return operatorMatcher.matches(valueMatcher: valueMatcher, userValue: userValue, matchValue: match.values)
+        return operatorMatcher.matches(valueMatcher: valueMatcher, userValue: userValue, matchValues: match.values)
     }
 
     private func arrayMatches(

--- a/Sources/Hackle/Core/Evaluation/Match/ValueOperatorMatcher.swift
+++ b/Sources/Hackle/Core/Evaluation/Match/ValueOperatorMatcher.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 protocol ValueOperatorMatcher {
-    func matches(userValue: Any, match: Target.Match) -> Bool
+    func matches(userValue: Any?, match: Target.Match) -> Bool
 }
 
 class DefaultValueOperatorMatcher: ValueOperatorMatcher {
@@ -14,7 +14,7 @@ class DefaultValueOperatorMatcher: ValueOperatorMatcher {
         self.operatorMatcherFactory = operatorMatcherFactory
     }
 
-    func matches(userValue: Any, match: Target.Match) -> Bool {
+    func matches(userValue: Any?, match: Target.Match) -> Bool {
         let valueMatcher = valueMatcherFactory.getMatcher(match.valueType)
         let operatorMatcher = operatorMatcherFactory.getMatcher(match.matchOperator)
         let isMatched = matches(userValue: userValue, match: match, valueMatcher: valueMatcher, operatorMatcher: operatorMatcher)
@@ -22,7 +22,7 @@ class DefaultValueOperatorMatcher: ValueOperatorMatcher {
     }
 
     private func matches(
-        userValue: Any,
+        userValue: Any?,
         match: Target.Match,
         valueMatcher: ValueMatcher,
         operatorMatcher: OperatorMatcher
@@ -34,7 +34,7 @@ class DefaultValueOperatorMatcher: ValueOperatorMatcher {
     }
 
     private func singleMatches(
-        userValue: Any,
+        userValue: Any?,
         match: Target.Match,
         valueMatcher: ValueMatcher,
         operatorMatcher: OperatorMatcher

--- a/Sources/Hackle/Core/Model/Target.swift
+++ b/Sources/Hackle/Core/Model/Target.swift
@@ -64,6 +64,7 @@ class Target {
             case gte = "GTE"
             case lt = "LT"
             case lte = "LTE"
+            case exists = "EXISTS"
         }
     }
 

--- a/Tests/HackleTests/Core/Evaluation/Match/EventConditionMatcherSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Match/EventConditionMatcherSpecs.swift
@@ -38,28 +38,6 @@ class EventConditionMatcherSpecs: QuickSpec {
             expect(actual) == false
         }
 
-        it("when cannot resolve event value then returns false") {
-            // given
-            let condition = Target.Condition(
-                key: Target.Key(type: .eventProperty, name: "os_name"),
-                match: Target.Match(type: .match, matchOperator: ._in, valueType: .string, values: [HackleValue(value: "iOS")])
-            )
-
-            let user = HackleUser.builder().identifier(.id, "user").build()
-            let event = UserEvents.track(
-                eventType: EventTypeEntity(id: 42, key: "test"),
-                event: Event.builder("test").build(),
-                timestamp: Date(), user: user
-            )
-            let request = EventRequest(workspace: MockWorkspace(), user: user, event: event)
-
-            // when
-            let actual = try sut.matches(request: request, context: Evaluators.context(), condition: condition)
-
-            // then
-            expect(actual) == false
-        }
-
         it("matches") {
             // given
             let condition = Target.Condition(

--- a/Tests/HackleTests/Core/Evaluation/Match/MockValueOperatorMatcher.swift
+++ b/Tests/HackleTests/Core/Evaluation/Match/MockValueOperatorMatcher.swift
@@ -7,7 +7,7 @@ import Mockery
 class MockValueOperatorMatcher: Mock, ValueOperatorMatcher {
     lazy var matchesMock = MockFunction(self, matches)
 
-    func matches(userValue: Any, match: Target.Match) -> Bool {
+    func matches(userValue: Any?, match: Target.Match) -> Bool {
         call(matchesMock, args: (userValue, match))
     }
 }

--- a/Tests/HackleTests/Core/Evaluation/Match/OperatorMatcherSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Match/OperatorMatcherSpecs.swift
@@ -13,31 +13,31 @@ class OperatorMatcherSpecs: QuickSpec {
             let sut = InMatcher()
 
             it("string") {
-                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValue: [HackleValue(value: "abc")]))
-                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValue: [HackleValue(value: "abc"), HackleValue(value: "def")]))
-                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValue: [HackleValue(value: "abc1")]))
+                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValues: [HackleValue(value: "abc")]))
+                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValues: [HackleValue(value: "abc"), HackleValue(value: "def")]))
+                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValues: [HackleValue(value: "abc1")]))
             }
 
             it("number") {
-                self.assertTrue(sut.matches(valueMatcher: NumberMatcher(), userValue: 320, matchValue: [HackleValue(value: 320)]))
-                self.assertTrue(sut.matches(valueMatcher: NumberMatcher(), userValue: 320.0, matchValue: [HackleValue(value: 320), HackleValue(value: 321)]))
-                self.assertTrue(sut.matches(valueMatcher: NumberMatcher(), userValue: 320.0, matchValue: [HackleValue(value: 320)]))
-                self.assertTrue(sut.matches(valueMatcher: NumberMatcher(), userValue: 320.0, matchValue: [HackleValue(value: 320.0)]))
-                self.assertFalse(sut.matches(valueMatcher: NumberMatcher(), userValue: 320, matchValue: [HackleValue(value: 321)]))
+                self.assertTrue(sut.matches(valueMatcher: NumberMatcher(), userValue: 320, matchValues: [HackleValue(value: 320)]))
+                self.assertTrue(sut.matches(valueMatcher: NumberMatcher(), userValue: 320.0, matchValues: [HackleValue(value: 320), HackleValue(value: 321)]))
+                self.assertTrue(sut.matches(valueMatcher: NumberMatcher(), userValue: 320.0, matchValues: [HackleValue(value: 320)]))
+                self.assertTrue(sut.matches(valueMatcher: NumberMatcher(), userValue: 320.0, matchValues: [HackleValue(value: 320.0)]))
+                self.assertFalse(sut.matches(valueMatcher: NumberMatcher(), userValue: 320, matchValues: [HackleValue(value: 321)]))
             }
 
             it("boolean") {
-                self.assertTrue(sut.matches(valueMatcher: BoolMatcher(), userValue: true, matchValue: [HackleValue(value: true)]))
-                self.assertTrue(sut.matches(valueMatcher: BoolMatcher(), userValue: false, matchValue: [HackleValue(value: false)]))
-                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: true, matchValue: [HackleValue(value: false)]))
-                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: false, matchValue: [HackleValue(value: true)]))
+                self.assertTrue(sut.matches(valueMatcher: BoolMatcher(), userValue: true, matchValues: [HackleValue(value: true)]))
+                self.assertTrue(sut.matches(valueMatcher: BoolMatcher(), userValue: false, matchValues: [HackleValue(value: false)]))
+                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: true, matchValues: [HackleValue(value: false)]))
+                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: false, matchValues: [HackleValue(value: true)]))
             }
 
             it("version") {
-                self.assertTrue(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValue: [HackleValue(value: "1.0.0")]))
-                self.assertTrue(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValue: [HackleValue(value: "1.0.0")]))
-                self.assertTrue(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValue: [HackleValue(value: "1.0.0"), HackleValue(value: "1.0.1")]))
-                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValue: [HackleValue(value: "1.0.1")]))
+                self.assertTrue(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValues: [HackleValue(value: "1.0.0")]))
+                self.assertTrue(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValues: [HackleValue(value: "1.0.0")]))
+                self.assertTrue(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValues: [HackleValue(value: "1.0.0"), HackleValue(value: "1.0.1")]))
+                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValues: [HackleValue(value: "1.0.1")]))
             }
         }
 
@@ -45,32 +45,32 @@ class OperatorMatcherSpecs: QuickSpec {
             let sut = ContainsMatcher()
 
             it("string") {
-                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValue: [HackleValue(value: "abc")]))
-                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValue: [HackleValue(value: "a")]))
-                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValue: [HackleValue(value: "b")]))
-                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValue: [HackleValue(value: "c")]))
-                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValue: [HackleValue(value: "ab")]))
-                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValue: [HackleValue(value: "ac")]))
-                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "a", matchValue: [HackleValue(value: "ab")]))
+                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValues: [HackleValue(value: "abc")]))
+                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValues: [HackleValue(value: "a")]))
+                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValues: [HackleValue(value: "b")]))
+                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValues: [HackleValue(value: "c")]))
+                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValues: [HackleValue(value: "ab")]))
+                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValues: [HackleValue(value: "ac")]))
+                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "a", matchValues: [HackleValue(value: "ab")]))
             }
 
             it("number") {
-                self.assertFalse(sut.matches(valueMatcher: NumberMatcher(), userValue: 1, matchValue: [HackleValue(value: 1)]))
-                self.assertFalse(sut.matches(valueMatcher: NumberMatcher(), userValue: 11, matchValue: [HackleValue(value: 1)]))
-                self.assertFalse(sut.matches(valueMatcher: NumberMatcher(), userValue: 1, matchValue: [HackleValue(value: 11)]))
+                self.assertFalse(sut.matches(valueMatcher: NumberMatcher(), userValue: 1, matchValues: [HackleValue(value: 1)]))
+                self.assertFalse(sut.matches(valueMatcher: NumberMatcher(), userValue: 11, matchValues: [HackleValue(value: 1)]))
+                self.assertFalse(sut.matches(valueMatcher: NumberMatcher(), userValue: 1, matchValues: [HackleValue(value: 11)]))
             }
 
             it("boolean") {
-                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: true, matchValue: [HackleValue(value: true)]))
-                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: false, matchValue: [HackleValue(value: false)]))
-                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: true, matchValue: [HackleValue(value: false)]))
-                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: false, matchValue: [HackleValue(value: true)]))
+                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: true, matchValues: [HackleValue(value: true)]))
+                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: false, matchValues: [HackleValue(value: false)]))
+                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: true, matchValues: [HackleValue(value: false)]))
+                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: false, matchValues: [HackleValue(value: true)]))
             }
 
             it("version") {
-                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValue: [HackleValue(value: "1.0.0")]))
-                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValue: [HackleValue(value: "2.0.0")]))
-                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: "2.0.0", matchValue: [HackleValue(value: "1.0.0")]))
+                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValues: [HackleValue(value: "1.0.0")]))
+                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValues: [HackleValue(value: "2.0.0")]))
+                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: "2.0.0", matchValues: [HackleValue(value: "1.0.0")]))
             }
         }
 
@@ -78,32 +78,32 @@ class OperatorMatcherSpecs: QuickSpec {
             let sut = StartsWithMatcher()
 
             it("string") {
-                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValue: [HackleValue(value: "abc")]))
-                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValue: [HackleValue(value: "a")]))
-                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValue: [HackleValue(value: "b")]))
-                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValue: [HackleValue(value: "c")]))
-                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValue: [HackleValue(value: "ab")]))
-                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValue: [HackleValue(value: "ac")]))
-                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "a", matchValue: [HackleValue(value: "ab")]))
+                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValues: [HackleValue(value: "abc")]))
+                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValues: [HackleValue(value: "a")]))
+                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValues: [HackleValue(value: "b")]))
+                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValues: [HackleValue(value: "c")]))
+                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValues: [HackleValue(value: "ab")]))
+                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValues: [HackleValue(value: "ac")]))
+                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "a", matchValues: [HackleValue(value: "ab")]))
             }
 
             it("number") {
-                self.assertFalse(sut.matches(valueMatcher: NumberMatcher(), userValue: 1, matchValue: [HackleValue(value: 1)]))
-                self.assertFalse(sut.matches(valueMatcher: NumberMatcher(), userValue: 11, matchValue: [HackleValue(value: 1)]))
-                self.assertFalse(sut.matches(valueMatcher: NumberMatcher(), userValue: 1, matchValue: [HackleValue(value: 11)]))
+                self.assertFalse(sut.matches(valueMatcher: NumberMatcher(), userValue: 1, matchValues: [HackleValue(value: 1)]))
+                self.assertFalse(sut.matches(valueMatcher: NumberMatcher(), userValue: 11, matchValues: [HackleValue(value: 1)]))
+                self.assertFalse(sut.matches(valueMatcher: NumberMatcher(), userValue: 1, matchValues: [HackleValue(value: 11)]))
             }
 
             it("boolean") {
-                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: true, matchValue: [HackleValue(value: true)]))
-                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: false, matchValue: [HackleValue(value: false)]))
-                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: true, matchValue: [HackleValue(value: false)]))
-                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: false, matchValue: [HackleValue(value: true)]))
+                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: true, matchValues: [HackleValue(value: true)]))
+                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: false, matchValues: [HackleValue(value: false)]))
+                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: true, matchValues: [HackleValue(value: false)]))
+                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: false, matchValues: [HackleValue(value: true)]))
             }
 
             it("version") {
-                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValue: [HackleValue(value: "1.0.0")]))
-                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValue: [HackleValue(value: "2.0.0")]))
-                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: "2.0.0", matchValue: [HackleValue(value: "1.0.0")]))
+                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValues: [HackleValue(value: "1.0.0")]))
+                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValues: [HackleValue(value: "2.0.0")]))
+                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: "2.0.0", matchValues: [HackleValue(value: "1.0.0")]))
             }
         }
 
@@ -111,32 +111,32 @@ class OperatorMatcherSpecs: QuickSpec {
             let sut = EndsWithMatcher()
 
             it("string") {
-                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValue: [HackleValue(value: "abc")]))
-                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValue: [HackleValue(value: "a")]))
-                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValue: [HackleValue(value: "b")]))
-                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValue: [HackleValue(value: "c")]))
-                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValue: [HackleValue(value: "ab")]))
-                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValue: [HackleValue(value: "ac")]))
-                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "a", matchValue: [HackleValue(value: "ab")]))
+                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValues: [HackleValue(value: "abc")]))
+                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValues: [HackleValue(value: "a")]))
+                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValues: [HackleValue(value: "b")]))
+                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValues: [HackleValue(value: "c")]))
+                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValues: [HackleValue(value: "ab")]))
+                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValues: [HackleValue(value: "ac")]))
+                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "a", matchValues: [HackleValue(value: "ab")]))
             }
 
             it("number") {
-                self.assertFalse(sut.matches(valueMatcher: NumberMatcher(), userValue: 1, matchValue: [HackleValue(value: 1)]))
-                self.assertFalse(sut.matches(valueMatcher: NumberMatcher(), userValue: 11, matchValue: [HackleValue(value: 1)]))
-                self.assertFalse(sut.matches(valueMatcher: NumberMatcher(), userValue: 1, matchValue: [HackleValue(value: 11)]))
+                self.assertFalse(sut.matches(valueMatcher: NumberMatcher(), userValue: 1, matchValues: [HackleValue(value: 1)]))
+                self.assertFalse(sut.matches(valueMatcher: NumberMatcher(), userValue: 11, matchValues: [HackleValue(value: 1)]))
+                self.assertFalse(sut.matches(valueMatcher: NumberMatcher(), userValue: 1, matchValues: [HackleValue(value: 11)]))
             }
 
             it("boolean") {
-                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: true, matchValue: [HackleValue(value: true)]))
-                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: false, matchValue: [HackleValue(value: false)]))
-                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: true, matchValue: [HackleValue(value: false)]))
-                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: false, matchValue: [HackleValue(value: true)]))
+                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: true, matchValues: [HackleValue(value: true)]))
+                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: false, matchValues: [HackleValue(value: false)]))
+                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: true, matchValues: [HackleValue(value: false)]))
+                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: false, matchValues: [HackleValue(value: true)]))
             }
 
             it("version") {
-                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValue: [HackleValue(value: "1.0.0")]))
-                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValue: [HackleValue(value: "2.0.0")]))
-                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: "2.0.0", matchValue: [HackleValue(value: "1.0.0")]))
+                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValues: [HackleValue(value: "1.0.0")]))
+                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValues: [HackleValue(value: "2.0.0")]))
+                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: "2.0.0", matchValues: [HackleValue(value: "1.0.0")]))
             }
         }
 
@@ -144,42 +144,42 @@ class OperatorMatcherSpecs: QuickSpec {
             let sut = GreaterThanMatcher()
 
             it("string") {
-                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "41", matchValue: [HackleValue(value: "42")]))
-                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "42", matchValue: [HackleValue(value: "42")]))
-                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "43", matchValue: [HackleValue(value: "42")]))
+                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "41", matchValues: [HackleValue(value: "42")]))
+                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "42", matchValues: [HackleValue(value: "42")]))
+                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "43", matchValues: [HackleValue(value: "42")]))
 
-                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "20230114", matchValue: [HackleValue(value: "20230115")]))
-                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "20230115", matchValue: [HackleValue(value: "20230115")]))
-                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "20230116", matchValue: [HackleValue(value: "20230115")]))
+                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "20230114", matchValues: [HackleValue(value: "20230115")]))
+                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "20230115", matchValues: [HackleValue(value: "20230115")]))
+                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "20230116", matchValues: [HackleValue(value: "20230115")]))
 
-                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "2023-01-14", matchValue: [HackleValue(value: "2023-01-15")]))
-                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "2023-01-15", matchValue: [HackleValue(value: "2023-01-15")]))
-                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "2023-01-16", matchValue: [HackleValue(value: "2023-01-15")]))
+                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "2023-01-14", matchValues: [HackleValue(value: "2023-01-15")]))
+                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "2023-01-15", matchValues: [HackleValue(value: "2023-01-15")]))
+                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "2023-01-16", matchValues: [HackleValue(value: "2023-01-15")]))
 
-                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "a", matchValue: [HackleValue(value: "a")]))
-                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "a", matchValue: [HackleValue(value: "A")]))
-                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "A", matchValue: [HackleValue(value: "a")]))
-                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "aa", matchValue: [HackleValue(value: "a")]))
-                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "a", matchValue: [HackleValue(value: "aa")]))
+                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "a", matchValues: [HackleValue(value: "a")]))
+                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "a", matchValues: [HackleValue(value: "A")]))
+                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "A", matchValues: [HackleValue(value: "a")]))
+                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "aa", matchValues: [HackleValue(value: "a")]))
+                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "a", matchValues: [HackleValue(value: "aa")]))
             }
 
             it("number") {
-                self.assertFalse(sut.matches(valueMatcher: NumberMatcher(), userValue: 1, matchValue: [HackleValue(value: 1)]))
-                self.assertTrue(sut.matches(valueMatcher: NumberMatcher(), userValue: 1.1, matchValue: [HackleValue(value: 1)]))
-                self.assertFalse(sut.matches(valueMatcher: NumberMatcher(), userValue: 1, matchValue: [HackleValue(value: 1.1)]))
+                self.assertFalse(sut.matches(valueMatcher: NumberMatcher(), userValue: 1, matchValues: [HackleValue(value: 1)]))
+                self.assertTrue(sut.matches(valueMatcher: NumberMatcher(), userValue: 1.1, matchValues: [HackleValue(value: 1)]))
+                self.assertFalse(sut.matches(valueMatcher: NumberMatcher(), userValue: 1, matchValues: [HackleValue(value: 1.1)]))
             }
 
             it("boolean") {
-                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: true, matchValue: [HackleValue(value: true)]))
-                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: false, matchValue: [HackleValue(value: false)]))
-                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: true, matchValue: [HackleValue(value: false)]))
-                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: false, matchValue: [HackleValue(value: true)]))
+                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: true, matchValues: [HackleValue(value: true)]))
+                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: false, matchValues: [HackleValue(value: false)]))
+                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: true, matchValues: [HackleValue(value: false)]))
+                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: false, matchValues: [HackleValue(value: true)]))
             }
 
             it("version") {
-                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValue: [HackleValue(value: "1.0.0")]))
-                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValue: [HackleValue(value: "2.0.0")]))
-                self.assertTrue(sut.matches(valueMatcher: VersionMatcher(), userValue: "2.0.0", matchValue: [HackleValue(value: "1.0.0")]))
+                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValues: [HackleValue(value: "1.0.0")]))
+                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValues: [HackleValue(value: "2.0.0")]))
+                self.assertTrue(sut.matches(valueMatcher: VersionMatcher(), userValue: "2.0.0", matchValues: [HackleValue(value: "1.0.0")]))
             }
         }
         
@@ -187,42 +187,42 @@ class OperatorMatcherSpecs: QuickSpec {
             let sut = GreaterThanOrEqualToMatcher()
 
             it("string") {
-                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "41", matchValue: [HackleValue(value: "42")]))
-                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "42", matchValue: [HackleValue(value: "42")]))
-                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "43", matchValue: [HackleValue(value: "42")]))
+                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "41", matchValues: [HackleValue(value: "42")]))
+                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "42", matchValues: [HackleValue(value: "42")]))
+                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "43", matchValues: [HackleValue(value: "42")]))
 
-                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "20230114", matchValue: [HackleValue(value: "20230115")]))
-                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "20230115", matchValue: [HackleValue(value: "20230115")]))
-                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "20230116", matchValue: [HackleValue(value: "20230115")]))
+                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "20230114", matchValues: [HackleValue(value: "20230115")]))
+                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "20230115", matchValues: [HackleValue(value: "20230115")]))
+                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "20230116", matchValues: [HackleValue(value: "20230115")]))
 
-                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "2023-01-14", matchValue: [HackleValue(value: "2023-01-15")]))
-                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "2023-01-15", matchValue: [HackleValue(value: "2023-01-15")]))
-                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "2023-01-16", matchValue: [HackleValue(value: "2023-01-15")]))
+                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "2023-01-14", matchValues: [HackleValue(value: "2023-01-15")]))
+                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "2023-01-15", matchValues: [HackleValue(value: "2023-01-15")]))
+                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "2023-01-16", matchValues: [HackleValue(value: "2023-01-15")]))
 
-                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "a", matchValue: [HackleValue(value: "a")]))
-                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "a", matchValue: [HackleValue(value: "A")]))
-                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "A", matchValue: [HackleValue(value: "a")]))
-                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "aa", matchValue: [HackleValue(value: "a")]))
-                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "a", matchValue: [HackleValue(value: "aa")]))
+                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "a", matchValues: [HackleValue(value: "a")]))
+                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "a", matchValues: [HackleValue(value: "A")]))
+                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "A", matchValues: [HackleValue(value: "a")]))
+                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "aa", matchValues: [HackleValue(value: "a")]))
+                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "a", matchValues: [HackleValue(value: "aa")]))
             }
 
             it("number") {
-                self.assertTrue(sut.matches(valueMatcher: NumberMatcher(), userValue: 1, matchValue: [HackleValue(value: 1)]))
-                self.assertTrue(sut.matches(valueMatcher: NumberMatcher(), userValue: 1.1, matchValue: [HackleValue(value: 1)]))
-                self.assertFalse(sut.matches(valueMatcher: NumberMatcher(), userValue: 1, matchValue: [HackleValue(value: 1.1)]))
+                self.assertTrue(sut.matches(valueMatcher: NumberMatcher(), userValue: 1, matchValues: [HackleValue(value: 1)]))
+                self.assertTrue(sut.matches(valueMatcher: NumberMatcher(), userValue: 1.1, matchValues: [HackleValue(value: 1)]))
+                self.assertFalse(sut.matches(valueMatcher: NumberMatcher(), userValue: 1, matchValues: [HackleValue(value: 1.1)]))
             }
 
             it("boolean") {
-                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: true, matchValue: [HackleValue(value: true)]))
-                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: false, matchValue: [HackleValue(value: false)]))
-                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: true, matchValue: [HackleValue(value: false)]))
-                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: false, matchValue: [HackleValue(value: true)]))
+                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: true, matchValues: [HackleValue(value: true)]))
+                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: false, matchValues: [HackleValue(value: false)]))
+                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: true, matchValues: [HackleValue(value: false)]))
+                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: false, matchValues: [HackleValue(value: true)]))
             }
 
             it("version") {
-                self.assertTrue(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValue: [HackleValue(value: "1.0.0")]))
-                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValue: [HackleValue(value: "2.0.0")]))
-                self.assertTrue(sut.matches(valueMatcher: VersionMatcher(), userValue: "2.0.0", matchValue: [HackleValue(value: "1.0.0")]))
+                self.assertTrue(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValues: [HackleValue(value: "1.0.0")]))
+                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValues: [HackleValue(value: "2.0.0")]))
+                self.assertTrue(sut.matches(valueMatcher: VersionMatcher(), userValue: "2.0.0", matchValues: [HackleValue(value: "1.0.0")]))
             }
         }
 
@@ -230,42 +230,42 @@ class OperatorMatcherSpecs: QuickSpec {
             let sut = LessThanMatcher()
 
             it("string") {
-                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "41", matchValue: [HackleValue(value: "42")]))
-                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "42", matchValue: [HackleValue(value: "42")]))
-                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "43", matchValue: [HackleValue(value: "42")]))
+                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "41", matchValues: [HackleValue(value: "42")]))
+                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "42", matchValues: [HackleValue(value: "42")]))
+                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "43", matchValues: [HackleValue(value: "42")]))
 
-                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "20230114", matchValue: [HackleValue(value: "20230115")]))
-                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "20230115", matchValue: [HackleValue(value: "20230115")]))
-                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "20230116", matchValue: [HackleValue(value: "20230115")]))
+                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "20230114", matchValues: [HackleValue(value: "20230115")]))
+                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "20230115", matchValues: [HackleValue(value: "20230115")]))
+                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "20230116", matchValues: [HackleValue(value: "20230115")]))
 
-                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "2023-01-14", matchValue: [HackleValue(value: "2023-01-15")]))
-                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "2023-01-15", matchValue: [HackleValue(value: "2023-01-15")]))
-                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "2023-01-16", matchValue: [HackleValue(value: "2023-01-15")]))
+                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "2023-01-14", matchValues: [HackleValue(value: "2023-01-15")]))
+                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "2023-01-15", matchValues: [HackleValue(value: "2023-01-15")]))
+                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "2023-01-16", matchValues: [HackleValue(value: "2023-01-15")]))
 
-                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "a", matchValue: [HackleValue(value: "a")]))
-                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "a", matchValue: [HackleValue(value: "A")]))
-                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "A", matchValue: [HackleValue(value: "a")]))
-                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "aa", matchValue: [HackleValue(value: "a")]))
-                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "a", matchValue: [HackleValue(value: "aa")]))
+                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "a", matchValues: [HackleValue(value: "a")]))
+                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "a", matchValues: [HackleValue(value: "A")]))
+                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "A", matchValues: [HackleValue(value: "a")]))
+                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "aa", matchValues: [HackleValue(value: "a")]))
+                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "a", matchValues: [HackleValue(value: "aa")]))
             }
 
             it("number") {
-                self.assertFalse(sut.matches(valueMatcher: NumberMatcher(), userValue: 1, matchValue: [HackleValue(value: 1)]))
-                self.assertFalse(sut.matches(valueMatcher: NumberMatcher(), userValue: 1.1, matchValue: [HackleValue(value: 1)]))
-                self.assertTrue(sut.matches(valueMatcher: NumberMatcher(), userValue: 1, matchValue: [HackleValue(value: 1.1)]))
+                self.assertFalse(sut.matches(valueMatcher: NumberMatcher(), userValue: 1, matchValues: [HackleValue(value: 1)]))
+                self.assertFalse(sut.matches(valueMatcher: NumberMatcher(), userValue: 1.1, matchValues: [HackleValue(value: 1)]))
+                self.assertTrue(sut.matches(valueMatcher: NumberMatcher(), userValue: 1, matchValues: [HackleValue(value: 1.1)]))
             }
 
             it("boolean") {
-                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: true, matchValue: [HackleValue(value: true)]))
-                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: false, matchValue: [HackleValue(value: false)]))
-                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: true, matchValue: [HackleValue(value: false)]))
-                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: false, matchValue: [HackleValue(value: true)]))
+                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: true, matchValues: [HackleValue(value: true)]))
+                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: false, matchValues: [HackleValue(value: false)]))
+                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: true, matchValues: [HackleValue(value: false)]))
+                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: false, matchValues: [HackleValue(value: true)]))
             }
 
             it("version") {
-                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValue: [HackleValue(value: "1.0.0")]))
-                self.assertTrue(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValue: [HackleValue(value: "2.0.0")]))
-                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: "2.0.0", matchValue: [HackleValue(value: "1.0.0")]))
+                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValues: [HackleValue(value: "1.0.0")]))
+                self.assertTrue(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValues: [HackleValue(value: "2.0.0")]))
+                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: "2.0.0", matchValues: [HackleValue(value: "1.0.0")]))
             }
         }
 
@@ -273,42 +273,42 @@ class OperatorMatcherSpecs: QuickSpec {
             let sut = LessThanOrEqualToMatcher()
 
             it("string") {
-                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "41", matchValue: [HackleValue(value: "42")]))
-                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "42", matchValue: [HackleValue(value: "42")]))
-                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "43", matchValue: [HackleValue(value: "42")]))
+                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "41", matchValues: [HackleValue(value: "42")]))
+                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "42", matchValues: [HackleValue(value: "42")]))
+                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "43", matchValues: [HackleValue(value: "42")]))
 
-                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "20230114", matchValue: [HackleValue(value: "20230115")]))
-                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "20230115", matchValue: [HackleValue(value: "20230115")]))
-                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "20230116", matchValue: [HackleValue(value: "20230115")]))
+                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "20230114", matchValues: [HackleValue(value: "20230115")]))
+                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "20230115", matchValues: [HackleValue(value: "20230115")]))
+                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "20230116", matchValues: [HackleValue(value: "20230115")]))
 
-                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "2023-01-14", matchValue: [HackleValue(value: "2023-01-15")]))
-                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "2023-01-15", matchValue: [HackleValue(value: "2023-01-15")]))
-                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "2023-01-16", matchValue: [HackleValue(value: "2023-01-15")]))
+                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "2023-01-14", matchValues: [HackleValue(value: "2023-01-15")]))
+                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "2023-01-15", matchValues: [HackleValue(value: "2023-01-15")]))
+                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "2023-01-16", matchValues: [HackleValue(value: "2023-01-15")]))
 
-                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "a", matchValue: [HackleValue(value: "a")]))
-                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "a", matchValue: [HackleValue(value: "A")]))
-                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "A", matchValue: [HackleValue(value: "a")]))
-                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "aa", matchValue: [HackleValue(value: "a")]))
-                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "a", matchValue: [HackleValue(value: "aa")]))
+                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "a", matchValues: [HackleValue(value: "a")]))
+                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "a", matchValues: [HackleValue(value: "A")]))
+                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "A", matchValues: [HackleValue(value: "a")]))
+                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "aa", matchValues: [HackleValue(value: "a")]))
+                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "a", matchValues: [HackleValue(value: "aa")]))
             }
 
             it("number") {
-                self.assertTrue(sut.matches(valueMatcher: NumberMatcher(), userValue: 1, matchValue: [HackleValue(value: 1)]))
-                self.assertFalse(sut.matches(valueMatcher: NumberMatcher(), userValue: 1.1, matchValue: [HackleValue(value: 1)]))
-                self.assertTrue(sut.matches(valueMatcher: NumberMatcher(), userValue: 1, matchValue: [HackleValue(value: 1.1)]))
+                self.assertTrue(sut.matches(valueMatcher: NumberMatcher(), userValue: 1, matchValues: [HackleValue(value: 1)]))
+                self.assertFalse(sut.matches(valueMatcher: NumberMatcher(), userValue: 1.1, matchValues: [HackleValue(value: 1)]))
+                self.assertTrue(sut.matches(valueMatcher: NumberMatcher(), userValue: 1, matchValues: [HackleValue(value: 1.1)]))
             }
 
             it("boolean") {
-                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: true, matchValue: [HackleValue(value: true)]))
-                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: false, matchValue: [HackleValue(value: false)]))
-                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: true, matchValue: [HackleValue(value: false)]))
-                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: false, matchValue: [HackleValue(value: true)]))
+                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: true, matchValues: [HackleValue(value: true)]))
+                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: false, matchValues: [HackleValue(value: false)]))
+                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: true, matchValues: [HackleValue(value: false)]))
+                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: false, matchValues: [HackleValue(value: true)]))
             }
 
             it("version") {
-                self.assertTrue(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValue: [HackleValue(value: "1.0.0")]))
-                self.assertTrue(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValue: [HackleValue(value: "2.0.0")]))
-                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: "2.0.0", matchValue: [HackleValue(value: "1.0.0")]))
+                self.assertTrue(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValues: [HackleValue(value: "1.0.0")]))
+                self.assertTrue(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValues: [HackleValue(value: "2.0.0")]))
+                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: "2.0.0", matchValues: [HackleValue(value: "1.0.0")]))
             }
         }
         
@@ -316,32 +316,32 @@ class OperatorMatcherSpecs: QuickSpec {
             let sut = ExistsMatcher()
             
             it("if null fail") {
-                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: nil, matchValue: []))
-                self.assertFalse(sut.matches(valueMatcher: NumberMatcher(), userValue: nil, matchValue: []))
-                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: nil, matchValue: []))
-                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: nil, matchValue: []))
+                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: nil, matchValues: []))
+                self.assertFalse(sut.matches(valueMatcher: NumberMatcher(), userValue: nil, matchValues: []))
+                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: nil, matchValues: []))
+                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: nil, matchValues: []))
             }
             
             it("if not null success") {
-                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValue: []))
-                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: 1, matchValue: []))
-                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: true, matchValue: []))
-                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "1.0.0", matchValue: []))
+                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValues: []))
+                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: 1, matchValues: []))
+                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: true, matchValues: []))
+                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "1.0.0", matchValues: []))
                 
-                self.assertTrue(sut.matches(valueMatcher: NumberMatcher(), userValue: "abc", matchValue: []))
-                self.assertTrue(sut.matches(valueMatcher: NumberMatcher(), userValue: 1, matchValue: []))
-                self.assertTrue(sut.matches(valueMatcher: NumberMatcher(), userValue: true, matchValue: []))
-                self.assertTrue(sut.matches(valueMatcher: NumberMatcher(), userValue: "1.0.0", matchValue: []))
+                self.assertTrue(sut.matches(valueMatcher: NumberMatcher(), userValue: "abc", matchValues: []))
+                self.assertTrue(sut.matches(valueMatcher: NumberMatcher(), userValue: 1, matchValues: []))
+                self.assertTrue(sut.matches(valueMatcher: NumberMatcher(), userValue: true, matchValues: []))
+                self.assertTrue(sut.matches(valueMatcher: NumberMatcher(), userValue: "1.0.0", matchValues: []))
                 
-                self.assertTrue(sut.matches(valueMatcher: BoolMatcher(), userValue: "abc", matchValue: []))
-                self.assertTrue(sut.matches(valueMatcher: BoolMatcher(), userValue: 1, matchValue: []))
-                self.assertTrue(sut.matches(valueMatcher: BoolMatcher(), userValue: true, matchValue: []))
-                self.assertTrue(sut.matches(valueMatcher: BoolMatcher(), userValue: "1.0.0", matchValue: []))
+                self.assertTrue(sut.matches(valueMatcher: BoolMatcher(), userValue: "abc", matchValues: []))
+                self.assertTrue(sut.matches(valueMatcher: BoolMatcher(), userValue: 1, matchValues: []))
+                self.assertTrue(sut.matches(valueMatcher: BoolMatcher(), userValue: true, matchValues: []))
+                self.assertTrue(sut.matches(valueMatcher: BoolMatcher(), userValue: "1.0.0", matchValues: []))
                 
-                self.assertTrue(sut.matches(valueMatcher: VersionMatcher(), userValue: "abc", matchValue: []))
-                self.assertTrue(sut.matches(valueMatcher: VersionMatcher(), userValue: 1, matchValue: []))
-                self.assertTrue(sut.matches(valueMatcher: VersionMatcher(), userValue: true, matchValue: []))
-                self.assertTrue(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValue: []))
+                self.assertTrue(sut.matches(valueMatcher: VersionMatcher(), userValue: "abc", matchValues: []))
+                self.assertTrue(sut.matches(valueMatcher: VersionMatcher(), userValue: 1, matchValues: []))
+                self.assertTrue(sut.matches(valueMatcher: VersionMatcher(), userValue: true, matchValues: []))
+                self.assertTrue(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValues: []))
             }
             
             

--- a/Tests/HackleTests/Core/Evaluation/Match/OperatorMatcherSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Match/OperatorMatcherSpecs.swift
@@ -13,28 +13,31 @@ class OperatorMatcherSpecs: QuickSpec {
             let sut = InMatcher()
 
             it("string") {
-                self.assertTrue(sut.matches(userValue: "abc", matchValue: "abc"))
-                self.assertFalse(sut.matches(userValue: "abc", matchValue: "abc1"))
+                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValue: [HackleValue(value: "abc")]))
+                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValue: [HackleValue(value: "abc"), HackleValue(value: "def")]))
+                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValue: [HackleValue(value: "abc1")]))
             }
 
             it("number") {
-                self.assertTrue(sut.matches(userValue: 320, matchValue: 320))
-                self.assertTrue(sut.matches(userValue: 320.0, matchValue: 320))
-                self.assertTrue(sut.matches(userValue: 320.0, matchValue: 320.0))
-                self.assertFalse(sut.matches(userValue: 321.0, matchValue: 320.0))
+                self.assertTrue(sut.matches(valueMatcher: NumberMatcher(), userValue: 320, matchValue: [HackleValue(value: 320)]))
+                self.assertTrue(sut.matches(valueMatcher: NumberMatcher(), userValue: 320.0, matchValue: [HackleValue(value: 320), HackleValue(value: 321)]))
+                self.assertTrue(sut.matches(valueMatcher: NumberMatcher(), userValue: 320.0, matchValue: [HackleValue(value: 320)]))
+                self.assertTrue(sut.matches(valueMatcher: NumberMatcher(), userValue: 320.0, matchValue: [HackleValue(value: 320.0)]))
+                self.assertFalse(sut.matches(valueMatcher: NumberMatcher(), userValue: 320, matchValue: [HackleValue(value: 321)]))
             }
 
             it("boolean") {
-                self.assertTrue(sut.matches(userValue: true, matchValue: true))
-                self.assertTrue(sut.matches(userValue: false, matchValue: false))
-                self.assertFalse(sut.matches(userValue: true, matchValue: false))
-                self.assertFalse(sut.matches(userValue: false, matchValue: true))
+                self.assertTrue(sut.matches(valueMatcher: BoolMatcher(), userValue: true, matchValue: [HackleValue(value: true)]))
+                self.assertTrue(sut.matches(valueMatcher: BoolMatcher(), userValue: false, matchValue: [HackleValue(value: false)]))
+                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: true, matchValue: [HackleValue(value: false)]))
+                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: false, matchValue: [HackleValue(value: true)]))
             }
 
             it("version") {
-                self.assertTrue(sut.matches(userValue: self.v("1.0.0"), matchValue: self.v("1.0.0")))
-                self.assertFalse(sut.matches(userValue: self.v("1.0.0"), matchValue: self.v("2.0.0")))
-                self.assertFalse(sut.matches(userValue: self.v("2.0.0"), matchValue: self.v("1.0.0")))
+                self.assertTrue(sut.matches(valueMatcher: VersionMatcher(), userValue: self.v("1.0.0"), matchValue: [HackleValue(value: self.v("1.0.0"))]))
+                self.assertTrue(sut.matches(valueMatcher: VersionMatcher(), userValue: self.v("1.0.0"), matchValue: [HackleValue(value: self.v("1.0.0"))]))
+                self.assertTrue(sut.matches(valueMatcher: VersionMatcher(), userValue: self.v("1.0.0"), matchValue: [HackleValue(value: self.v("1.0.0")), HackleValue(value: self.v("1.0.1"))]))
+                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: self.v("1.0.0"), matchValue: [HackleValue(value: self.v("1.0.1"))]))
             }
         }
 
@@ -42,32 +45,32 @@ class OperatorMatcherSpecs: QuickSpec {
             let sut = ContainsMatcher()
 
             it("string") {
-                self.assertTrue(sut.matches(userValue: "abc", matchValue: "abc"))
-                self.assertTrue(sut.matches(userValue: "abc", matchValue: "a"))
-                self.assertTrue(sut.matches(userValue: "abc", matchValue: "b"))
-                self.assertTrue(sut.matches(userValue: "abc", matchValue: "c"))
-                self.assertTrue(sut.matches(userValue: "abc", matchValue: "ab"))
-                self.assertFalse(sut.matches(userValue: "abc", matchValue: "ac"))
-                self.assertFalse(sut.matches(userValue: "a", matchValue: "ab"))
+                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValue: [HackleValue(value: "abc")]))
+                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValue: [HackleValue(value: "a")]))
+                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValue: [HackleValue(value: "b")]))
+                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValue: [HackleValue(value: "c")]))
+                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValue: [HackleValue(value: "ab")]))
+                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValue: [HackleValue(value: "ac")]))
+                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "a", matchValue: [HackleValue(value: "ab")]))
             }
 
             it("number") {
-                self.assertFalse(sut.matches(userValue: 1, matchValue: 1))
-                self.assertFalse(sut.matches(userValue: 11, matchValue: 1))
-                self.assertFalse(sut.matches(userValue: 1, matchValue: 11))
+                self.assertFalse(sut.matches(valueMatcher: NumberMatcher(), userValue: 1, matchValue: [HackleValue(value: 1)]))
+                self.assertFalse(sut.matches(valueMatcher: NumberMatcher(), userValue: 11, matchValue: [HackleValue(value: 1)]))
+                self.assertFalse(sut.matches(valueMatcher: NumberMatcher(), userValue: 1, matchValue: [HackleValue(value: 11)]))
             }
 
             it("boolean") {
-                self.assertFalse(sut.matches(userValue: true, matchValue: true))
-                self.assertFalse(sut.matches(userValue: false, matchValue: false))
-                self.assertFalse(sut.matches(userValue: true, matchValue: false))
-                self.assertFalse(sut.matches(userValue: false, matchValue: true))
+                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: true, matchValue: [HackleValue(value: true)]))
+                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: false, matchValue: [HackleValue(value: false)]))
+                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: true, matchValue: [HackleValue(value: false)]))
+                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: false, matchValue: [HackleValue(value: true)]))
             }
 
             it("version") {
-                self.assertFalse(sut.matches(userValue: self.v("1.0.0"), matchValue: self.v("1.0.0")))
-                self.assertFalse(sut.matches(userValue: self.v("1.0.0"), matchValue: self.v("2.0.0")))
-                self.assertFalse(sut.matches(userValue: self.v("2.0.0"), matchValue: self.v("1.0.0")))
+                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: self.v("1.0.0"), matchValue: [HackleValue(value: self.v("1.0.0"))]))
+                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: self.v("1.0.0"), matchValue: [HackleValue(value: self.v("2.0.0"))]))
+                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: self.v("2.0.0"), matchValue: [HackleValue(value: self.v("1.0.0"))]))
             }
         }
 
@@ -75,32 +78,32 @@ class OperatorMatcherSpecs: QuickSpec {
             let sut = StartsWithMatcher()
 
             it("string") {
-                self.assertTrue(sut.matches(userValue: "abc", matchValue: "abc"))
-                self.assertTrue(sut.matches(userValue: "abc", matchValue: "a"))
-                self.assertFalse(sut.matches(userValue: "abc", matchValue: "b"))
-                self.assertFalse(sut.matches(userValue: "abc", matchValue: "c"))
-                self.assertTrue(sut.matches(userValue: "abc", matchValue: "ab"))
-                self.assertFalse(sut.matches(userValue: "abc", matchValue: "ac"))
-                self.assertFalse(sut.matches(userValue: "a", matchValue: "ab"))
+                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValue: [HackleValue(value: "abc")]))
+                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValue: [HackleValue(value: "a")]))
+                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValue: [HackleValue(value: "b")]))
+                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValue: [HackleValue(value: "c")]))
+                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValue: [HackleValue(value: "ab")]))
+                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValue: [HackleValue(value: "ac")]))
+                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "a", matchValue: [HackleValue(value: "ab")]))
             }
 
             it("number") {
-                self.assertFalse(sut.matches(userValue: 1, matchValue: 1))
-                self.assertFalse(sut.matches(userValue: 11, matchValue: 1))
-                self.assertFalse(sut.matches(userValue: 1, matchValue: 11))
+                self.assertFalse(sut.matches(valueMatcher: NumberMatcher(), userValue: 1, matchValue: [HackleValue(value: 1)]))
+                self.assertFalse(sut.matches(valueMatcher: NumberMatcher(), userValue: 11, matchValue: [HackleValue(value: 1)]))
+                self.assertFalse(sut.matches(valueMatcher: NumberMatcher(), userValue: 1, matchValue: [HackleValue(value: 11)]))
             }
 
             it("boolean") {
-                self.assertFalse(sut.matches(userValue: true, matchValue: true))
-                self.assertFalse(sut.matches(userValue: false, matchValue: false))
-                self.assertFalse(sut.matches(userValue: true, matchValue: false))
-                self.assertFalse(sut.matches(userValue: false, matchValue: true))
+                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: true, matchValue: [HackleValue(value: true)]))
+                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: false, matchValue: [HackleValue(value: false)]))
+                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: true, matchValue: [HackleValue(value: false)]))
+                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: false, matchValue: [HackleValue(value: true)]))
             }
 
             it("version") {
-                self.assertFalse(sut.matches(userValue: self.v("1.0.0"), matchValue: self.v("1.0.0")))
-                self.assertFalse(sut.matches(userValue: self.v("1.0.0"), matchValue: self.v("2.0.0")))
-                self.assertFalse(sut.matches(userValue: self.v("2.0.0"), matchValue: self.v("1.0.0")))
+                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: self.v("1.0.0"), matchValue: [HackleValue(value: self.v("1.0.0"))]))
+                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: self.v("1.0.0"), matchValue: [HackleValue(value: self.v("2.0.0"))]))
+                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: self.v("2.0.0"), matchValue: [HackleValue(value: self.v("1.0.0"))]))
             }
         }
 
@@ -108,32 +111,32 @@ class OperatorMatcherSpecs: QuickSpec {
             let sut = EndsWithMatcher()
 
             it("string") {
-                self.assertTrue(sut.matches(userValue: "abc", matchValue: "abc"))
-                self.assertFalse(sut.matches(userValue: "abc", matchValue: "a"))
-                self.assertFalse(sut.matches(userValue: "abc", matchValue: "b"))
-                self.assertTrue(sut.matches(userValue: "abc", matchValue: "c"))
-                self.assertFalse(sut.matches(userValue: "abc", matchValue: "ab"))
-                self.assertFalse(sut.matches(userValue: "abc", matchValue: "ac"))
-                self.assertFalse(sut.matches(userValue: "a", matchValue: "ab"))
+                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValue: [HackleValue(value: "abc")]))
+                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValue: [HackleValue(value: "a")]))
+                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValue: [HackleValue(value: "b")]))
+                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValue: [HackleValue(value: "c")]))
+                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValue: [HackleValue(value: "ab")]))
+                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValue: [HackleValue(value: "ac")]))
+                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "a", matchValue: [HackleValue(value: "ab")]))
             }
 
             it("number") {
-                self.assertFalse(sut.matches(userValue: 1, matchValue: 1))
-                self.assertFalse(sut.matches(userValue: 11, matchValue: 1))
-                self.assertFalse(sut.matches(userValue: 1, matchValue: 11))
+                self.assertFalse(sut.matches(valueMatcher: NumberMatcher(), userValue: 1, matchValue: [HackleValue(value: 1)]))
+                self.assertFalse(sut.matches(valueMatcher: NumberMatcher(), userValue: 11, matchValue: [HackleValue(value: 1)]))
+                self.assertFalse(sut.matches(valueMatcher: NumberMatcher(), userValue: 1, matchValue: [HackleValue(value: 11)]))
             }
 
             it("boolean") {
-                self.assertFalse(sut.matches(userValue: true, matchValue: true))
-                self.assertFalse(sut.matches(userValue: false, matchValue: false))
-                self.assertFalse(sut.matches(userValue: true, matchValue: false))
-                self.assertFalse(sut.matches(userValue: false, matchValue: true))
+                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: true, matchValue: [HackleValue(value: true)]))
+                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: false, matchValue: [HackleValue(value: false)]))
+                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: true, matchValue: [HackleValue(value: false)]))
+                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: false, matchValue: [HackleValue(value: true)]))
             }
 
             it("version") {
-                self.assertFalse(sut.matches(userValue: self.v("1.0.0"), matchValue: self.v("1.0.0")))
-                self.assertFalse(sut.matches(userValue: self.v("1.0.0"), matchValue: self.v("2.0.0")))
-                self.assertFalse(sut.matches(userValue: self.v("2.0.0"), matchValue: self.v("1.0.0")))
+                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: self.v("1.0.0"), matchValue: [HackleValue(value: self.v("1.0.0"))]))
+                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: self.v("1.0.0"), matchValue: [HackleValue(value: self.v("2.0.0"))]))
+                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: self.v("2.0.0"), matchValue: [HackleValue(value: self.v("1.0.0"))]))
             }
         }
 
@@ -141,86 +144,85 @@ class OperatorMatcherSpecs: QuickSpec {
             let sut = GreaterThanMatcher()
 
             it("string") {
-                self.assertFalse(sut.matches(userValue: "41", matchValue: "42"))
-                self.assertFalse(sut.matches(userValue: "42", matchValue: "42"))
-                self.assertTrue(sut.matches(userValue: "43", matchValue: "42"))
+                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "41", matchValue: [HackleValue(value: "42")]))
+                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "42", matchValue: [HackleValue(value: "42")]))
+                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "43", matchValue: [HackleValue(value: "42")]))
 
-                self.assertFalse(sut.matches(userValue: "20230114", matchValue: "20230115"))
-                self.assertFalse(sut.matches(userValue: "20230115", matchValue: "20230115"))
-                self.assertTrue(sut.matches(userValue: "20230116", matchValue: "20230115"))
+                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "20230114", matchValue: [HackleValue(value: "20230115")]))
+                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "20230115", matchValue: [HackleValue(value: "20230115")]))
+                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "20230116", matchValue: [HackleValue(value: "20230115")]))
 
-                self.assertFalse(sut.matches(userValue: "2023-01-14", matchValue: "2023-01-15"))
-                self.assertFalse(sut.matches(userValue: "2023-01-15", matchValue: "2023-01-15"))
-                self.assertTrue(sut.matches(userValue: "2023-01-16", matchValue: "2023-01-15"))
+                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "2023-01-14", matchValue: [HackleValue(value: "2023-01-15")]))
+                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "2023-01-15", matchValue: [HackleValue(value: "2023-01-15")]))
+                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "2023-01-16", matchValue: [HackleValue(value: "2023-01-15")]))
 
-                self.assertFalse(sut.matches(userValue: "a", matchValue: "a"))
-                self.assertTrue(sut.matches(userValue: "a", matchValue: "A"))
-                self.assertFalse(sut.matches(userValue: "A", matchValue: "a"))
-                self.assertTrue(sut.matches(userValue: "aa", matchValue: "a"))
-                self.assertFalse(sut.matches(userValue: "a", matchValue: "aa"))
+                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "a", matchValue: [HackleValue(value: "a")]))
+                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "a", matchValue: [HackleValue(value: "A")]))
+                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "A", matchValue: [HackleValue(value: "a")]))
+                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "aa", matchValue: [HackleValue(value: "a")]))
+                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "a", matchValue: [HackleValue(value: "aa")]))
             }
 
             it("number") {
-                self.assertFalse(sut.matches(userValue: 1, matchValue: 1))
-                self.assertTrue(sut.matches(userValue: 1.1, matchValue: 1))
-                self.assertFalse(sut.matches(userValue: 1, matchValue: 1.1))
+                self.assertFalse(sut.matches(valueMatcher: NumberMatcher(), userValue: 1, matchValue: [HackleValue(value: 1)]))
+                self.assertTrue(sut.matches(valueMatcher: NumberMatcher(), userValue: 1.1, matchValue: [HackleValue(value: 1)]))
+                self.assertFalse(sut.matches(valueMatcher: NumberMatcher(), userValue: 1, matchValue: [HackleValue(value: 1.1)]))
             }
 
             it("boolean") {
-                self.assertFalse(sut.matches(userValue: true, matchValue: true))
-                self.assertFalse(sut.matches(userValue: false, matchValue: false))
-                self.assertFalse(sut.matches(userValue: true, matchValue: false))
-                self.assertFalse(sut.matches(userValue: false, matchValue: true))
+                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: true, matchValue: [HackleValue(value: true)]))
+                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: false, matchValue: [HackleValue(value: false)]))
+                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: true, matchValue: [HackleValue(value: false)]))
+                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: false, matchValue: [HackleValue(value: true)]))
             }
 
             it("version") {
-                self.assertFalse(sut.matches(userValue: self.v("1.0.0"), matchValue: self.v("1.0.0")))
-                self.assertFalse(sut.matches(userValue: self.v("1.0.0"), matchValue: self.v("2.0.0")))
-                self.assertTrue(sut.matches(userValue: self.v("2.0.0"), matchValue: self.v("1.0.0")))
+                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: self.v("1.0.0"), matchValue: [HackleValue(value: self.v("1.0.0"))]))
+                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: self.v("1.0.0"), matchValue: [HackleValue(value: self.v("2.0.0"))]))
+                self.assertTrue(sut.matches(valueMatcher: VersionMatcher(), userValue: self.v("2.0.0"), matchValue: [HackleValue(value: self.v("1.0.0"))]))
             }
         }
-
+        
         describe("GreaterThanOrEqualToMatcher") {
             let sut = GreaterThanOrEqualToMatcher()
 
             it("string") {
-                self.assertFalse(sut.matches(userValue: "41", matchValue: "42"))
-                self.assertTrue(sut.matches(userValue: "42", matchValue: "42"))
-                self.assertTrue(sut.matches(userValue: "43", matchValue: "42"))
+                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "41", matchValue: [HackleValue(value: "42")]))
+                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "42", matchValue: [HackleValue(value: "42")]))
+                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "43", matchValue: [HackleValue(value: "42")]))
 
-                self.assertFalse(sut.matches(userValue: "20230114", matchValue: "20230115"))
-                self.assertTrue(sut.matches(userValue: "20230115", matchValue: "20230115"))
-                self.assertTrue(sut.matches(userValue: "20230116", matchValue: "20230115"))
+                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "20230114", matchValue: [HackleValue(value: "20230115")]))
+                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "20230115", matchValue: [HackleValue(value: "20230115")]))
+                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "20230116", matchValue: [HackleValue(value: "20230115")]))
 
+                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "2023-01-14", matchValue: [HackleValue(value: "2023-01-15")]))
+                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "2023-01-15", matchValue: [HackleValue(value: "2023-01-15")]))
+                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "2023-01-16", matchValue: [HackleValue(value: "2023-01-15")]))
 
-                self.assertFalse(sut.matches(userValue: "2023-01-14", matchValue: "2023-01-15"))
-                self.assertTrue(sut.matches(userValue: "2023-01-15", matchValue: "2023-01-15"))
-                self.assertTrue(sut.matches(userValue: "2023-01-16", matchValue: "2023-01-15"))
-
-                self.assertTrue(sut.matches(userValue: "a", matchValue: "a"))
-                self.assertTrue(sut.matches(userValue: "a", matchValue: "A"))
-                self.assertFalse(sut.matches(userValue: "A", matchValue: "a"))
-                self.assertTrue(sut.matches(userValue: "aa", matchValue: "a"))
-                self.assertFalse(sut.matches(userValue: "a", matchValue: "aa"))
+                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "a", matchValue: [HackleValue(value: "a")]))
+                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "a", matchValue: [HackleValue(value: "A")]))
+                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "A", matchValue: [HackleValue(value: "a")]))
+                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "aa", matchValue: [HackleValue(value: "a")]))
+                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "a", matchValue: [HackleValue(value: "aa")]))
             }
 
             it("number") {
-                self.assertTrue(sut.matches(userValue: 1, matchValue: 1))
-                self.assertTrue(sut.matches(userValue: 1.1, matchValue: 1))
-                self.assertFalse(sut.matches(userValue: 1, matchValue: 1.1))
+                self.assertTrue(sut.matches(valueMatcher: NumberMatcher(), userValue: 1, matchValue: [HackleValue(value: 1)]))
+                self.assertTrue(sut.matches(valueMatcher: NumberMatcher(), userValue: 1.1, matchValue: [HackleValue(value: 1)]))
+                self.assertFalse(sut.matches(valueMatcher: NumberMatcher(), userValue: 1, matchValue: [HackleValue(value: 1.1)]))
             }
 
             it("boolean") {
-                self.assertFalse(sut.matches(userValue: true, matchValue: true))
-                self.assertFalse(sut.matches(userValue: false, matchValue: false))
-                self.assertFalse(sut.matches(userValue: true, matchValue: false))
-                self.assertFalse(sut.matches(userValue: false, matchValue: true))
+                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: true, matchValue: [HackleValue(value: true)]))
+                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: false, matchValue: [HackleValue(value: false)]))
+                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: true, matchValue: [HackleValue(value: false)]))
+                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: false, matchValue: [HackleValue(value: true)]))
             }
 
             it("version") {
-                self.assertTrue(sut.matches(userValue: self.v("1.0.0"), matchValue: self.v("1.0.0")))
-                self.assertFalse(sut.matches(userValue: self.v("1.0.0"), matchValue: self.v("2.0.0")))
-                self.assertTrue(sut.matches(userValue: self.v("2.0.0"), matchValue: self.v("1.0.0")))
+                self.assertTrue(sut.matches(valueMatcher: VersionMatcher(), userValue: self.v("1.0.0"), matchValue: [HackleValue(value: self.v("1.0.0"))]))
+                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: self.v("1.0.0"), matchValue: [HackleValue(value: self.v("2.0.0"))]))
+                self.assertTrue(sut.matches(valueMatcher: VersionMatcher(), userValue: self.v("2.0.0"), matchValue: [HackleValue(value: self.v("1.0.0"))]))
             }
         }
 
@@ -228,42 +230,42 @@ class OperatorMatcherSpecs: QuickSpec {
             let sut = LessThanMatcher()
 
             it("string") {
-                self.assertTrue(sut.matches(userValue: "41", matchValue: "42"))
-                self.assertFalse(sut.matches(userValue: "42", matchValue: "42"))
-                self.assertFalse(sut.matches(userValue: "43", matchValue: "42"))
+                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "41", matchValue: [HackleValue(value: "42")]))
+                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "42", matchValue: [HackleValue(value: "42")]))
+                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "43", matchValue: [HackleValue(value: "42")]))
 
-                self.assertTrue(sut.matches(userValue: "20230114", matchValue: "20230115"))
-                self.assertFalse(sut.matches(userValue: "20230115", matchValue: "20230115"))
-                self.assertFalse(sut.matches(userValue: "20230116", matchValue: "20230115"))
+                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "20230114", matchValue: [HackleValue(value: "20230115")]))
+                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "20230115", matchValue: [HackleValue(value: "20230115")]))
+                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "20230116", matchValue: [HackleValue(value: "20230115")]))
 
-                self.assertTrue(sut.matches(userValue: "2023-01-14", matchValue: "2023-01-15"))
-                self.assertFalse(sut.matches(userValue: "2023-01-15", matchValue: "2023-01-15"))
-                self.assertFalse(sut.matches(userValue: "2023-01-16", matchValue: "2023-01-15"))
+                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "2023-01-14", matchValue: [HackleValue(value: "2023-01-15")]))
+                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "2023-01-15", matchValue: [HackleValue(value: "2023-01-15")]))
+                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "2023-01-16", matchValue: [HackleValue(value: "2023-01-15")]))
 
-                self.assertFalse(sut.matches(userValue: "a", matchValue: "a"))
-                self.assertFalse(sut.matches(userValue: "a", matchValue: "A"))
-                self.assertTrue(sut.matches(userValue: "A", matchValue: "a"))
-                self.assertFalse(sut.matches(userValue: "aa", matchValue: "a"))
-                self.assertTrue(sut.matches(userValue: "a", matchValue: "aa"))
+                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "a", matchValue: [HackleValue(value: "a")]))
+                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "a", matchValue: [HackleValue(value: "A")]))
+                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "A", matchValue: [HackleValue(value: "a")]))
+                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "aa", matchValue: [HackleValue(value: "a")]))
+                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "a", matchValue: [HackleValue(value: "aa")]))
             }
 
             it("number") {
-                self.assertFalse(sut.matches(userValue: 1, matchValue: 1))
-                self.assertFalse(sut.matches(userValue: 1.1, matchValue: 1))
-                self.assertTrue(sut.matches(userValue: 1, matchValue: 1.1))
+                self.assertFalse(sut.matches(valueMatcher: NumberMatcher(), userValue: 1, matchValue: [HackleValue(value: 1)]))
+                self.assertFalse(sut.matches(valueMatcher: NumberMatcher(), userValue: 1.1, matchValue: [HackleValue(value: 1)]))
+                self.assertTrue(sut.matches(valueMatcher: NumberMatcher(), userValue: 1, matchValue: [HackleValue(value: 1.1)]))
             }
 
             it("boolean") {
-                self.assertFalse(sut.matches(userValue: true, matchValue: true))
-                self.assertFalse(sut.matches(userValue: false, matchValue: false))
-                self.assertFalse(sut.matches(userValue: true, matchValue: false))
-                self.assertFalse(sut.matches(userValue: false, matchValue: true))
+                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: true, matchValue: [HackleValue(value: true)]))
+                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: false, matchValue: [HackleValue(value: false)]))
+                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: true, matchValue: [HackleValue(value: false)]))
+                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: false, matchValue: [HackleValue(value: true)]))
             }
 
             it("version") {
-                self.assertFalse(sut.matches(userValue: self.v("1.0.0"), matchValue: self.v("1.0.0")))
-                self.assertTrue(sut.matches(userValue: self.v("1.0.0"), matchValue: self.v("2.0.0")))
-                self.assertFalse(sut.matches(userValue: self.v("2.0.0"), matchValue: self.v("1.0.0")))
+                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: self.v("1.0.0"), matchValue: [HackleValue(value: self.v("1.0.0"))]))
+                self.assertTrue(sut.matches(valueMatcher: VersionMatcher(), userValue: self.v("1.0.0"), matchValue: [HackleValue(value: self.v("2.0.0"))]))
+                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: self.v("2.0.0"), matchValue: [HackleValue(value: self.v("1.0.0"))]))
             }
         }
 
@@ -271,43 +273,78 @@ class OperatorMatcherSpecs: QuickSpec {
             let sut = LessThanOrEqualToMatcher()
 
             it("string") {
-                self.assertTrue(sut.matches(userValue: "41", matchValue: "42"))
-                self.assertTrue(sut.matches(userValue: "42", matchValue: "42"))
-                self.assertFalse(sut.matches(userValue: "43", matchValue: "42"))
+                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "41", matchValue: [HackleValue(value: "42")]))
+                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "42", matchValue: [HackleValue(value: "42")]))
+                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "43", matchValue: [HackleValue(value: "42")]))
 
-                self.assertTrue(sut.matches(userValue: "20230114", matchValue: "20230115"))
-                self.assertTrue(sut.matches(userValue: "20230115", matchValue: "20230115"))
-                self.assertFalse(sut.matches(userValue: "20230116", matchValue: "20230115"))
+                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "20230114", matchValue: [HackleValue(value: "20230115")]))
+                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "20230115", matchValue: [HackleValue(value: "20230115")]))
+                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "20230116", matchValue: [HackleValue(value: "20230115")]))
 
-                self.assertTrue(sut.matches(userValue: "2023-01-14", matchValue: "2023-01-15"))
-                self.assertTrue(sut.matches(userValue: "2023-01-15", matchValue: "2023-01-15"))
-                self.assertFalse(sut.matches(userValue: "2023-01-16", matchValue: "2023-01-15"))
+                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "2023-01-14", matchValue: [HackleValue(value: "2023-01-15")]))
+                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "2023-01-15", matchValue: [HackleValue(value: "2023-01-15")]))
+                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "2023-01-16", matchValue: [HackleValue(value: "2023-01-15")]))
 
-                self.assertTrue(sut.matches(userValue: "a", matchValue: "a"))
-                self.assertFalse(sut.matches(userValue: "a", matchValue: "A"))
-                self.assertTrue(sut.matches(userValue: "A", matchValue: "a"))
-                self.assertFalse(sut.matches(userValue: "aa", matchValue: "a"))
-                self.assertTrue(sut.matches(userValue: "a", matchValue: "aa"))
+                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "a", matchValue: [HackleValue(value: "a")]))
+                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "a", matchValue: [HackleValue(value: "A")]))
+                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "A", matchValue: [HackleValue(value: "a")]))
+                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "aa", matchValue: [HackleValue(value: "a")]))
+                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "a", matchValue: [HackleValue(value: "aa")]))
             }
 
             it("number") {
-                self.assertTrue(sut.matches(userValue: 1, matchValue: 1))
-                self.assertFalse(sut.matches(userValue: 1.1, matchValue: 1))
-                self.assertTrue(sut.matches(userValue: 1, matchValue: 1.1))
+                self.assertTrue(sut.matches(valueMatcher: NumberMatcher(), userValue: 1, matchValue: [HackleValue(value: 1)]))
+                self.assertFalse(sut.matches(valueMatcher: NumberMatcher(), userValue: 1.1, matchValue: [HackleValue(value: 1)]))
+                self.assertTrue(sut.matches(valueMatcher: NumberMatcher(), userValue: 1, matchValue: [HackleValue(value: 1.1)]))
             }
 
             it("boolean") {
-                self.assertFalse(sut.matches(userValue: true, matchValue: true))
-                self.assertFalse(sut.matches(userValue: false, matchValue: false))
-                self.assertFalse(sut.matches(userValue: true, matchValue: false))
-                self.assertFalse(sut.matches(userValue: false, matchValue: true))
+                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: true, matchValue: [HackleValue(value: true)]))
+                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: false, matchValue: [HackleValue(value: false)]))
+                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: true, matchValue: [HackleValue(value: false)]))
+                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: false, matchValue: [HackleValue(value: true)]))
             }
 
             it("version") {
-                self.assertTrue(sut.matches(userValue: self.v("1.0.0"), matchValue: self.v("1.0.0")))
-                self.assertTrue(sut.matches(userValue: self.v("1.0.0"), matchValue: self.v("2.0.0")))
-                self.assertFalse(sut.matches(userValue: self.v("2.0.0"), matchValue: self.v("1.0.0")))
+                self.assertTrue(sut.matches(valueMatcher: VersionMatcher(), userValue: self.v("1.0.0"), matchValue: [HackleValue(value: self.v("1.0.0"))]))
+                self.assertTrue(sut.matches(valueMatcher: VersionMatcher(), userValue: self.v("1.0.0"), matchValue: [HackleValue(value: self.v("2.0.0"))]))
+                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: self.v("2.0.0"), matchValue: [HackleValue(value: self.v("1.0.0"))]))
             }
+        }
+        
+        describe("ExistMatcher") {
+            let sut = ExistsMatcher()
+            
+            it("if null fail") {
+                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: nil, matchValue: []))
+                self.assertFalse(sut.matches(valueMatcher: NumberMatcher(), userValue: nil, matchValue: []))
+                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: nil, matchValue: []))
+                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: nil, matchValue: []))
+            }
+            
+            it("if not null success") {
+                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValue: []))
+                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: 1, matchValue: []))
+                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: true, matchValue: []))
+                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: self.v("1.0.0"), matchValue: []))
+                
+                self.assertTrue(sut.matches(valueMatcher: NumberMatcher(), userValue: "abc", matchValue: []))
+                self.assertTrue(sut.matches(valueMatcher: NumberMatcher(), userValue: 1, matchValue: []))
+                self.assertTrue(sut.matches(valueMatcher: NumberMatcher(), userValue: true, matchValue: []))
+                self.assertTrue(sut.matches(valueMatcher: NumberMatcher(), userValue: self.v("1.0.0"), matchValue: []))
+                
+                self.assertTrue(sut.matches(valueMatcher: BoolMatcher(), userValue: "abc", matchValue: []))
+                self.assertTrue(sut.matches(valueMatcher: BoolMatcher(), userValue: 1, matchValue: []))
+                self.assertTrue(sut.matches(valueMatcher: BoolMatcher(), userValue: true, matchValue: []))
+                self.assertTrue(sut.matches(valueMatcher: BoolMatcher(), userValue: self.v("1.0.0"), matchValue: []))
+                
+                self.assertTrue(sut.matches(valueMatcher: VersionMatcher(), userValue: "abc", matchValue: []))
+                self.assertTrue(sut.matches(valueMatcher: VersionMatcher(), userValue: 1, matchValue: []))
+                self.assertTrue(sut.matches(valueMatcher: VersionMatcher(), userValue: true, matchValue: []))
+                self.assertTrue(sut.matches(valueMatcher: VersionMatcher(), userValue: self.v("1.0.0"), matchValue: []))
+            }
+            
+            
         }
     }
 

--- a/Tests/HackleTests/Core/Evaluation/Match/OperatorMatcherSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Match/OperatorMatcherSpecs.swift
@@ -34,10 +34,10 @@ class OperatorMatcherSpecs: QuickSpec {
             }
 
             it("version") {
-                self.assertTrue(sut.matches(valueMatcher: VersionMatcher(), userValue: self.v("1.0.0"), matchValue: [HackleValue(value: self.v("1.0.0"))]))
-                self.assertTrue(sut.matches(valueMatcher: VersionMatcher(), userValue: self.v("1.0.0"), matchValue: [HackleValue(value: self.v("1.0.0"))]))
-                self.assertTrue(sut.matches(valueMatcher: VersionMatcher(), userValue: self.v("1.0.0"), matchValue: [HackleValue(value: self.v("1.0.0")), HackleValue(value: self.v("1.0.1"))]))
-                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: self.v("1.0.0"), matchValue: [HackleValue(value: self.v("1.0.1"))]))
+                self.assertTrue(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValue: [HackleValue(value: "1.0.0")]))
+                self.assertTrue(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValue: [HackleValue(value: "1.0.0")]))
+                self.assertTrue(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValue: [HackleValue(value: "1.0.0"), HackleValue(value: "1.0.1")]))
+                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValue: [HackleValue(value: "1.0.1")]))
             }
         }
 
@@ -68,9 +68,9 @@ class OperatorMatcherSpecs: QuickSpec {
             }
 
             it("version") {
-                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: self.v("1.0.0"), matchValue: [HackleValue(value: self.v("1.0.0"))]))
-                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: self.v("1.0.0"), matchValue: [HackleValue(value: self.v("2.0.0"))]))
-                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: self.v("2.0.0"), matchValue: [HackleValue(value: self.v("1.0.0"))]))
+                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValue: [HackleValue(value: "1.0.0")]))
+                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValue: [HackleValue(value: "2.0.0")]))
+                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: "2.0.0", matchValue: [HackleValue(value: "1.0.0")]))
             }
         }
 
@@ -101,9 +101,9 @@ class OperatorMatcherSpecs: QuickSpec {
             }
 
             it("version") {
-                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: self.v("1.0.0"), matchValue: [HackleValue(value: self.v("1.0.0"))]))
-                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: self.v("1.0.0"), matchValue: [HackleValue(value: self.v("2.0.0"))]))
-                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: self.v("2.0.0"), matchValue: [HackleValue(value: self.v("1.0.0"))]))
+                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValue: [HackleValue(value: "1.0.0")]))
+                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValue: [HackleValue(value: "2.0.0")]))
+                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: "2.0.0", matchValue: [HackleValue(value: "1.0.0")]))
             }
         }
 
@@ -134,9 +134,9 @@ class OperatorMatcherSpecs: QuickSpec {
             }
 
             it("version") {
-                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: self.v("1.0.0"), matchValue: [HackleValue(value: self.v("1.0.0"))]))
-                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: self.v("1.0.0"), matchValue: [HackleValue(value: self.v("2.0.0"))]))
-                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: self.v("2.0.0"), matchValue: [HackleValue(value: self.v("1.0.0"))]))
+                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValue: [HackleValue(value: "1.0.0")]))
+                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValue: [HackleValue(value: "2.0.0")]))
+                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: "2.0.0", matchValue: [HackleValue(value: "1.0.0")]))
             }
         }
 
@@ -177,9 +177,9 @@ class OperatorMatcherSpecs: QuickSpec {
             }
 
             it("version") {
-                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: self.v("1.0.0"), matchValue: [HackleValue(value: self.v("1.0.0"))]))
-                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: self.v("1.0.0"), matchValue: [HackleValue(value: self.v("2.0.0"))]))
-                self.assertTrue(sut.matches(valueMatcher: VersionMatcher(), userValue: self.v("2.0.0"), matchValue: [HackleValue(value: self.v("1.0.0"))]))
+                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValue: [HackleValue(value: "1.0.0")]))
+                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValue: [HackleValue(value: "2.0.0")]))
+                self.assertTrue(sut.matches(valueMatcher: VersionMatcher(), userValue: "2.0.0", matchValue: [HackleValue(value: "1.0.0")]))
             }
         }
         
@@ -220,9 +220,9 @@ class OperatorMatcherSpecs: QuickSpec {
             }
 
             it("version") {
-                self.assertTrue(sut.matches(valueMatcher: VersionMatcher(), userValue: self.v("1.0.0"), matchValue: [HackleValue(value: self.v("1.0.0"))]))
-                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: self.v("1.0.0"), matchValue: [HackleValue(value: self.v("2.0.0"))]))
-                self.assertTrue(sut.matches(valueMatcher: VersionMatcher(), userValue: self.v("2.0.0"), matchValue: [HackleValue(value: self.v("1.0.0"))]))
+                self.assertTrue(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValue: [HackleValue(value: "1.0.0")]))
+                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValue: [HackleValue(value: "2.0.0")]))
+                self.assertTrue(sut.matches(valueMatcher: VersionMatcher(), userValue: "2.0.0", matchValue: [HackleValue(value: "1.0.0")]))
             }
         }
 
@@ -263,9 +263,9 @@ class OperatorMatcherSpecs: QuickSpec {
             }
 
             it("version") {
-                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: self.v("1.0.0"), matchValue: [HackleValue(value: self.v("1.0.0"))]))
-                self.assertTrue(sut.matches(valueMatcher: VersionMatcher(), userValue: self.v("1.0.0"), matchValue: [HackleValue(value: self.v("2.0.0"))]))
-                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: self.v("2.0.0"), matchValue: [HackleValue(value: self.v("1.0.0"))]))
+                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValue: [HackleValue(value: "1.0.0")]))
+                self.assertTrue(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValue: [HackleValue(value: "2.0.0")]))
+                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: "2.0.0", matchValue: [HackleValue(value: "1.0.0")]))
             }
         }
 
@@ -306,9 +306,9 @@ class OperatorMatcherSpecs: QuickSpec {
             }
 
             it("version") {
-                self.assertTrue(sut.matches(valueMatcher: VersionMatcher(), userValue: self.v("1.0.0"), matchValue: [HackleValue(value: self.v("1.0.0"))]))
-                self.assertTrue(sut.matches(valueMatcher: VersionMatcher(), userValue: self.v("1.0.0"), matchValue: [HackleValue(value: self.v("2.0.0"))]))
-                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: self.v("2.0.0"), matchValue: [HackleValue(value: self.v("1.0.0"))]))
+                self.assertTrue(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValue: [HackleValue(value: "1.0.0")]))
+                self.assertTrue(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValue: [HackleValue(value: "2.0.0")]))
+                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: "2.0.0", matchValue: [HackleValue(value: "1.0.0")]))
             }
         }
         
@@ -326,22 +326,22 @@ class OperatorMatcherSpecs: QuickSpec {
                 self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValue: []))
                 self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: 1, matchValue: []))
                 self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: true, matchValue: []))
-                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: self.v("1.0.0"), matchValue: []))
+                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "1.0.0", matchValue: []))
                 
                 self.assertTrue(sut.matches(valueMatcher: NumberMatcher(), userValue: "abc", matchValue: []))
                 self.assertTrue(sut.matches(valueMatcher: NumberMatcher(), userValue: 1, matchValue: []))
                 self.assertTrue(sut.matches(valueMatcher: NumberMatcher(), userValue: true, matchValue: []))
-                self.assertTrue(sut.matches(valueMatcher: NumberMatcher(), userValue: self.v("1.0.0"), matchValue: []))
+                self.assertTrue(sut.matches(valueMatcher: NumberMatcher(), userValue: "1.0.0", matchValue: []))
                 
                 self.assertTrue(sut.matches(valueMatcher: BoolMatcher(), userValue: "abc", matchValue: []))
                 self.assertTrue(sut.matches(valueMatcher: BoolMatcher(), userValue: 1, matchValue: []))
                 self.assertTrue(sut.matches(valueMatcher: BoolMatcher(), userValue: true, matchValue: []))
-                self.assertTrue(sut.matches(valueMatcher: BoolMatcher(), userValue: self.v("1.0.0"), matchValue: []))
+                self.assertTrue(sut.matches(valueMatcher: BoolMatcher(), userValue: "1.0.0", matchValue: []))
                 
                 self.assertTrue(sut.matches(valueMatcher: VersionMatcher(), userValue: "abc", matchValue: []))
                 self.assertTrue(sut.matches(valueMatcher: VersionMatcher(), userValue: 1, matchValue: []))
                 self.assertTrue(sut.matches(valueMatcher: VersionMatcher(), userValue: true, matchValue: []))
-                self.assertTrue(sut.matches(valueMatcher: VersionMatcher(), userValue: self.v("1.0.0"), matchValue: []))
+                self.assertTrue(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValue: []))
             }
             
             

--- a/Tests/HackleTests/Core/Evaluation/Match/UserConditionMatcherSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Match/UserConditionMatcherSpecs.swift
@@ -17,21 +17,6 @@ class UserConditionMatcherSpecs: QuickSpec {
             sut = UserConditionMatcher(userValueResolver: userValueResolver, valueOperatorMatcher: valueOperatorMatcher)
         }
 
-        it("key 에 해당하는 값이 없는 경우 match false") {
-            // given
-            every(userValueResolver.resolveOrNilMock).returns(nil)
-            let condition = Target.Condition(
-                key: Target.Key(type: .hackleProperty, name: "osName"),
-                match: Target.Match(type: .match, matchOperator: ._in, valueType: .string, values: [HackleValue(value: "iOS")])
-            )
-
-            // when
-            let actual = try sut.matches(request: experimentRequest(), context: Evaluators.context(), condition: condition)
-
-            // then
-            expect(actual).to(beFalse())
-        }
-
         it("key 에 해당하는 UserValue 로 매칭한다") {
             // given
             let condition = Target.Condition(

--- a/Tests/HackleTests/Core/Evaluation/Match/ValueMatcherSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Match/ValueMatcherSpecs.swift
@@ -335,10 +335,10 @@ class ValueMatcherSpecs: QuickSpec {
                 self.verifyIn(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: "1.0.0"), expected: true)
                 self.verifyIn(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: "2.0.0"), expected: false)
                 self.verifyGreaterThan(sut: sut, userValue: "1.0.1", matchValue: HackleValue(value: "1.0.0"), expected: true)
-                self.verifyGreaterThanOrEqual(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: "1.0.0"), expected: false)
+                self.verifyGreaterThanOrEqual(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: "1.0.0"), expected: true)
                 self.verifyGreaterThanOrEqual(sut: sut, userValue: "1.0.1", matchValue: HackleValue(value: "1.0.0"), expected: true)
                 self.verifyLessThan(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: "1.0.1"), expected: true)
-                self.verifyLessThanOrEqual(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: "1.0.0"), expected: false)
+                self.verifyLessThanOrEqual(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: "1.0.0"), expected: true)
                 self.verifyLessThanOrEqual(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: "1.0.1"), expected: true)
             }
 
@@ -423,6 +423,10 @@ class ValueMatcherSpecs: QuickSpec {
     }
     
     private func v(_ value: Any) -> Any {
+        if value is tmp {
+            return value
+        }
+        
         let tmp = ["tmp": value]
         let data = Json.serialize(tmp)!
         let dict = try! JSONSerialization.jsonObject(with: data) as! [String: Any]

--- a/Tests/HackleTests/Core/Evaluation/Match/ValueMatcherSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Match/ValueMatcherSpecs.swift
@@ -5,7 +5,423 @@ import Mockery
 @testable import Hackle
 
 class ValueMatcherSpecs: QuickSpec {
+    override func spec() {
 
+        describe("StringMatcher") {
+            let sut = StringMatcher()
+            
+
+            it("string type match") {
+                self.verifyIn(sut: sut, userValue: "42", matchValue: HackleValue(value: "42"), expected: true)
+                self.verifyIn(sut: sut, userValue: "42.42", matchValue: HackleValue(value: "42.42"), expected: true)
+                self.verifyContains(sut: sut, userValue: "42", matchValue: HackleValue(value: "4"), expected: true)
+                self.verifyStartsWith(sut: sut, userValue: "42", matchValue: HackleValue(value: "4"), expected: true)
+                self.verifyEndsWith(sut: sut, userValue: "42", matchValue: HackleValue(value: "2"), expected: true)
+                self.verifyGreaterThan(sut: sut, userValue: "42", matchValue: HackleValue(value: "41"), expected: true)
+                self.verifyGreaterThanOrEqual(sut: sut, userValue: "42", matchValue: HackleValue(value: "42"), expected: true)
+                self.verifyGreaterThanOrEqual(sut: sut, userValue: "43", matchValue: HackleValue(value: "42"), expected: true)
+                self.verifyLessThan(sut: sut, userValue: "42", matchValue: HackleValue(value: "43"), expected: true)
+                self.verifyLessThanOrEqual(sut: sut, userValue: "42", matchValue: HackleValue(value: "42"), expected: true)
+                self.verifyLessThanOrEqual(sut: sut, userValue: "41", matchValue: HackleValue(value: "42"), expected: true)
+            }
+            
+            it("matchValue가 자료형이 아니면 항상 false") {
+                self.verifyIn(sut: sut, userValue: "42", matchValue: HackleValue(value: tmp()), expected: false)
+                self.verifyContains(sut: sut, userValue: "42", matchValue: HackleValue(value: tmp()), expected: false)
+                self.verifyStartsWith(sut: sut, userValue: "42", matchValue: HackleValue(value: tmp()), expected: false)
+                self.verifyEndsWith(sut: sut, userValue: "42", matchValue: HackleValue(value: tmp()), expected: false)
+                self.verifyGreaterThan(sut: sut, userValue: "42", matchValue: HackleValue(value: tmp()), expected: false)
+                self.verifyGreaterThanOrEqual(sut: sut, userValue: "42", matchValue: HackleValue(value: tmp()), expected: false)
+                self.verifyLessThan(sut: sut, userValue: "42", matchValue: HackleValue(value: tmp()), expected: false)
+                self.verifyLessThanOrEqual(sut: sut, userValue: "42", matchValue: HackleValue(value: tmp()), expected: false)
+            }
+            
+            it("userValue가 자료형이 아니면 항상 false") {
+                self.verifyIn(sut: sut, userValue: tmp(), matchValue: HackleValue(value: "42"), expected: false)
+                self.verifyContains(sut: sut, userValue: tmp(), matchValue: HackleValue(value: "42"), expected: false)
+                self.verifyStartsWith(sut: sut, userValue: tmp(), matchValue: HackleValue(value: "42"), expected: false)
+                self.verifyEndsWith(sut: sut, userValue: tmp(), matchValue: HackleValue(value: "42"), expected: false)
+                self.verifyGreaterThan(sut: sut, userValue: tmp(), matchValue: HackleValue(value: "42"), expected: false)
+                self.verifyGreaterThanOrEqual(sut: sut, userValue: tmp(), matchValue: HackleValue(value: "42"), expected: false)
+                self.verifyLessThan(sut: sut, userValue: tmp(), matchValue: HackleValue(value: "42"), expected: false)
+                self.verifyLessThanOrEqual(sut: sut, userValue: tmp(), matchValue: HackleValue(value: "42"), expected: false)
+            }
+
+            it("number 타입이면 캐스팅 후 match") {
+                self.verifyIn(sut: sut, userValue: "42", matchValue: HackleValue(value: 42), expected: true)
+                self.verifyIn(sut: sut, userValue: 42, matchValue: HackleValue(value: "42"), expected: true)
+                self.verifyIn(sut: sut, userValue: 42, matchValue: HackleValue(value: 42), expected: true)
+                
+                self.verifyIn(sut: sut, userValue: "42.42", matchValue: HackleValue(value: 42.42), expected: true)
+                self.verifyIn(sut: sut, userValue: 42.42, matchValue: HackleValue(value: "42.42"), expected: true)
+                self.verifyIn(sut: sut, userValue: 42.42, matchValue: HackleValue(value: 42.42), expected: true)
+                
+                self.verifyIn(sut: sut, userValue: "42.0", matchValue: HackleValue(value: 42.0), expected: true)
+                self.verifyIn(sut: sut, userValue: 42.0, matchValue: HackleValue(value: "42.0"), expected: true)
+                self.verifyIn(sut: sut, userValue: 42.0, matchValue: HackleValue(value: 42.0), expected: true)
+            }
+
+            it("bool 타입이면 캐스팅 후 match") {
+                self.verifyIn(sut: sut, userValue: "true", matchValue: HackleValue(value: true), expected: true)
+                self.verifyIn(sut: sut, userValue: true, matchValue: HackleValue(value: "true"), expected: true)
+                self.verifyIn(sut: sut, userValue: true, matchValue: HackleValue(value: true), expected: true)
+                self.verifyIn(sut: sut, userValue: "false", matchValue: HackleValue(value: false), expected: true)
+                self.verifyIn(sut: sut, userValue: false, matchValue: HackleValue(value: "false"), expected: true)
+                self.verifyIn(sut: sut, userValue: false, matchValue: HackleValue(value: false), expected: true)
+            }
+
+            it("지원하지 않는 type") {
+                self.verifyIn(sut: sut, userValue: true, matchValue: HackleValue(value: "1"), expected: false)
+                self.verifyIn(sut: sut, userValue: "1", matchValue: HackleValue(value: true), expected: false)
+                self.verifyIn(sut: sut, userValue: false, matchValue: HackleValue(value: "0"), expected: false)
+                self.verifyIn(sut: sut, userValue: "0", matchValue: HackleValue(value: false), expected: false)
+                self.verifyIn(sut: sut, userValue: true, matchValue: HackleValue(value: "TRUE"), expected: false)
+                self.verifyIn(sut: sut, userValue: false, matchValue: HackleValue(value: "FALSE"), expected: false)
+            }
+        }
+
+        describe("NumberMatcher") {
+            let sut = NumberMatcher()
+
+            it("number type") {
+                self.verifyIn(sut: sut, userValue: 42, matchValue: HackleValue(value: 42), expected: true)
+                self.verifyIn(sut: sut, userValue: 42.1, matchValue: HackleValue(value: 42.1), expected: true)
+                self.verifyIn(sut: sut, userValue: 42.0, matchValue: HackleValue(value: 42), expected: true)
+                self.verifyIn(sut: sut, userValue: 42, matchValue: HackleValue(value: 42.0), expected: true)
+                self.verifyIn(sut: sut, userValue: 0, matchValue: HackleValue(value: 0.0), expected: true)
+                self.verifyIn(sut: sut, userValue: Int64(42), matchValue: HackleValue(value: 42), expected: true)
+                self.verifyIn(sut: sut, userValue: Int64(42), matchValue: HackleValue(value: 42.0), expected: true)
+                self.verifyIn(sut: sut, userValue: 42, matchValue: HackleValue(value: Int64(42)), expected: true)
+                self.verifyIn(sut: sut, userValue: 42.0, matchValue: HackleValue(value: Int64(42)), expected: true)
+                self.verifyIn(sut: sut, userValue: Double(42.0), matchValue: HackleValue(value: 42), expected: true)
+                self.verifyIn(sut: sut, userValue: Double(42.1), matchValue: HackleValue(value: 42.1), expected: true)
+                self.verifyIn(sut: sut, userValue: 42.0, matchValue: HackleValue(value: Double(42.0)), expected: true)
+                self.verifyIn(sut: sut, userValue: 42.1, matchValue: HackleValue(value: Double(42.1)), expected: true)
+
+                self.verifyGreaterThan(sut: sut, userValue: 43, matchValue: HackleValue(value: 42), expected: true)
+                self.verifyGreaterThan(sut: sut, userValue: 43.1, matchValue: HackleValue(value: 42.1), expected: true)
+                self.verifyGreaterThan(sut: sut, userValue: 43.0, matchValue: HackleValue(value: 42), expected: true)
+                self.verifyGreaterThan(sut: sut, userValue: 43, matchValue: HackleValue(value: 42.0), expected: true)
+                self.verifyGreaterThan(sut: sut, userValue: 1, matchValue: HackleValue(value: 0.0), expected: true)
+                self.verifyGreaterThan(sut: sut, userValue: Int64(43), matchValue: HackleValue(value: 42), expected: true)
+                self.verifyGreaterThan(sut: sut, userValue: Int64(43), matchValue: HackleValue(value: 42.0), expected: true)
+                self.verifyGreaterThan(sut: sut, userValue: 43, matchValue: HackleValue(value: Int64(42)), expected: true)
+                self.verifyGreaterThan(sut: sut, userValue: 43.0, matchValue: HackleValue(value: Int64(42)), expected: true)
+                self.verifyGreaterThan(sut: sut, userValue: Double(43.0), matchValue: HackleValue(value: 42), expected: true)
+                self.verifyGreaterThan(sut: sut, userValue: Double(43.1), matchValue: HackleValue(value: 42.1), expected: true)
+                self.verifyGreaterThan(sut: sut, userValue: 43.0, matchValue: HackleValue(value: Double(42.0)), expected: true)
+                self.verifyGreaterThan(sut: sut, userValue: 43.1, matchValue: HackleValue(value: Double(42.1)), expected: true)
+                
+                self.verifyGreaterThanOrEqual(sut: sut, userValue: 42, matchValue: HackleValue(value: 42), expected: true)
+                self.verifyGreaterThanOrEqual(sut: sut, userValue: 42.1, matchValue: HackleValue(value: 42.1), expected: true)
+                self.verifyGreaterThanOrEqual(sut: sut, userValue: 42.0, matchValue: HackleValue(value: 42), expected: true)
+                self.verifyGreaterThanOrEqual(sut: sut, userValue: 42, matchValue: HackleValue(value: 42.0), expected: true)
+                self.verifyGreaterThanOrEqual(sut: sut, userValue: 0, matchValue: HackleValue(value: 0.0), expected: true)
+                self.verifyGreaterThanOrEqual(sut: sut, userValue: Int64(42), matchValue: HackleValue(value: 42), expected: true)
+                self.verifyGreaterThanOrEqual(sut: sut, userValue: Int64(42), matchValue: HackleValue(value: 42.0), expected: true)
+                self.verifyGreaterThanOrEqual(sut: sut, userValue: 42, matchValue: HackleValue(value: Int64(42)), expected: true)
+                self.verifyGreaterThanOrEqual(sut: sut, userValue: 42.0, matchValue: HackleValue(value: Int64(42)), expected: true)
+                self.verifyGreaterThanOrEqual(sut: sut, userValue: Double(42.0), matchValue: HackleValue(value: 42), expected: true)
+                self.verifyGreaterThanOrEqual(sut: sut, userValue: Double(42.1), matchValue: HackleValue(value: 42.1), expected: true)
+                self.verifyGreaterThanOrEqual(sut: sut, userValue: 42.0, matchValue: HackleValue(value: Double(42.0)), expected: true)
+                self.verifyGreaterThanOrEqual(sut: sut, userValue: 42.1, matchValue: HackleValue(value: Double(42.1)), expected: true)
+                
+                self.verifyGreaterThanOrEqual(sut: sut, userValue: 43, matchValue: HackleValue(value: 42), expected: true)
+                self.verifyGreaterThanOrEqual(sut: sut, userValue: 43.1, matchValue: HackleValue(value: 42.1), expected: true)
+                self.verifyGreaterThanOrEqual(sut: sut, userValue: 43.0, matchValue: HackleValue(value: 42), expected: true)
+                self.verifyGreaterThanOrEqual(sut: sut, userValue: 43, matchValue: HackleValue(value: 42.0), expected: true)
+                self.verifyGreaterThanOrEqual(sut: sut, userValue: 1, matchValue: HackleValue(value: 0.0), expected: true)
+                self.verifyGreaterThanOrEqual(sut: sut, userValue: Int64(43), matchValue: HackleValue(value: 42), expected: true)
+                self.verifyGreaterThanOrEqual(sut: sut, userValue: Int64(43), matchValue: HackleValue(value: 42.0), expected: true)
+                self.verifyGreaterThanOrEqual(sut: sut, userValue: 43, matchValue: HackleValue(value: Int64(42)), expected: true)
+                self.verifyGreaterThanOrEqual(sut: sut, userValue: 43.0, matchValue: HackleValue(value: Int64(42)), expected: true)
+                self.verifyGreaterThanOrEqual(sut: sut, userValue: Double(43.0), matchValue: HackleValue(value: 42), expected: true)
+                self.verifyGreaterThanOrEqual(sut: sut, userValue: Double(43.1), matchValue: HackleValue(value: 42.1), expected: true)
+                self.verifyGreaterThanOrEqual(sut: sut, userValue: 43.0, matchValue: HackleValue(value: Double(42.0)), expected: true)
+                self.verifyGreaterThanOrEqual(sut: sut, userValue: 43.1, matchValue: HackleValue(value: Double(42.1)), expected: true)
+                
+                self.verifyLessThan(sut: sut, userValue: 41, matchValue: HackleValue(value: 42), expected: true)
+                self.verifyLessThan(sut: sut, userValue: 41.1, matchValue: HackleValue(value: 42.1), expected: true)
+                self.verifyLessThan(sut: sut, userValue: 41.0, matchValue: HackleValue(value: 42), expected: true)
+                self.verifyLessThan(sut: sut, userValue: 41, matchValue: HackleValue(value: 42.0), expected: true)
+                self.verifyLessThan(sut: sut, userValue: -1, matchValue: HackleValue(value: 0.0), expected: true)
+                self.verifyLessThan(sut: sut, userValue: Int64(41), matchValue: HackleValue(value: 42), expected: true)
+                self.verifyLessThan(sut: sut, userValue: Int64(41), matchValue: HackleValue(value: 42.0), expected: true)
+                self.verifyLessThan(sut: sut, userValue: 41, matchValue: HackleValue(value: Int64(42)), expected: true)
+                self.verifyLessThan(sut: sut, userValue: 41.0, matchValue: HackleValue(value: Int64(42)), expected: true)
+                self.verifyLessThan(sut: sut, userValue: Double(41.0), matchValue: HackleValue(value: 42), expected: true)
+                self.verifyLessThan(sut: sut, userValue: Double(41.1), matchValue: HackleValue(value: 42.1), expected: true)
+                self.verifyLessThan(sut: sut, userValue: 41.0, matchValue: HackleValue(value: Double(42.0)), expected: true)
+                self.verifyLessThan(sut: sut, userValue: 41.1, matchValue: HackleValue(value: Double(42.1)), expected: true)
+                
+                self.verifyLessThanOrEqual(sut: sut, userValue: 41, matchValue: HackleValue(value: 42), expected: true)
+                self.verifyLessThanOrEqual(sut: sut, userValue: 41.1, matchValue: HackleValue(value: 42.1), expected: true)
+                self.verifyLessThanOrEqual(sut: sut, userValue: 41.0, matchValue: HackleValue(value: 42), expected: true)
+                self.verifyLessThanOrEqual(sut: sut, userValue: 41, matchValue: HackleValue(value: 42.0), expected: true)
+                self.verifyLessThanOrEqual(sut: sut, userValue: -1, matchValue: HackleValue(value: 0.0), expected: true)
+                self.verifyLessThanOrEqual(sut: sut, userValue: Int64(41), matchValue: HackleValue(value: 42), expected: true)
+                self.verifyLessThanOrEqual(sut: sut, userValue: Int64(41), matchValue: HackleValue(value: 42.0), expected: true)
+                self.verifyLessThanOrEqual(sut: sut, userValue: 41, matchValue: HackleValue(value: Int64(42)), expected: true)
+                self.verifyLessThanOrEqual(sut: sut, userValue: 41.0, matchValue: HackleValue(value: Int64(42)), expected: true)
+                self.verifyLessThanOrEqual(sut: sut, userValue: Double(41.0), matchValue: HackleValue(value: 42), expected: true)
+                self.verifyLessThanOrEqual(sut: sut, userValue: Double(41.1), matchValue: HackleValue(value: 42.1), expected: true)
+                self.verifyLessThanOrEqual(sut: sut, userValue: 41.0, matchValue: HackleValue(value: Double(42.0)), expected: true)
+                self.verifyLessThanOrEqual(sut: sut, userValue: 41.1, matchValue: HackleValue(value: Double(42.1)), expected: true)
+                
+                self.verifyLessThanOrEqual(sut: sut, userValue: 42, matchValue: HackleValue(value: 42), expected: true)
+                self.verifyLessThanOrEqual(sut: sut, userValue: 42.1, matchValue: HackleValue(value: 42.1), expected: true)
+                self.verifyLessThanOrEqual(sut: sut, userValue: 42.0, matchValue: HackleValue(value: 42), expected: true)
+                self.verifyLessThanOrEqual(sut: sut, userValue: 42, matchValue: HackleValue(value: 42.0), expected: true)
+                self.verifyLessThanOrEqual(sut: sut, userValue: 0, matchValue: HackleValue(value: 0.0), expected: true)
+                self.verifyLessThanOrEqual(sut: sut, userValue: Int64(42), matchValue: HackleValue(value: 42), expected: true)
+                self.verifyLessThanOrEqual(sut: sut, userValue: Int64(42), matchValue: HackleValue(value: 42.0), expected: true)
+                self.verifyLessThanOrEqual(sut: sut, userValue: 42, matchValue: HackleValue(value: Int64(42)), expected: true)
+                self.verifyLessThanOrEqual(sut: sut, userValue: 42.0, matchValue: HackleValue(value: Int64(42)), expected: true)
+                self.verifyLessThanOrEqual(sut: sut, userValue: Double(42.0), matchValue: HackleValue(value: 42), expected: true)
+                self.verifyLessThanOrEqual(sut: sut, userValue: Double(42.1), matchValue: HackleValue(value: 42.1), expected: true)
+                self.verifyLessThanOrEqual(sut: sut, userValue: 42.0, matchValue: HackleValue(value: Double(42.0)), expected: true)
+                self.verifyLessThanOrEqual(sut: sut, userValue: 42.1, matchValue: HackleValue(value: Double(42.1)), expected: true)
+            }
+            
+            it("숫자형 범위 체크") {
+                self.verifyIn(sut: sut, userValue: Int.max, matchValue: HackleValue(value: Int.max), expected: true)
+                self.verifyIn(sut: sut, userValue: Int.min, matchValue: HackleValue(value: Int.min), expected: true)
+                self.verifyIn(sut: sut, userValue: Int64.max, matchValue: HackleValue(value: Int64.max), expected: true)
+                self.verifyIn(sut: sut, userValue: Int64.min, matchValue: HackleValue(value: Int64.min), expected: true)
+                self.verifyIn(sut: sut, userValue: UInt64.min, matchValue: HackleValue(value: UInt64.min), expected: true)
+                self.verifyIn(sut: sut, userValue: UInt64.max, matchValue: HackleValue(value: UInt64.max), expected: true)
+                self.verifyIn(sut: sut, userValue: Double(Int.max), matchValue: HackleValue(value: Int.max), expected: true)
+                self.verifyIn(sut: sut, userValue: Double(Int.min), matchValue: HackleValue(value: Int.min), expected: true)
+                self.verifyIn(sut: sut, userValue: Double(Int64.max), matchValue: HackleValue(value: Int64.max), expected: true)
+                self.verifyIn(sut: sut, userValue: Double(Int64.min), matchValue: HackleValue(value: Int64.min), expected: true)
+                self.verifyIn(sut: sut, userValue: Double(UInt64.max), matchValue: HackleValue(value: UInt64.max), expected: true)
+                self.verifyIn(sut: sut, userValue: Double(UInt64.min), matchValue: HackleValue(value: UInt64.min), expected: true)
+                self.verifyIn(sut: sut, userValue: Double.zero, matchValue: HackleValue(value: Int.zero), expected: true)
+                self.verifyIn(sut: sut, userValue: Double.zero, matchValue: HackleValue(value: Int64.zero), expected: true)
+                self.verifyIn(sut: sut, userValue: Int.zero, matchValue: HackleValue(value: Double.zero), expected: true)
+                self.verifyIn(sut: sut, userValue: Int64.zero, matchValue: HackleValue(value: Double.zero), expected: true)
+                
+                self.verifyGreaterThanOrEqual(sut: sut, userValue: Double.greatestFiniteMagnitude, matchValue: HackleValue(value: Int.max), expected: true)
+                self.verifyGreaterThanOrEqual(sut: sut, userValue: Double.greatestFiniteMagnitude, matchValue: HackleValue(value: Int64.max), expected: true)
+                self.verifyGreaterThanOrEqual(sut: sut, userValue: Double.greatestFiniteMagnitude, matchValue: HackleValue(value: UInt64.max), expected: true)
+                
+                self.verifyLessThanOrEqual(sut: sut, userValue: Int.min, matchValue: HackleValue(value: -Double.greatestFiniteMagnitude), expected: true)
+                self.verifyLessThanOrEqual(sut: sut, userValue: Int64.min, matchValue: HackleValue(value: -Double.greatestFiniteMagnitude), expected: true)
+                self.verifyLessThanOrEqual(sut: sut, userValue: UInt64.min, matchValue: HackleValue(value: -Double.greatestFiniteMagnitude), expected: true)
+                
+            }
+            
+            it("matchValue가 숫자가 아니면 아니면 항상 false") {
+                self.verifyIn(sut: sut, userValue: "1", matchValue: HackleValue(value: true), expected: false)
+                self.verifyContains(sut: sut, userValue: "42", matchValue: HackleValue(value: false), expected: false)
+                self.verifyStartsWith(sut: sut, userValue: "42", matchValue: HackleValue(value: tmp()), expected: false)
+                self.verifyEndsWith(sut: sut, userValue: "1", matchValue: HackleValue(value: false), expected: false)
+                self.verifyGreaterThan(sut: sut, userValue: "42", matchValue: HackleValue(value: "string"), expected: false)
+                self.verifyGreaterThanOrEqual(sut: sut, userValue: "42", matchValue: HackleValue(value: "1.1.1"), expected: false)
+                self.verifyLessThan(sut: sut, userValue: "42", matchValue: HackleValue(value: "string"), expected: false)
+                self.verifyLessThanOrEqual(sut: sut, userValue: "42", matchValue: HackleValue(value: tmp()), expected: false)
+            }
+            
+            it("userValue가 숫자가 아니면 항상 false") {
+                self.verifyIn(sut: sut, userValue: true, matchValue: HackleValue(value: "1"), expected: false)
+                self.verifyContains(sut: sut, userValue: "false", matchValue: HackleValue(value: "42"), expected: false)
+                self.verifyStartsWith(sut: sut, userValue: "string", matchValue: HackleValue(value: "42"), expected: false)
+                self.verifyEndsWith(sut: sut, userValue: tmp(), matchValue: HackleValue(value: "42"), expected: false)
+                self.verifyGreaterThan(sut: sut, userValue: "1.1.1", matchValue: HackleValue(value: "42"), expected: false)
+                self.verifyGreaterThanOrEqual(sut: sut, userValue: false, matchValue: HackleValue(value: "42"), expected: false)
+                self.verifyLessThan(sut: sut, userValue: tmp(), matchValue: HackleValue(value: "42"), expected: false)
+                self.verifyLessThanOrEqual(sut: sut, userValue: true, matchValue: HackleValue(value: "42"), expected: false)
+            }
+
+            it("string type 이면 캐스팅후 match") {
+                self.verifyIn(sut: sut, userValue: "42", matchValue: HackleValue(value: "42"), expected: true)
+                self.verifyIn(sut: sut, userValue: "42", matchValue: HackleValue(value: 42), expected: true)
+                self.verifyIn(sut: sut, userValue: 42, matchValue: HackleValue(value: "42"), expected: true)
+
+                self.verifyIn(sut: sut, userValue: "42.42", matchValue: HackleValue(value: "42.42"), expected: true)
+                self.verifyIn(sut: sut, userValue: "42.42", matchValue: HackleValue(value: 42.42), expected: true)
+                self.verifyIn(sut: sut, userValue: 42.42, matchValue: HackleValue(value: "42.42"), expected: true)
+                
+                self.verifyIn(sut: sut, userValue: "42.0", matchValue: HackleValue(value: "42.0"), expected: true)
+                self.verifyIn(sut: sut, userValue: "42.0", matchValue: HackleValue(value: 42.0), expected: true)
+                self.verifyIn(sut: sut, userValue: 42.0, matchValue: HackleValue(value: "42.0"), expected: true)
+            }
+
+            it("지원하지 않는 type") {
+                self.verifyIn(sut: sut, userValue: true, matchValue: HackleValue(value: true), expected: false)
+                self.verifyIn(sut: sut, userValue: true, matchValue: HackleValue(value: 1), expected: false)
+                self.verifyIn(sut: sut, userValue: 1, matchValue: HackleValue(value: true), expected: false)
+                self.verifyIn(sut: sut, userValue: "42a", matchValue: HackleValue(value: 42), expected: false)
+            }
+            
+            it("지원하지 않는 연산자") {
+                self.verifyContains(sut: sut, userValue: 42, matchValue: HackleValue(value: 42), expected: false)
+                self.verifyStartsWith(sut: sut, userValue: 42, matchValue: HackleValue(value: 42), expected: false)
+                self.verifyEndsWith(sut: sut, userValue: 42, matchValue: HackleValue(value: 42), expected: false)
+            }
+        }
+
+        describe("BoolMatcher") {
+            let sut = BoolMatcher()
+
+            it("bool type") {
+                self.verifyIn(sut: sut, userValue: true, matchValue: HackleValue(value: true), expected: true)
+                self.verifyIn(sut: sut, userValue: "true", matchValue: HackleValue(value: true), expected: true)
+                self.verifyIn(sut: sut, userValue: true, matchValue: HackleValue(value: "true"), expected: true)
+                self.verifyIn(sut: sut, userValue: "true", matchValue: HackleValue(value: "true"), expected: true)
+                self.verifyIn(sut: sut, userValue: false, matchValue: HackleValue(value: false), expected: true)
+                self.verifyIn(sut: sut, userValue: "false", matchValue: HackleValue(value: false), expected: true)
+                self.verifyIn(sut: sut, userValue: false, matchValue: HackleValue(value: "false"), expected: true)
+                self.verifyIn(sut: sut, userValue: "false", matchValue: HackleValue(value: "false"), expected: true)
+                
+                self.verifyIn(sut: sut, userValue: true, matchValue: HackleValue(value: false), expected: false)
+                self.verifyIn(sut: sut, userValue: "true", matchValue: HackleValue(value: false), expected: false)
+                self.verifyIn(sut: sut, userValue: false, matchValue: HackleValue(value: true), expected: false)
+                self.verifyIn(sut: sut, userValue: "false", matchValue: HackleValue(value: true), expected: false)
+                
+                self.verifyIn(sut: sut, userValue: true, matchValue: HackleValue(value: 1), expected: false)
+                self.verifyIn(sut: sut, userValue: true, matchValue: HackleValue(value: "1"), expected: false)
+                self.verifyIn(sut: sut, userValue: false, matchValue: HackleValue(value: 0), expected: false)
+                self.verifyIn(sut: sut, userValue: false, matchValue: HackleValue(value: "0"), expected: false)
+                self.verifyIn(sut: sut, userValue: 1, matchValue: HackleValue(value: true), expected: false)
+                self.verifyIn(sut: sut, userValue: "1", matchValue: HackleValue(value: true), expected: false)
+                self.verifyIn(sut: sut, userValue: 0, matchValue: HackleValue(value: false), expected: false)
+                self.verifyIn(sut: sut, userValue: "0", matchValue: HackleValue(value: false), expected: false)
+                
+                self.verifyIn(sut: sut, userValue: "0", matchValue: HackleValue(value: true), expected: false)
+                self.verifyIn(sut: sut, userValue: 0, matchValue: HackleValue(value: true), expected: false)
+                self.verifyIn(sut: sut, userValue: "1", matchValue: HackleValue(value: false), expected: false)
+                self.verifyIn(sut: sut, userValue: 1, matchValue: HackleValue(value: false), expected: false)
+                self.verifyIn(sut: sut, userValue: true, matchValue: HackleValue(value: "0"), expected: false)
+                self.verifyIn(sut: sut, userValue: true, matchValue: HackleValue(value: 0), expected: false)
+                self.verifyIn(sut: sut, userValue: false, matchValue: HackleValue(value: "1"), expected: false)
+                self.verifyIn(sut: sut, userValue: false, matchValue: HackleValue(value: 1), expected: false)
+                
+                self.verifyIn(sut: sut, userValue: true, matchValue: HackleValue(value: "TRUE"), expected: false)
+                self.verifyIn(sut: sut, userValue: false, matchValue: HackleValue(value: "FALSE"), expected: false)
+                self.verifyIn(sut: sut, userValue: "TRUE", matchValue: HackleValue(value: true), expected: false)
+                self.verifyIn(sut: sut, userValue: "FALSE", matchValue: HackleValue(value: false), expected: false)
+            }
+            
+            it("matchValue가 Bool이 아니면 항상 false") {
+                self.verifyIn(sut: sut, userValue: "true", matchValue: HackleValue(value: tmp()), expected: false)
+                self.verifyIn(sut: sut, userValue: true, matchValue: HackleValue(value: "string"), expected: false)
+                self.verifyIn(sut: sut, userValue: "false", matchValue: HackleValue(value: "1.1.1"), expected: false)
+                self.verifyIn(sut: sut, userValue: false, matchValue: HackleValue(value: 234), expected: false)
+            }
+
+            it("userValue가 Bool타입이 아니면 false") {
+                self.verifyIn(sut: sut, userValue: "string", matchValue: HackleValue(value: true), expected: false)
+                self.verifyIn(sut: sut, userValue: 234, matchValue: HackleValue(value: true), expected: false)
+                self.verifyIn(sut: sut, userValue: tmp(), matchValue: HackleValue(value: true), expected: false)
+                self.verifyIn(sut: sut, userValue: "1.1.1", matchValue: HackleValue(value: true), expected: false)
+            }
+
+            it("지원하지 않는 연산자") {
+                self.verifyContains(sut: sut, userValue: true, matchValue: HackleValue(value: true), expected: false)
+                self.verifyStartsWith(sut: sut, userValue: true, matchValue: HackleValue(value: true), expected: false)
+                self.verifyEndsWith(sut: sut, userValue: true, matchValue: HackleValue(value: true), expected: false)
+                self.verifyGreaterThan(sut: sut, userValue: true, matchValue: HackleValue(value: true), expected: false)
+                self.verifyGreaterThanOrEqual(sut: sut, userValue: true, matchValue: HackleValue(value: true), expected: false)
+                self.verifyLessThan(sut: sut, userValue: true, matchValue: HackleValue(value: true), expected: false)
+                self.verifyLessThanOrEqual(sut: sut, userValue: true, matchValue: HackleValue(value: true), expected: false)
+            }
+        }
+
+        describe("VersionMatcher") {
+            let sut = VersionMatcher()
+            
+            it("version type") {
+                self.verifyIn(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: "1.0.0"), expected: true)
+                self.verifyIn(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: "2.0.0"), expected: false)
+                self.verifyGreaterThan(sut: sut, userValue: "1.0.1", matchValue: HackleValue(value: "1.0.0"), expected: true)
+                self.verifyGreaterThanOrEqual(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: "1.0.0"), expected: false)
+                self.verifyGreaterThanOrEqual(sut: sut, userValue: "1.0.1", matchValue: HackleValue(value: "1.0.0"), expected: true)
+                self.verifyLessThan(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: "1.0.1"), expected: true)
+                self.verifyLessThanOrEqual(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: "1.0.0"), expected: false)
+                self.verifyLessThanOrEqual(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: "1.0.1"), expected: true)
+            }
+
+            it("matchValue가 Version 타입이 아니면 항상 false") {
+                self.verifyIn(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: Int.max), expected: false)
+                self.verifyIn(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: 1.0), expected: false)
+                self.verifyIn(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: "1.0"), expected: false)
+                self.verifyIn(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: "string"), expected: false)
+                self.verifyIn(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: true), expected: false)
+                
+                self.verifyGreaterThan(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: Int.max), expected: false)
+                self.verifyGreaterThan(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: 1.0), expected: false)
+                self.verifyGreaterThan(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: "1.0"), expected: false)
+                self.verifyGreaterThan(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: "string"), expected: false)
+                self.verifyGreaterThan(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: true), expected: false)
+                
+                self.verifyGreaterThanOrEqual(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: Int.max), expected: false)
+                self.verifyGreaterThanOrEqual(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: 1.0), expected: false)
+                self.verifyGreaterThanOrEqual(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: "1.0"), expected: false)
+                self.verifyGreaterThanOrEqual(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: "string"), expected: false)
+                self.verifyGreaterThanOrEqual(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: true), expected: false)
+                
+                self.verifyLessThan(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: Int.max), expected: false)
+                self.verifyLessThan(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: 1.0), expected: false)
+                self.verifyLessThan(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: "1.0"), expected: false)
+                self.verifyLessThan(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: "string"), expected: false)
+                self.verifyLessThan(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: true), expected: false)
+                
+                self.verifyLessThanOrEqual(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: Int.max), expected: false)
+                self.verifyLessThanOrEqual(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: 1.0), expected: false)
+                self.verifyLessThanOrEqual(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: "1.0"), expected: false)
+                self.verifyLessThanOrEqual(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: "string"), expected: false)
+                self.verifyLessThanOrEqual(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: true), expected: false)
+            }
+
+            it("userValue가 Version 타입이 아니면 false") {
+                self.verifyIn(sut: sut, userValue: Int.max, matchValue: HackleValue(value: "1.0.0"), expected: false)
+                self.verifyIn(sut: sut, userValue: 1.0, matchValue: HackleValue(value: "1.0.0"), expected: false)
+                self.verifyIn(sut: sut, userValue: "1.0", matchValue: HackleValue(value: "1.0.0"), expected: false)
+                self.verifyIn(sut: sut, userValue: "string", matchValue: HackleValue(value: "1.0.0"), expected: false)
+                self.verifyIn(sut: sut, userValue: true, matchValue: HackleValue(value: "1.0.0"), expected: false)
+                
+                self.verifyGreaterThan(sut: sut, userValue: Int.max, matchValue: HackleValue(value: "1.0.0"), expected: false)
+                self.verifyGreaterThan(sut: sut, userValue: 1.0, matchValue: HackleValue(value: "1.0.0"), expected: false)
+                self.verifyGreaterThan(sut: sut, userValue: "1.0", matchValue: HackleValue(value: "1.0.0"), expected: false)
+                self.verifyGreaterThan(sut: sut, userValue: "string", matchValue: HackleValue(value: "1.0.0"), expected: false)
+                self.verifyGreaterThan(sut: sut, userValue: true, matchValue: HackleValue(value: "1.0.0"), expected: false)
+                
+                self.verifyGreaterThanOrEqual(sut: sut, userValue: Int.max, matchValue: HackleValue(value: "1.0.0"), expected: false)
+                self.verifyGreaterThanOrEqual(sut: sut, userValue: 1.0, matchValue: HackleValue(value: "1.0.0"), expected: false)
+                self.verifyGreaterThanOrEqual(sut: sut, userValue: "1.0", matchValue: HackleValue(value: "1.0.0"), expected: false)
+                self.verifyGreaterThanOrEqual(sut: sut, userValue: "string", matchValue: HackleValue(value: "1.0.0"), expected: false)
+                self.verifyGreaterThanOrEqual(sut: sut, userValue: true, matchValue: HackleValue(value: "1.0.0"), expected: false)
+                
+                self.verifyLessThan(sut: sut, userValue: Int.max, matchValue: HackleValue(value: "1.0.0"), expected: false)
+                self.verifyLessThan(sut: sut, userValue: 1.0, matchValue: HackleValue(value: "1.0.0"), expected: false)
+                self.verifyLessThan(sut: sut, userValue: "1.0", matchValue: HackleValue(value: "1.0.0"), expected: false)
+                self.verifyLessThan(sut: sut, userValue: "string", matchValue: HackleValue(value: "1.0.0"), expected: false)
+                self.verifyLessThan(sut: sut, userValue: true, matchValue: HackleValue(value: "1.0.0"), expected: false)
+                
+                self.verifyLessThanOrEqual(sut: sut, userValue: Int.max, matchValue: HackleValue(value: "1.0.0"), expected: false)
+                self.verifyLessThanOrEqual(sut: sut, userValue: 1.0, matchValue: HackleValue(value: "1.0.0"), expected: false)
+                self.verifyLessThanOrEqual(sut: sut, userValue: "1.0", matchValue: HackleValue(value: "1.0.0"), expected: false)
+                self.verifyLessThanOrEqual(sut: sut, userValue: "string", matchValue: HackleValue(value: "1.0.0"), expected: false)
+                self.verifyLessThanOrEqual(sut: sut, userValue: true, matchValue: HackleValue(value: "1.0.0"), expected: false)
+            }
+
+            it("지원하지 않는 연산자") {
+                self.verifyContains(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: "1.0.0"), expected: false)
+                self.verifyStartsWith(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: "1.0.0"), expected: false)
+                self.verifyEndsWith(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: "1.0.0"), expected: false)
+            }
+        }
+    }
+    
+    class tmp {
+        let data: Any?
+        
+        init(data: Any? = nil) {
+            self.data = data
+        }
+    }
+    
     private func v(_ value: Any) -> Any {
         let tmp = ["tmp": value]
         let data = Json.serialize(tmp)!
@@ -13,155 +429,108 @@ class ValueMatcherSpecs: QuickSpec {
         return dict["tmp"]!
     }
 
-    private func verify(sut: ValueMatcher, userValue: Any, matchValue: HackleValue, expected: Bool) {
-        let matcher = InMatcher()
-        let v1 = userValue
-        let a1 = sut.matches(operatorMatcher: matcher, userValue: v1, matchValue: matchValue)
-        expect(a1).to(equal(expected))
-
-        let v2 = v(userValue)
-        let a2 = sut.matches(operatorMatcher: matcher, userValue: v2, matchValue: matchValue)
-        expect(a2).to(equal(expected))
-    }
-
-    override func spec() {
-
-        describe("StringMatcher") {
-            let sut = StringMatcher()
-
-            it("string type match") {
-                self.verify(sut: sut, userValue: "42", matchValue: HackleValue(value: "42"), expected: true)
-                self.verify(sut: sut, userValue: "42", matchValue: HackleValue(value: "42"), expected: true)
-            }
-
-            it("number 타입이면 캐스팅 후 match") {
-                self.verify(sut: sut, userValue: "42", matchValue: HackleValue(value: 42), expected: true)
-                self.verify(sut: sut, userValue: 42, matchValue: HackleValue(value: "42"), expected: true)
-                self.verify(sut: sut, userValue: 42, matchValue: HackleValue(value: 42), expected: true)
-            }
-
-            it("bool 타입이면 캐스팅 후 match") {
-                self.verify(sut: sut, userValue: "true", matchValue: HackleValue(value: true), expected: true)
-                self.verify(sut: sut, userValue: true, matchValue: HackleValue(value: "true"), expected: true)
-                self.verify(sut: sut, userValue: true, matchValue: HackleValue(value: true), expected: true)
-                self.verify(sut: sut, userValue: "false", matchValue: HackleValue(value: false), expected: true)
-                self.verify(sut: sut, userValue: false, matchValue: HackleValue(value: "false"), expected: true)
-                self.verify(sut: sut, userValue: false, matchValue: HackleValue(value: false), expected: true)
-
-                self.verify(sut: sut, userValue: true, matchValue: HackleValue(value: "TRUE"), expected: false)
-                self.verify(sut: sut, userValue: false, matchValue: HackleValue(value: "FALSE"), expected: false)
-            }
-
-            it("지원하지 않는 type") {
-                self.verify(sut: sut, userValue: true, matchValue: HackleValue(value: "1"), expected: false)
-                self.verify(sut: sut, userValue: "1", matchValue: HackleValue(value: true), expected: false)
-                self.verify(sut: sut, userValue: false, matchValue: HackleValue(value: "0"), expected: false)
-                self.verify(sut: sut, userValue: "0", matchValue: HackleValue(value: false), expected: false)
-            }
-        }
-
-        describe("NumberMatcher") {
-
-            let sut = NumberMatcher()
-
-            it("number type") {
-                self.verify(sut: sut, userValue: 42, matchValue: HackleValue(value: 42), expected: true)
-                self.verify(sut: sut, userValue: 42.1, matchValue: HackleValue(value: 42.1), expected: true)
-                self.verify(sut: sut, userValue: 42.0, matchValue: HackleValue(value: 42), expected: true)
-                self.verify(sut: sut, userValue: 42, matchValue: HackleValue(value: 42.0), expected: true)
-                self.verify(sut: sut, userValue: 0, matchValue: HackleValue(value: 0.0), expected: true)
-            }
-
-            it("string type 이면 캐스팅후 match") {
-                self.verify(sut: sut, userValue: "42", matchValue: HackleValue(value: "42"), expected: true)
-                self.verify(sut: sut, userValue: "42", matchValue: HackleValue(value: 42), expected: true)
-                self.verify(sut: sut, userValue: 42, matchValue: HackleValue(value: "42"), expected: true)
-
-                self.verify(sut: sut, userValue: "42.42", matchValue: HackleValue(value: "42.42"), expected: true)
-                self.verify(sut: sut, userValue: "42.42", matchValue: HackleValue(value: 42.42), expected: true)
-                self.verify(sut: sut, userValue: 42.42, matchValue: HackleValue(value: "42.42"), expected: true)
-            }
-
-            it("지원하지 않는 type") {
-                self.verify(sut: sut, userValue: true, matchValue: HackleValue(value: true), expected: false)
-                self.verify(sut: sut, userValue: true, matchValue: HackleValue(value: 1), expected: false)
-                self.verify(sut: sut, userValue: 1, matchValue: HackleValue(value: true), expected: false)
-                self.verify(sut: sut, userValue: "42a", matchValue: HackleValue(value: 42), expected: false)
-            }
-        }
-
-        describe("BoolMatcher") {
-
-            let sut = BoolMatcher()
-
-            it("userValue, matchValue가 Bool 타입이면 OperatorMatcher의 일치 결과로 평가한다") {
-                self.verify(sut: sut, userValue: true, matchValue: HackleValue(value: true), expected: true)
-                self.verify(sut: sut, userValue: false, matchValue: HackleValue(value: false), expected: true)
-                self.verify(sut: sut, userValue: true, matchValue: HackleValue(value: false), expected: false)
-                self.verify(sut: sut, userValue: false, matchValue: HackleValue(value: true), expected: false)
-            }
-
-            it("userValue가 Bool타입이 아니면 false") {
-                self.verify(sut: sut, userValue: "string", matchValue: HackleValue(value: true), expected: false)
-                self.verify(sut: sut, userValue: 1, matchValue: HackleValue(value: true), expected: false)
-            }
-
-            it("userValue가 Bool타입이지만 matchValue가 Bool타입이 아니면 false") {
-                self.verify(sut: sut, userValue: true, matchValue: HackleValue(value: 1), expected: false)
-                self.verify(sut: sut, userValue: true, matchValue: HackleValue(value: "string"), expected: false)
-            }
-
-            it("userValue 혹은 matchValue가 String타입이지만 true이거나 false이면 BoolMatcher의 일치 결과로 평가한다.") {
-                self.verify(sut: sut, userValue: "true", matchValue: HackleValue(value: true), expected: true)
-                self.verify(sut: sut, userValue: "false", matchValue: HackleValue(value: false), expected: true)
-                self.verify(sut: sut, userValue: true, matchValue: HackleValue(value: "true"), expected: true)
-                self.verify(sut: sut, userValue: false, matchValue: HackleValue(value: "false"), expected: true)
-
-                self.verify(sut: sut, userValue: "TRUE", matchValue: HackleValue(value: true), expected: false)
-                self.verify(sut: sut, userValue: "FALSE", matchValue: HackleValue(value: false), expected: false)
-                self.verify(sut: sut, userValue: true, matchValue: HackleValue(value: "TRUE"), expected: false)
-                self.verify(sut: sut, userValue: false, matchValue: HackleValue(value: "FALSE"), expected: false)
-                self.verify(sut: sut, userValue: "FALSE", matchValue: HackleValue(value: true), expected: false)
-                self.verify(sut: sut, userValue: "true", matchValue: HackleValue(value: false), expected: false)
-            }
+    private func verifyIn(sut: ValueMatcher, userValue: Any, matchValue: HackleValue, expected: Bool) {
+        let userValueList = [userValue, v(userValue), HackleValue(value: userValue)]
+        let hackleValueWrapedMatchValue = HackleValue(value: matchValue)
+        
+        for user in userValueList {
+            let case1 = sut.inMatch(userValue: user, matchValue: matchValue)
+            let case2 = sut.inMatch(userValue: user, matchValue: hackleValueWrapedMatchValue)
             
-            it("bool all type checker") {
-                self.verify(sut: sut, userValue: true, matchValue: HackleValue(value: true), expected: true)
-                self.verify(sut: sut, userValue: true, matchValue: HackleValue(value: 1), expected: false)
-                self.verify(sut: sut, userValue: true, matchValue: HackleValue(value: "true"), expected: true)
-                self.verify(sut: sut, userValue: 1, matchValue: HackleValue(value: true), expected: false)
-                self.verify(sut: sut, userValue: true, matchValue: HackleValue(value: true), expected: true)
-                self.verify(sut: sut, userValue: "true", matchValue: HackleValue(value: true), expected: true)
-                
-                self.verify(sut: sut, userValue: false, matchValue: HackleValue(value: false), expected: true)
-                self.verify(sut: sut, userValue: false, matchValue: HackleValue(value: 0), expected: false)
-                self.verify(sut: sut, userValue: false, matchValue: HackleValue(value: "false"), expected: true)
-                self.verify(sut: sut, userValue: 0, matchValue: HackleValue(value: false), expected: false)
-                self.verify(sut: sut, userValue: false, matchValue: HackleValue(value: false), expected: true)
-                self.verify(sut: sut, userValue: "false", matchValue: HackleValue(value: false), expected: true)
-            }
+            expect(case1).to(equal(expected))
+            expect(case2).to(equal(expected))
         }
-
-        describe("VersionMatcher") {
-
-            let sut = VersionMatcher()
-
-            it("userValue, matchValue가 Version 타입이면 OperatorMatcher의 일치 결과로 평가한다") {
-                self.verify(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: "1.0.0"), expected: true)
-                self.verify(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: "2.0.0"), expected: false)
-            }
-
-            it("userValue가 Version 타입이 아니면 false") {
-                self.verify(sut: sut, userValue: 1.0, matchValue: HackleValue(value: "1.0.0"), expected: false)
-            }
-
-            it("userValue가 Version 타입이지만 matchValue가 Version 타입이 아니면 false") {
-                self.verify(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: 1.0), expected: false)
-            }
-
-            func v(_ version: String) -> Version {
-                Version.tryParse(value: version)!
-            }
+    }
+    
+    private func verifyContains(sut: ValueMatcher, userValue: Any, matchValue: HackleValue, expected: Bool) {
+        let userValueList = [userValue, v(userValue), HackleValue(value: userValue)]
+        let hackleValueWrapedMatchValue = HackleValue(value: matchValue)
+        
+        for user in userValueList {
+            let case1 = sut.containsMatch(userValue: user, matchValue: matchValue)
+            let case2 = sut.containsMatch(userValue: user, matchValue: hackleValueWrapedMatchValue)
+            
+            expect(case1).to(equal(expected))
+            expect(case2).to(equal(expected))
+        }
+    }
+    
+    private func verifyStartsWith(sut: ValueMatcher, userValue: Any, matchValue: HackleValue, expected: Bool) {
+        let userValueList = [userValue, v(userValue), HackleValue(value: userValue)]
+        let hackleValueWrapedMatchValue = HackleValue(value: matchValue)
+        
+        for user in userValueList {
+            let case1 = sut.startsWithMatch(userValue: user, matchValue: matchValue)
+            let case2 = sut.startsWithMatch(userValue: user, matchValue: hackleValueWrapedMatchValue)
+            
+            expect(case1).to(equal(expected))
+            expect(case2).to(equal(expected))
+        }
+    }
+    
+    private func verifyEndsWith(sut: ValueMatcher, userValue: Any, matchValue: HackleValue, expected: Bool) {
+        let userValueList = [userValue, v(userValue), HackleValue(value: userValue)]
+        let hackleValueWrapedMatchValue = HackleValue(value: matchValue)
+        
+        for user in userValueList {
+            let case1 = sut.endsWithMatch(userValue: user, matchValue: matchValue)
+            let case2 = sut.endsWithMatch(userValue: user, matchValue: hackleValueWrapedMatchValue)
+            
+            expect(case1).to(equal(expected))
+            expect(case2).to(equal(expected))
+        }
+        
+    }
+    
+    private func verifyGreaterThan(sut: ValueMatcher, userValue: Any, matchValue: HackleValue, expected: Bool) {
+        let userValueList = [userValue, v(userValue), HackleValue(value: userValue)]
+        let hackleValueWrapedMatchValue = HackleValue(value: matchValue)
+        
+        for user in userValueList {
+            let case1 = sut.greaterThanMatch(userValue: user, matchValue: matchValue)
+            let case2 = sut.greaterThanMatch(userValue: user, matchValue: hackleValueWrapedMatchValue)
+            
+            expect(case1).to(equal(expected))
+            expect(case2).to(equal(expected))
+        }
+    }
+    
+    private func verifyGreaterThanOrEqual(sut: ValueMatcher, userValue: Any, matchValue: HackleValue, expected: Bool) {
+        let userValueList = [userValue, v(userValue), HackleValue(value: userValue)]
+        let hackleValueWrapedMatchValue = HackleValue(value: matchValue)
+        
+        for user in userValueList {
+            let case1 = sut.greaterThanOrEqualMatch(userValue: user, matchValue: matchValue)
+            let case2 = sut.greaterThanOrEqualMatch(userValue: user, matchValue: hackleValueWrapedMatchValue)
+            
+            expect(case1).to(equal(expected))
+            expect(case2).to(equal(expected))
+        }
+    }
+    
+    private func verifyLessThan(sut: ValueMatcher, userValue: Any, matchValue: HackleValue, expected: Bool) {
+        let userValueList = [userValue, v(userValue), HackleValue(value: userValue)]
+        let hackleValueWrapedMatchValue = HackleValue(value: matchValue)
+        
+        for user in userValueList {
+            let case1 = sut.lessThanMatch(userValue: user, matchValue: matchValue)
+            let case2 = sut.lessThanMatch(userValue: user, matchValue: hackleValueWrapedMatchValue)
+            
+            expect(case1).to(equal(expected))
+            expect(case2).to(equal(expected))
+        }
+    }
+    
+    private func verifyLessThanOrEqual(sut: ValueMatcher, userValue: Any, matchValue: HackleValue, expected: Bool) {
+        let userValueList = [userValue, v(userValue), HackleValue(value: userValue)]
+        let hackleValueWrapedMatchValue = HackleValue(value: matchValue)
+        
+        for user in userValueList {
+            let case1 = sut.lessThanOrEqualMatch(userValue: user, matchValue: matchValue)
+            let case2 = sut.lessThanOrEqualMatch(userValue: user, matchValue: hackleValueWrapedMatchValue)
+            
+            expect(case1).to(equal(expected))
+            expect(case2).to(equal(expected))
         }
     }
 }

--- a/Tests/HackleTests/Core/Evaluation/Match/ValueMatcherSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Match/ValueMatcherSpecs.swift
@@ -55,10 +55,6 @@ class ValueMatcherSpecs: QuickSpec {
                 self.verifyIn(sut: sut, userValue: "42.42", matchValue: HackleValue(value: 42.42), expected: true)
                 self.verifyIn(sut: sut, userValue: 42.42, matchValue: HackleValue(value: "42.42"), expected: true)
                 self.verifyIn(sut: sut, userValue: 42.42, matchValue: HackleValue(value: 42.42), expected: true)
-                
-                self.verifyIn(sut: sut, userValue: "42.0", matchValue: HackleValue(value: 42.0), expected: true)
-                self.verifyIn(sut: sut, userValue: 42.0, matchValue: HackleValue(value: "42.0"), expected: true)
-                self.verifyIn(sut: sut, userValue: 42.0, matchValue: HackleValue(value: 42.0), expected: true)
             }
 
             it("bool 타입이면 캐스팅 후 match") {
@@ -188,14 +184,10 @@ class ValueMatcherSpecs: QuickSpec {
                 self.verifyIn(sut: sut, userValue: Int.min, matchValue: HackleValue(value: Int.min), expected: true)
                 self.verifyIn(sut: sut, userValue: Int64.max, matchValue: HackleValue(value: Int64.max), expected: true)
                 self.verifyIn(sut: sut, userValue: Int64.min, matchValue: HackleValue(value: Int64.min), expected: true)
-                self.verifyIn(sut: sut, userValue: UInt64.min, matchValue: HackleValue(value: UInt64.min), expected: true)
-                self.verifyIn(sut: sut, userValue: UInt64.max, matchValue: HackleValue(value: UInt64.max), expected: true)
                 self.verifyIn(sut: sut, userValue: Double(Int.max), matchValue: HackleValue(value: Int.max), expected: true)
                 self.verifyIn(sut: sut, userValue: Double(Int.min), matchValue: HackleValue(value: Int.min), expected: true)
                 self.verifyIn(sut: sut, userValue: Double(Int64.max), matchValue: HackleValue(value: Int64.max), expected: true)
                 self.verifyIn(sut: sut, userValue: Double(Int64.min), matchValue: HackleValue(value: Int64.min), expected: true)
-                self.verifyIn(sut: sut, userValue: Double(UInt64.max), matchValue: HackleValue(value: UInt64.max), expected: true)
-                self.verifyIn(sut: sut, userValue: Double(UInt64.min), matchValue: HackleValue(value: UInt64.min), expected: true)
                 self.verifyIn(sut: sut, userValue: Double.zero, matchValue: HackleValue(value: Int.zero), expected: true)
                 self.verifyIn(sut: sut, userValue: Double.zero, matchValue: HackleValue(value: Int64.zero), expected: true)
                 self.verifyIn(sut: sut, userValue: Int.zero, matchValue: HackleValue(value: Double.zero), expected: true)
@@ -203,11 +195,9 @@ class ValueMatcherSpecs: QuickSpec {
                 
                 self.verifyGreaterThanOrEqual(sut: sut, userValue: Double.greatestFiniteMagnitude, matchValue: HackleValue(value: Int.max), expected: true)
                 self.verifyGreaterThanOrEqual(sut: sut, userValue: Double.greatestFiniteMagnitude, matchValue: HackleValue(value: Int64.max), expected: true)
-                self.verifyGreaterThanOrEqual(sut: sut, userValue: Double.greatestFiniteMagnitude, matchValue: HackleValue(value: UInt64.max), expected: true)
                 
-                self.verifyLessThanOrEqual(sut: sut, userValue: Int.min, matchValue: HackleValue(value: -Double.greatestFiniteMagnitude), expected: true)
-                self.verifyLessThanOrEqual(sut: sut, userValue: Int64.min, matchValue: HackleValue(value: -Double.greatestFiniteMagnitude), expected: true)
-                self.verifyLessThanOrEqual(sut: sut, userValue: UInt64.min, matchValue: HackleValue(value: -Double.greatestFiniteMagnitude), expected: true)
+                self.verifyLessThanOrEqual(sut: sut, userValue: -Double.greatestFiniteMagnitude, matchValue: HackleValue(value: Int.min), expected: true)
+                self.verifyLessThanOrEqual(sut: sut, userValue: -Double.greatestFiniteMagnitude, matchValue: HackleValue(value: Int64.min), expected: true)
                 
             }
             
@@ -345,19 +335,19 @@ class ValueMatcherSpecs: QuickSpec {
             it("matchValue가 Version 타입이 아니면 항상 false") {
                 self.verifyIn(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: Int.max), expected: false)
                 self.verifyIn(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: 1.0), expected: false)
-                self.verifyIn(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: "1.0"), expected: false)
+                self.verifyIn(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: "1.0.asd"), expected: false)
                 self.verifyIn(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: "string"), expected: false)
                 self.verifyIn(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: true), expected: false)
                 
                 self.verifyGreaterThan(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: Int.max), expected: false)
                 self.verifyGreaterThan(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: 1.0), expected: false)
-                self.verifyGreaterThan(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: "1.0"), expected: false)
+                self.verifyGreaterThan(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: "1.0.asd"), expected: false)
                 self.verifyGreaterThan(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: "string"), expected: false)
                 self.verifyGreaterThan(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: true), expected: false)
                 
                 self.verifyGreaterThanOrEqual(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: Int.max), expected: false)
                 self.verifyGreaterThanOrEqual(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: 1.0), expected: false)
-                self.verifyGreaterThanOrEqual(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: "1.0"), expected: false)
+                self.verifyGreaterThanOrEqual(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: "1.0.asd"), expected: false)
                 self.verifyGreaterThanOrEqual(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: "string"), expected: false)
                 self.verifyGreaterThanOrEqual(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: true), expected: false)
                 
@@ -369,7 +359,7 @@ class ValueMatcherSpecs: QuickSpec {
                 
                 self.verifyLessThanOrEqual(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: Int.max), expected: false)
                 self.verifyLessThanOrEqual(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: 1.0), expected: false)
-                self.verifyLessThanOrEqual(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: "1.0"), expected: false)
+                self.verifyLessThanOrEqual(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: "1.0.asd"), expected: false)
                 self.verifyLessThanOrEqual(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: "string"), expected: false)
                 self.verifyLessThanOrEqual(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: true), expected: false)
             }
@@ -377,7 +367,7 @@ class ValueMatcherSpecs: QuickSpec {
             it("userValue가 Version 타입이 아니면 false") {
                 self.verifyIn(sut: sut, userValue: Int.max, matchValue: HackleValue(value: "1.0.0"), expected: false)
                 self.verifyIn(sut: sut, userValue: 1.0, matchValue: HackleValue(value: "1.0.0"), expected: false)
-                self.verifyIn(sut: sut, userValue: "1.0", matchValue: HackleValue(value: "1.0.0"), expected: false)
+                self.verifyIn(sut: sut, userValue: "1.0.x", matchValue: HackleValue(value: "1.0.0"), expected: false)
                 self.verifyIn(sut: sut, userValue: "string", matchValue: HackleValue(value: "1.0.0"), expected: false)
                 self.verifyIn(sut: sut, userValue: true, matchValue: HackleValue(value: "1.0.0"), expected: false)
                 
@@ -389,7 +379,7 @@ class ValueMatcherSpecs: QuickSpec {
                 
                 self.verifyGreaterThanOrEqual(sut: sut, userValue: Int.max, matchValue: HackleValue(value: "1.0.0"), expected: false)
                 self.verifyGreaterThanOrEqual(sut: sut, userValue: 1.0, matchValue: HackleValue(value: "1.0.0"), expected: false)
-                self.verifyGreaterThanOrEqual(sut: sut, userValue: "1.0", matchValue: HackleValue(value: "1.0.0"), expected: false)
+                self.verifyGreaterThanOrEqual(sut: sut, userValue: "1.0.x", matchValue: HackleValue(value: "1.0.0"), expected: false)
                 self.verifyGreaterThanOrEqual(sut: sut, userValue: "string", matchValue: HackleValue(value: "1.0.0"), expected: false)
                 self.verifyGreaterThanOrEqual(sut: sut, userValue: true, matchValue: HackleValue(value: "1.0.0"), expected: false)
                 
@@ -401,7 +391,7 @@ class ValueMatcherSpecs: QuickSpec {
                 
                 self.verifyLessThanOrEqual(sut: sut, userValue: Int.max, matchValue: HackleValue(value: "1.0.0"), expected: false)
                 self.verifyLessThanOrEqual(sut: sut, userValue: 1.0, matchValue: HackleValue(value: "1.0.0"), expected: false)
-                self.verifyLessThanOrEqual(sut: sut, userValue: "1.0", matchValue: HackleValue(value: "1.0.0"), expected: false)
+                self.verifyLessThanOrEqual(sut: sut, userValue: "1.0.x", matchValue: HackleValue(value: "1.0.0"), expected: false)
                 self.verifyLessThanOrEqual(sut: sut, userValue: "string", matchValue: HackleValue(value: "1.0.0"), expected: false)
                 self.verifyLessThanOrEqual(sut: sut, userValue: true, matchValue: HackleValue(value: "1.0.0"), expected: false)
             }

--- a/Tests/HackleTests/Core/Evaluation/Match/ValueMatcherSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Match/ValueMatcherSpecs.swift
@@ -180,25 +180,18 @@ class ValueMatcherSpecs: QuickSpec {
             }
             
             it("숫자형 범위 체크") {
-                self.verifyIn(sut: sut, userValue: Int.max, matchValue: HackleValue(value: Int.max), expected: true)
-                self.verifyIn(sut: sut, userValue: Int.min, matchValue: HackleValue(value: Int.min), expected: true)
-                self.verifyIn(sut: sut, userValue: Int64.max, matchValue: HackleValue(value: Int64.max), expected: true)
-                self.verifyIn(sut: sut, userValue: Int64.min, matchValue: HackleValue(value: Int64.min), expected: true)
-                self.verifyIn(sut: sut, userValue: Double(Int.max), matchValue: HackleValue(value: Int.max), expected: true)
-                self.verifyIn(sut: sut, userValue: Double(Int.min), matchValue: HackleValue(value: Int.min), expected: true)
-                self.verifyIn(sut: sut, userValue: Double(Int64.max), matchValue: HackleValue(value: Int64.max), expected: true)
-                self.verifyIn(sut: sut, userValue: Double(Int64.min), matchValue: HackleValue(value: Int64.min), expected: true)
-                self.verifyIn(sut: sut, userValue: Double.zero, matchValue: HackleValue(value: Int.zero), expected: true)
+                self.verifyIn(sut: sut, userValue: Int32.max, matchValue: HackleValue(value: Int32.max), expected: true)
+                self.verifyIn(sut: sut, userValue: Int32.min, matchValue: HackleValue(value: Int32.min), expected: true)
+                self.verifyIn(sut: sut, userValue: 2^53, matchValue: HackleValue(value: 2^53), expected: true)
+                self.verifyIn(sut: sut, userValue: -2^53, matchValue: HackleValue(value: -2^53), expected: true)
+                self.verifyIn(sut: sut, userValue: Double(Int32.max), matchValue: HackleValue(value: Int32.max), expected: true)
+                self.verifyIn(sut: sut, userValue: Double(Int32.min), matchValue: HackleValue(value: Int32.min), expected: true)
+                self.verifyIn(sut: sut, userValue: Double(2^53), matchValue: HackleValue(value: 2^53), expected: true)
+                self.verifyIn(sut: sut, userValue: Double(-2^53), matchValue: HackleValue(value: -2^53), expected: true)
+                self.verifyIn(sut: sut, userValue: Double.zero, matchValue: HackleValue(value: Int32.zero), expected: true)
                 self.verifyIn(sut: sut, userValue: Double.zero, matchValue: HackleValue(value: Int64.zero), expected: true)
-                self.verifyIn(sut: sut, userValue: Int.zero, matchValue: HackleValue(value: Double.zero), expected: true)
+                self.verifyIn(sut: sut, userValue: Int32.zero, matchValue: HackleValue(value: Double.zero), expected: true)
                 self.verifyIn(sut: sut, userValue: Int64.zero, matchValue: HackleValue(value: Double.zero), expected: true)
-                
-                self.verifyGreaterThanOrEqual(sut: sut, userValue: Double.greatestFiniteMagnitude, matchValue: HackleValue(value: Int.max), expected: true)
-                self.verifyGreaterThanOrEqual(sut: sut, userValue: Double.greatestFiniteMagnitude, matchValue: HackleValue(value: Int64.max), expected: true)
-                
-                self.verifyLessThanOrEqual(sut: sut, userValue: -Double.greatestFiniteMagnitude, matchValue: HackleValue(value: Int.min), expected: true)
-                self.verifyLessThanOrEqual(sut: sut, userValue: -Double.greatestFiniteMagnitude, matchValue: HackleValue(value: Int64.min), expected: true)
-                
             }
             
             it("matchValue가 숫자가 아니면 아니면 항상 false") {


### PR DESCRIPTION
## 개요
- Matcher의 구조를 수정했습니다.
- EXISTS Operator를 추가했습니다.

## 작업내용
### Matcher의 구조를 수정했습니다.
#### 기존
* 순서: ValueOperatorMatcher -> ValueMatcher -> OperatorMatcher
* ValueOperatorMatcher에서 userValue가 null이면 return false
* ValueMatcher 안에서 OperatorMatcher.{type}matches 메서드 호출
#### 변경
* 순서: ValueOperatorMatcher -> OperatorMatcher -> ValueMatcher
* ValueOperatorMatcher 에서 userValue가 null이어도 OperatorMatcher까지 진입 후 연산자에 따라 처리
* OperatorMatcher에서 userValue가 null check를 수행. 그 후 ValueMatcher.{operator}match 메서드 호출

### EXISTS Operator 추가
* 존재하는/하지 않는 구분은 matchType 으로 수행합니다
* EXISTS Operator는 OperatorMatcher에서 null 체크만 합니다.