### PR TITLE
add phone number support

### DIFF
--- a/Hackle.xcodeproj/project.pbxproj
+++ b/Hackle.xcodeproj/project.pbxproj
@@ -72,6 +72,8 @@
 		B24250262D9A2B7800CF27FC /* PIIEventManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B24250252D9A2B7800CF27FC /* PIIEventManager.swift */; };
 		B24250282D9A33A100CF27FC /* MockPIIEventManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B24250272D9A339700CF27FC /* MockPIIEventManager.swift */; };
 		B242502B2D9A34F500CF27FC /* PhoneNumber.swift in Sources */ = {isa = PBXBuildFile; fileRef = B242502A2D9A34F100CF27FC /* PhoneNumber.swift */; };
+		B24250312D9A59AE00CF27FC /* DefaultPIIEventManagerSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = B24250302D9A59A500CF27FC /* DefaultPIIEventManagerSpecs.swift */; };
+		B24250342D9A59CC00CF27FC /* DefaultPhoneNumberSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = B24250332D9A59C400CF27FC /* DefaultPhoneNumberSpecs.swift */; };
 		B2623C422CBD19BF0051D2D6 /* DatabaseConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2623C412CBD19BF0051D2D6 /* DatabaseConstants.swift */; };
 		B274AE0E2D4397D700C52FF5 /* TargetEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = B274AE0D2D4397D700C52FF5 /* TargetEvent.swift */; };
 		B290E6532D51A09B00F68D35 /* TargetEventConditionMatchSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = B290E6522D51A09000F68D35 /* TargetEventConditionMatchSpecs.swift */; };
@@ -614,6 +616,8 @@
 		B24250252D9A2B7800CF27FC /* PIIEventManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PIIEventManager.swift; sourceTree = "<group>"; };
 		B24250272D9A339700CF27FC /* MockPIIEventManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPIIEventManager.swift; sourceTree = "<group>"; };
 		B242502A2D9A34F100CF27FC /* PhoneNumber.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhoneNumber.swift; sourceTree = "<group>"; };
+		B24250302D9A59A500CF27FC /* DefaultPIIEventManagerSpecs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultPIIEventManagerSpecs.swift; sourceTree = "<group>"; };
+		B24250332D9A59C400CF27FC /* DefaultPhoneNumberSpecs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultPhoneNumberSpecs.swift; sourceTree = "<group>"; };
 		B2623C412CBD19BF0051D2D6 /* DatabaseConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseConstants.swift; sourceTree = "<group>"; };
 		B274AE0D2D4397D700C52FF5 /* TargetEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TargetEvent.swift; sourceTree = "<group>"; };
 		B290E6522D51A09000F68D35 /* TargetEventConditionMatchSpecs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TargetEventConditionMatchSpecs.swift; sourceTree = "<group>"; };
@@ -1261,6 +1265,23 @@
 			path = PhoneNumber;
 			sourceTree = "<group>";
 		};
+		B242502F2D9A597B00CF27FC /* PII */ = {
+			isa = PBXGroup;
+			children = (
+				B24250322D9A59B600CF27FC /* PhoneNumber */,
+				B24250302D9A59A500CF27FC /* DefaultPIIEventManagerSpecs.swift */,
+			);
+			path = PII;
+			sourceTree = "<group>";
+		};
+		B24250322D9A59B600CF27FC /* PhoneNumber */ = {
+			isa = PBXGroup;
+			children = (
+				B24250332D9A59C400CF27FC /* DefaultPhoneNumberSpecs.swift */,
+			);
+			path = PhoneNumber;
+			sourceTree = "<group>";
+		};
 		D160A65AC13330399B99C7E3 /* xcschemes */ = {
 			isa = PBXGroup;
 			children = (
@@ -1870,6 +1891,7 @@
 				EE29D9F529CD82C100B1FEAA /* Model */,
 				EED6A1252A0E266500A8875D /* Property */,
 				EEAC3F3A2B9D6A7800DC498E /* Push */,
+				B242502F2D9A597B00CF27FC /* PII */,
 				EE543CBE2C08BEF500F64BFA /* Screen */,
 				EE29DA3229CD82C200B1FEAA /* Session */,
 				EEDC58742ACBD818001E73DB /* Sync */,
@@ -3131,6 +3153,7 @@
 				EE0F340E2A66B5AD009DE640 /* MockInAppMessageEventTracker.swift in Sources */,
 				EE29DA7F29CD82C200B1FEAA /* MockConditionMatcher.swift in Sources */,
 				EE29DA3E29CD82C200B1FEAA /* MockHasher.swift in Sources */,
+				B24250312D9A59AE00CF27FC /* DefaultPIIEventManagerSpecs.swift in Sources */,
 				EE0F34102A66B8C2009DE640 /* MockInAppMessageEventProcessor.swift in Sources */,
 				EE789E2F29F01C700088D8A6 /* ResourcesWorkspaceFetcher.swift in Sources */,
 				EEF895A42A4A67CF00722CF6 /* InAppMessageRequestSpecs.swift in Sources */,
@@ -3156,6 +3179,7 @@
 				EE0F34122A66C3CF009DE640 /* MockInAppMessageActionHandler.swift in Sources */,
 				7E9065C32B5E902700FE6E52 /* MockHttpWorkspaceFetcher.swift in Sources */,
 				EE29DAA429CD82C200B1FEAA /* PropertiesBuilderSpecs.swift in Sources */,
+				B24250342D9A59CC00CF27FC /* DefaultPhoneNumberSpecs.swift in Sources */,
 				EEF895A02A49BCAF00722CF6 /* HackleCoreStub.swift in Sources */,
 				EE29DA5329CD82C200B1FEAA /* FlushCounterSpecs.swift in Sources */,
 				EEDC58652ACB241D001E73DB /* HackleUserSpecs.swift in Sources */,

--- a/Hackle.xcodeproj/project.pbxproj
+++ b/Hackle.xcodeproj/project.pbxproj
@@ -69,6 +69,9 @@
 		B24234AF2D89122E00878096 /* DatabaseSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = B24234AE2D89122500878096 /* DatabaseSpecs.swift */; };
 		B24234B32D89616600878096 /* MockSQLiteEventRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = B24234B22D89615B00878096 /* MockSQLiteEventRepository.swift */; };
 		B24234B52D8A646E00878096 /* DatabaseDDL.swift in Sources */ = {isa = PBXBuildFile; fileRef = B24234B42D8A646900878096 /* DatabaseDDL.swift */; };
+		B24250262D9A2B7800CF27FC /* PIIEventManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B24250252D9A2B7800CF27FC /* PIIEventManager.swift */; };
+		B24250282D9A33A100CF27FC /* MockPIIEventManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B24250272D9A339700CF27FC /* MockPIIEventManager.swift */; };
+		B242502B2D9A34F500CF27FC /* PhoneNumber.swift in Sources */ = {isa = PBXBuildFile; fileRef = B242502A2D9A34F100CF27FC /* PhoneNumber.swift */; };
 		B2623C422CBD19BF0051D2D6 /* DatabaseConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2623C412CBD19BF0051D2D6 /* DatabaseConstants.swift */; };
 		B274AE0E2D4397D700C52FF5 /* TargetEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = B274AE0D2D4397D700C52FF5 /* TargetEvent.swift */; };
 		B290E6532D51A09B00F68D35 /* TargetEventConditionMatchSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = B290E6522D51A09000F68D35 /* TargetEventConditionMatchSpecs.swift */; };
@@ -608,6 +611,9 @@
 		B24234AE2D89122500878096 /* DatabaseSpecs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseSpecs.swift; sourceTree = "<group>"; };
 		B24234B22D89615B00878096 /* MockSQLiteEventRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSQLiteEventRepository.swift; sourceTree = "<group>"; };
 		B24234B42D8A646900878096 /* DatabaseDDL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseDDL.swift; sourceTree = "<group>"; };
+		B24250252D9A2B7800CF27FC /* PIIEventManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PIIEventManager.swift; sourceTree = "<group>"; };
+		B24250272D9A339700CF27FC /* MockPIIEventManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPIIEventManager.swift; sourceTree = "<group>"; };
+		B242502A2D9A34F100CF27FC /* PhoneNumber.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhoneNumber.swift; sourceTree = "<group>"; };
 		B2623C412CBD19BF0051D2D6 /* DatabaseConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseConstants.swift; sourceTree = "<group>"; };
 		B274AE0D2D4397D700C52FF5 /* TargetEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TargetEvent.swift; sourceTree = "<group>"; };
 		B290E6522D51A09000F68D35 /* TargetEventConditionMatchSpecs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TargetEventConditionMatchSpecs.swift; sourceTree = "<group>"; };
@@ -1238,6 +1244,23 @@
 			path = Storage;
 			sourceTree = "<group>";
 		};
+		B24250242D9A2B1B00CF27FC /* PII */ = {
+			isa = PBXGroup;
+			children = (
+				B24250292D9A349B00CF27FC /* PhoneNumber */,
+				B24250252D9A2B7800CF27FC /* PIIEventManager.swift */,
+			);
+			path = PII;
+			sourceTree = "<group>";
+		};
+		B24250292D9A349B00CF27FC /* PhoneNumber */ = {
+			isa = PBXGroup;
+			children = (
+				B242502A2D9A34F100CF27FC /* PhoneNumber.swift */,
+			);
+			path = PhoneNumber;
+			sourceTree = "<group>";
+		};
 		D160A65AC13330399B99C7E3 /* xcschemes */ = {
 			isa = PBXGroup;
 			children = (
@@ -1384,6 +1407,7 @@
 				EE29D92A29CD825300B1FEAA /* Monitoring */,
 				EED6A1202A0DFC5C00A8875D /* Property */,
 				EEAC3F2A2B9D54C900DC498E /* Push */,
+				B24250242D9A2B1B00CF27FC /* PII */,
 				EE29D8DB29CD825300B1FEAA /* RemoteConfig */,
 				EEA7FCA92C04AAED0004F858 /* Screen */,
 				EE29D93229CD825300B1FEAA /* Session */,
@@ -1793,6 +1817,7 @@
 				7E64779E2AD50E5200971F20 /* MockHackleApp.swift */,
 				7E0F05462AD7BA6800631B42 /* MockRemoteConfig.swift */,
 				7E81DA452B452625003258DA /* MockNotificationManager.swift */,
+				B24250272D9A339700CF27FC /* MockPIIEventManager.swift */,
 				7E9065BE2B5E593F00FE6E52 /* MockWorkspaceConfigRepository.swift */,
 				7E9065C22B5E902700FE6E52 /* MockHttpWorkspaceFetcher.swift */,
 				7E9F7E882B6CCC3700A6B0B8 /* MockFileStorage.swift */,
@@ -2933,6 +2958,7 @@
 				EE29D95129CD825400B1FEAA /* PushMetricRegistry.swift in Sources */,
 				EE29D94929CD825400B1FEAA /* FlushMetricRegistry.swift in Sources */,
 				EE86377729ED312F000268DC /* ExperimentConditionMatcher.swift in Sources */,
+				B24250262D9A2B7800CF27FC /* PIIEventManager.swift in Sources */,
 				EEB7CBEE2A0BB6AA000F4B4D /* AppStateManager.swift in Sources */,
 				EE29D95029CD825400B1FEAA /* DelegatingMetricRegistry.swift in Sources */,
 				EE29D99629CD825400B1FEAA /* ExperimentTargetDeterminer.swift in Sources */,
@@ -3038,6 +3064,7 @@
 				7E9DDE002B319EFB006ACFDA /* NotificationManager.swift in Sources */,
 				EE80DF8A2A2831E700FB12CC /* InAppMessageRequest.swift in Sources */,
 				EE29D94029CD825400B1FEAA /* Hackle.swift in Sources */,
+				B242502B2D9A34F500CF27FC /* PhoneNumber.swift in Sources */,
 				EEFA31E02BC18A5900E133F8 /* UserEventDedupDeterminer.swift in Sources */,
 				B2F9D5BF2D4C912700F0C0E0 /* TargetEventConditionMatcher.swift in Sources */,
 				EE29D9A429CD825500B1FEAA /* MonitoringMetricRegistry.swift in Sources */,
@@ -3166,6 +3193,7 @@
 				EE543CDD2C09AA8600F64BFA /* MockViewManager.swift in Sources */,
 				EE29DA6B29CD82C200B1FEAA /* ClockSpecs.swift in Sources */,
 				EE29DA9229CD82C200B1FEAA /* DefaultBucketerSpec.swift in Sources */,
+				B24250282D9A33A100CF27FC /* MockPIIEventManager.swift in Sources */,
 				7E0F05472AD7BA6800631B42 /* MockRemoteConfig.swift in Sources */,
 				7E9F7E892B6CCC3700A6B0B8 /* MockFileStorage.swift in Sources */,
 				EEF895912A4971DE00722CF6 /* InAppMessageMatcherStub.swift in Sources */,

--- a/Sources/Hackle/Bridge/HackleBridge.swift
+++ b/Sources/Hackle/Bridge/HackleBridge.swift
@@ -58,6 +58,12 @@ extension HackleBridge {
         case .resetUser:
             app.resetUser()
             return .success()
+        case .setPhoneNumber:
+            try setPhoneNumber(parameters: parameters)
+            return .success()
+        case .unsetPhoneNumber:
+            app.unsetPhoneNumber()
+            return .success()
         case .variation:
             let data = try variation(parameters: parameters)
             return .success(data)
@@ -122,6 +128,13 @@ fileprivate extension HackleBridge {
         }
         let operations = PropertyOperations.from(dto: data)
         app.updateUserProperties(operations: operations)
+    }
+    
+    private func setPhoneNumber(parameters: [String: Any]) throws {
+        guard let phoneNumber = parameters["phoneNumber"] as? String else {
+            throw HackleError.error("Valid 'phoneNumber' parameter must be provided.")
+        }
+        app.setPhoneNumber(phoneNumber: phoneNumber)
     }
 
     private func variation(parameters: [String: Any]) throws -> String? {

--- a/Sources/Hackle/Bridge/Model/BridgeInvocation.swift
+++ b/Sources/Hackle/Bridge/Model/BridgeInvocation.swift
@@ -17,6 +17,8 @@ class BridgeInvocation {
         case setUserProperty = "setUserProperty"
         case updateUserProperties = "updateUserProperties"
         case resetUser = "resetUser"
+        case setPhoneNumber = "setPhoneNumber"
+        case unsetPhoneNumber = "unsetPhoneNumber"
         case variation = "variation"
         case variationDetail = "variationDetail"
         case isFeatureOn = "isFeatureOn"

--- a/Sources/Hackle/Core/Model/Version.swift
+++ b/Sources/Hackle/Core/Model/Version.swift
@@ -229,7 +229,7 @@ func compareValuesBy<T, C: Comparable>(_ a: T, _  b: T, _  selectors: (T) -> C..
 
 extension NSRegularExpression {
 
-    func match(_ string: String, options: NSRegularExpression.Options = []) -> [String?]? {
+    fileprivate func match(_ string: String, options: NSRegularExpression.Options = []) -> [String?]? {
         let range = NSRange(string.startIndex..., in: string)
         guard let match = firstMatch(in: string, options: [], range: range) else {
             return nil

--- a/Sources/Hackle/Core/PII/PIIEventManager.swift
+++ b/Sources/Hackle/Core/PII/PIIEventManager.swift
@@ -23,9 +23,9 @@ class DefaultPIIEventManager: PIIEventManager {
     }
     
     func setPhoneNumber(phoneNumber: String, user: User, timestamp: Date) {
-        let phoneNumber = PhoneNumber.filtered(phoneNumber: phoneNumber)
+        let filteredPhoneNumber = PhoneNumber.filtered(phoneNumber: phoneNumber)
         let properties = PropertyOperationsBuilder()
-            .set(PIIProperty.phoneNumber.rawValue, phoneNumber)
+            .set(PIIProperty.phoneNumber.rawValue, filteredPhoneNumber)
             .build()
         let event = properties.toSecuredEvent()
         track(event: event, user: user, timestamp: timestamp)

--- a/Sources/Hackle/Core/PII/PIIEventManager.swift
+++ b/Sources/Hackle/Core/PII/PIIEventManager.swift
@@ -8,18 +8,21 @@
 import Foundation
 
 protocol PIIEventManager {
-    func setPhoneNumber(phoneNumber: String, hackleUser: HackleUser, timestamp: Date)
-    func unsetPhoneNumber(hackleUser: HackleUser, timestamp: Date)
+    func setPhoneNumber(phoneNumber: String, user: User, timestamp: Date)
+    func unsetPhoneNumber(user: User, timestamp: Date)
 }
 
 class DefaultPIIEventManager: PIIEventManager {
+    
+    private let userManager: UserManager
     private let core: HackleCore
     
-    init(core: HackleCore) {
+    init(userManager: UserManager, core: HackleCore) {
+        self.userManager = userManager
         self.core = core
     }
     
-    func setPhoneNumber(phoneNumber: String, hackleUser: HackleUser, timestamp: Date) {
+    func setPhoneNumber(phoneNumber: String, user: User, timestamp: Date) {
         guard let phoneNumber = PhoneNumber.tryParse(phoneNumber: phoneNumber) else {
             return
         }
@@ -28,18 +31,19 @@ class DefaultPIIEventManager: PIIEventManager {
             .set(PIIProperty.phoneNumber.rawValue, phoneNumber)
             .build()
         let event = properties.toSecuredEvent()
-        track(event: event, hackleUser: hackleUser, timestamp: timestamp)
+        track(event: event, user: user, timestamp: timestamp)
     }
     
-    func unsetPhoneNumber(hackleUser: HackleUser, timestamp: Date) {
+    func unsetPhoneNumber(user: User, timestamp: Date) {
         let properties = PropertyOperationsBuilder()
             .unset(PIIProperty.phoneNumber.rawValue)
             .build()
         let event = properties.toSecuredEvent()
-        track(event: event, hackleUser: hackleUser, timestamp: timestamp)
+        track(event: event, user: user, timestamp: timestamp)
     }
     
-    private func track(event: Event, hackleUser: HackleUser, timestamp: Date) {
+    private func track(event: Event, user: User, timestamp: Date) {
+        let hackleUser = userManager.toHackleUser(user: user)
         core.track(event: event, user: hackleUser, timestamp: timestamp)
     }
 

--- a/Sources/Hackle/Core/PII/PIIEventManager.swift
+++ b/Sources/Hackle/Core/PII/PIIEventManager.swift
@@ -24,6 +24,7 @@ class DefaultPIIEventManager: PIIEventManager {
     
     func setPhoneNumber(phoneNumber: String, user: User, timestamp: Date) {
         guard let phoneNumber = PhoneNumber.tryParse(phoneNumber: phoneNumber) else {
+            Log.error("Invalid phone number: phoneNumber must e.164 format")
             return
         }
         

--- a/Sources/Hackle/Core/PII/PIIEventManager.swift
+++ b/Sources/Hackle/Core/PII/PIIEventManager.swift
@@ -1,0 +1,60 @@
+//
+//  PIIEventTracker.swift
+//  Hackle
+//
+//  Created by sungwoo.yeo on 3/31/25.
+//
+
+import Foundation
+
+protocol PIIEventManager {
+    func setPhoneNumber(phoneNumber: String, hackleUser: HackleUser, timestamp: Date)
+    func unsetPhoneNumber(hackleUser: HackleUser, timestamp: Date)
+}
+
+class DefaultPIIEventManager: PIIEventManager {
+    private let core: HackleCore
+    
+    init(core: HackleCore) {
+        self.core = core
+    }
+    
+    func setPhoneNumber(phoneNumber: String, hackleUser: HackleUser, timestamp: Date) {
+        guard let phoneNumber = PhoneNumber.tryParse(phoneNumber: phoneNumber) else {
+            return
+        }
+        
+        let properties = PropertyOperationsBuilder()
+            .set(PIIProperty.phoneNumber.rawValue, phoneNumber)
+            .build()
+        let event = properties.toSecuredEvent()
+        track(event: event, hackleUser: hackleUser, timestamp: timestamp)
+    }
+    
+    func unsetPhoneNumber(hackleUser: HackleUser, timestamp: Date) {
+        let properties = PropertyOperationsBuilder()
+            .unset(PIIProperty.phoneNumber.rawValue)
+            .build()
+        let event = properties.toSecuredEvent()
+        track(event: event, hackleUser: hackleUser, timestamp: timestamp)
+    }
+    
+    private func track(event: Event, hackleUser: HackleUser, timestamp: Date) {
+        core.track(event: event, user: hackleUser, timestamp: timestamp)
+    }
+
+}
+
+enum PIIProperty: String {
+    case phoneNumber = "$phone_number"
+}
+
+extension PropertyOperations {
+    fileprivate func toSecuredEvent() -> Event {
+        let builder = Event.builder("$secured_properties")
+        for (operation, properties) in asDictionary() {
+            builder.property(operation.rawValue, properties)
+        }
+        return builder.build()
+    }
+}

--- a/Sources/Hackle/Core/PII/PIIEventManager.swift
+++ b/Sources/Hackle/Core/PII/PIIEventManager.swift
@@ -23,11 +23,7 @@ class DefaultPIIEventManager: PIIEventManager {
     }
     
     func setPhoneNumber(phoneNumber: String, user: User, timestamp: Date) {
-        guard let phoneNumber = PhoneNumber.tryParse(phoneNumber: phoneNumber) else {
-            Log.error("Invalid phone number: phoneNumber must e.164 format")
-            return
-        }
-        
+        let phoneNumber = PhoneNumber.filtered(phoneNumber: phoneNumber)
         let properties = PropertyOperationsBuilder()
             .set(PIIProperty.phoneNumber.rawValue, phoneNumber)
             .build()

--- a/Sources/Hackle/Core/PII/PIIEventManager.swift
+++ b/Sources/Hackle/Core/PII/PIIEventManager.swift
@@ -16,12 +16,12 @@ protocol PIIEventManager {
     ///   - phoneNumber: 전화번호
     ///   - user: 유저
     ///   - timestamp: 설정 시간
-    func setPhoneNumber(phoneNumber: String, user: User, timestamp: Date)
+    func setPhoneNumber(phoneNumber: PhoneNumber, timestamp: Date)
     /// 전화번호를 삭제
     /// - Parameters:
     ///   - user: 유저
     ///   - timestamp: 삭제 시간
-    func unsetPhoneNumber(user: User, timestamp: Date)
+    func unsetPhoneNumber(timestamp: Date)
 }
 
 class DefaultPIIEventManager: PIIEventManager {
@@ -34,21 +34,20 @@ class DefaultPIIEventManager: PIIEventManager {
         self.core = core
     }
     
-    func setPhoneNumber(phoneNumber: String, user: User, timestamp: Date) {
-        let filteredPhoneNumber = PhoneNumber.filtered(phoneNumber: phoneNumber)
+    func setPhoneNumber(phoneNumber: PhoneNumber, timestamp: Date) {
         let properties = PropertyOperationsBuilder()
-            .set(PIIProperty.phoneNumber.rawValue, filteredPhoneNumber)
+            .set(PIIProperty.phoneNumber.rawValue, phoneNumber.value)
             .build()
         let event = properties.toSecuredEvent()
-        track(event: event, user: user, timestamp: timestamp)
+        track(event: event, timestamp: timestamp)
     }
     
-    func unsetPhoneNumber(user: User, timestamp: Date) {
+    func unsetPhoneNumber(timestamp: Date) {
         let properties = PropertyOperationsBuilder()
             .unset(PIIProperty.phoneNumber.rawValue)
             .build()
         let event = properties.toSecuredEvent()
-        track(event: event, user: user, timestamp: timestamp)
+        track(event: event, timestamp: timestamp)
     }
     
     /// secured properties event를 추적
@@ -56,8 +55,8 @@ class DefaultPIIEventManager: PIIEventManager {
     ///   - event: 이벤트
     ///   - user: 유저
     ///   - timestamp: 이벤트 발생 시각
-    private func track(event: Event, user: User, timestamp: Date) {
-        let hackleUser = userManager.toHackleUser(user: user)
+    private func track(event: Event, timestamp: Date) {
+        let hackleUser = userManager.resolve(user: nil)
         core.track(event: event, user: hackleUser, timestamp: timestamp)
     }
 

--- a/Sources/Hackle/Core/PII/PIIEventManager.swift
+++ b/Sources/Hackle/Core/PII/PIIEventManager.swift
@@ -7,8 +7,20 @@
 
 import Foundation
 
+/// Personally Identifiable Information Event Manager
 protocol PIIEventManager {
+    /// 전화번호를 설정
+    ///
+    /// set 할 때마다 기존 전화번호는 덮어쓰기 됩니다.
+    /// - Parameters:
+    ///   - phoneNumber: 전화번호
+    ///   - user: 유저
+    ///   - timestamp: 설정 시간
     func setPhoneNumber(phoneNumber: String, user: User, timestamp: Date)
+    /// 전화번호를 삭제
+    /// - Parameters:
+    ///   - user: 유저
+    ///   - timestamp: 삭제 시간
     func unsetPhoneNumber(user: User, timestamp: Date)
 }
 
@@ -39,6 +51,11 @@ class DefaultPIIEventManager: PIIEventManager {
         track(event: event, user: user, timestamp: timestamp)
     }
     
+    /// secured properties event를 추적
+    /// - Parameters:
+    ///   - event: 이벤트
+    ///   - user: 유저
+    ///   - timestamp: 이벤트 발생 시각
     private func track(event: Event, user: User, timestamp: Date) {
         let hackleUser = userManager.toHackleUser(user: user)
         core.track(event: event, user: hackleUser, timestamp: timestamp)
@@ -46,11 +63,14 @@ class DefaultPIIEventManager: PIIEventManager {
 
 }
 
+/// Personally Identifiable Information Property
 enum PIIProperty: String {
     case phoneNumber = "$phone_number"
 }
 
 extension PropertyOperations {
+    /// property operations를 secured event로 변환
+    /// - Returns: Hackle Event
     fileprivate func toSecuredEvent() -> Event {
         let builder = Event.builder("$secured_properties")
         for (operation, properties) in asDictionary() {

--- a/Sources/Hackle/Core/PII/PhoneNumber/PhoneNumber.swift
+++ b/Sources/Hackle/Core/PII/PhoneNumber/PhoneNumber.swift
@@ -1,0 +1,26 @@
+//
+//  PhoneNumber.swift
+//  Hackle
+//
+//  Created by sungwoo.yeo on 3/31/25.
+//
+
+import Foundation
+
+class PhoneNumber {
+    private static let pattern = "^\\+[0-9]{1,15}$" // +로 시작하고 1~15자리 숫자
+    private static let regex = try! NSRegularExpression(pattern: pattern, options: [])
+    
+    static func tryParse(phoneNumber: String) -> String? {
+        if phoneNumber.isEmpty {
+            return nil
+        }
+        
+        let cleanedPhoneNumber = phoneNumber.replacingOccurrences(of: "[ .()-]", with: "", options: .regularExpression) // + 제외 특수문자 삭제
+        guard regex.firstMatch(in: cleanedPhoneNumber, range: NSRange(location: 0, length: cleanedPhoneNumber.count)) != nil else {
+            return nil
+        }
+        
+        return cleanedPhoneNumber
+    }
+}

--- a/Sources/Hackle/Core/PII/PhoneNumber/PhoneNumber.swift
+++ b/Sources/Hackle/Core/PII/PhoneNumber/PhoneNumber.swift
@@ -11,7 +11,7 @@ struct PhoneNumber {
     let value: String
     
     static func create(phoneNumber: String) -> PhoneNumber {
-        let filterdValue = phoneNumber.filter { $0.isNumber || $0 == "+" }
-        return PhoneNumber(value: filterdValue)
+        //let filterdValue = phoneNumber.filter { $0.isNumber || $0 == "+" }
+        return PhoneNumber(value: phoneNumber)
     }
 }

--- a/Sources/Hackle/Core/PII/PhoneNumber/PhoneNumber.swift
+++ b/Sources/Hackle/Core/PII/PhoneNumber/PhoneNumber.swift
@@ -11,7 +11,6 @@ struct PhoneNumber {
     let value: String
     
     static func create(phoneNumber: String) -> PhoneNumber {
-        //let filterdValue = phoneNumber.filter { $0.isNumber || $0 == "+" }
         return PhoneNumber(value: phoneNumber)
     }
 }

--- a/Sources/Hackle/Core/PII/PhoneNumber/PhoneNumber.swift
+++ b/Sources/Hackle/Core/PII/PhoneNumber/PhoneNumber.swift
@@ -8,19 +8,8 @@
 import Foundation
 
 class PhoneNumber {
-    private static let pattern = "^\\+[0-9]{1,15}$" // +로 시작하고 1~15자리 숫자
-    private static let regex = try! NSRegularExpression(pattern: pattern, options: [])
-    
-    static func tryParse(phoneNumber: String) -> String? {
-        if phoneNumber.isEmpty {
-            return nil
-        }
-        
-        let cleanedPhoneNumber = phoneNumber.replacingOccurrences(of: "[ .()-]", with: "", options: .regularExpression) // + 제외 특수문자 삭제
-        guard regex.firstMatch(in: cleanedPhoneNumber, range: NSRange(location: 0, length: cleanedPhoneNumber.count)) != nil else {
-            return nil
-        }
-        
-        return cleanedPhoneNumber
+    static func filtered(phoneNumber: String) -> String {
+        let filtered = phoneNumber.filter { $0.isNumber || $0 == "+" }
+        return String(filtered.prefix(16)) // + 제외 15자리 숫자가 e.164 표준
     }
 }

--- a/Sources/Hackle/Core/PII/PhoneNumber/PhoneNumber.swift
+++ b/Sources/Hackle/Core/PII/PhoneNumber/PhoneNumber.swift
@@ -10,12 +10,8 @@ import Foundation
 struct PhoneNumber {
     let value: String
     
-    init(value: String) {
-        self.value = PhoneNumber.filtered(phoneNumber: value)
-    }
-    
-    static func filtered(phoneNumber: String) -> String {
-        let filtered = phoneNumber.filter { $0.isNumber || $0 == "+" }
-        return String(filtered.prefix(16)) // + 제외 15자리 숫자가 e.164 표준
+    static func create(phoneNumber: String) -> PhoneNumber {
+        let filterdValue = phoneNumber.filter { $0.isNumber || $0 == "+" }
+        return PhoneNumber(value: filterdValue)
     }
 }

--- a/Sources/Hackle/Core/PII/PhoneNumber/PhoneNumber.swift
+++ b/Sources/Hackle/Core/PII/PhoneNumber/PhoneNumber.swift
@@ -7,7 +7,13 @@
 
 import Foundation
 
-class PhoneNumber {
+struct PhoneNumber {
+    let value: String
+    
+    init(value: String) {
+        self.value = PhoneNumber.filtered(phoneNumber: value)
+    }
+    
     static func filtered(phoneNumber: String) -> String {
         let filtered = phoneNumber.filter { $0.isNumber || $0 == "+" }
         return String(filtered.prefix(16)) // + 제외 15자리 숫자가 e.164 표준

--- a/Sources/Hackle/HackleApp.swift
+++ b/Sources/Hackle/HackleApp.swift
@@ -169,7 +169,7 @@ import WebKit
     }
 
     @objc public func setPhoneNumber(phoneNumber: String, completion: @escaping () -> ()) {
-        piiEventManager.setPhoneNumber(phoneNumber: phoneNumber, user: user, timestamp: Date())
+        piiEventManager.setPhoneNumber(phoneNumber: PhoneNumber(value: phoneNumber), timestamp: Date())
         eventProcessor.flush()
         completion()
     }
@@ -179,7 +179,7 @@ import WebKit
     }
     
     @objc public func unsetPhoneNumber(completion: @escaping () -> ()) {
-        piiEventManager.unsetPhoneNumber(user: user, timestamp: Date())
+        piiEventManager.unsetPhoneNumber(timestamp: Date())
         eventProcessor.flush()
         completion()
     }

--- a/Sources/Hackle/HackleApp.swift
+++ b/Sources/Hackle/HackleApp.swift
@@ -169,7 +169,7 @@ import WebKit
     }
 
     @objc public func setPhoneNumber(phoneNumber: String, completion: @escaping () -> ()) {
-        piiEventManager.setPhoneNumber(phoneNumber: PhoneNumber(value: phoneNumber), timestamp: Date())
+        piiEventManager.setPhoneNumber(phoneNumber: PhoneNumber.create(phoneNumber: phoneNumber), timestamp: Date())
         eventProcessor.flush()
         completion()
     }

--- a/Sources/Hackle/HackleApp.swift
+++ b/Sources/Hackle/HackleApp.swift
@@ -165,11 +165,23 @@ import WebKit
     }
 
     @objc public func setPhoneNumber(phoneNumber: String) {
+        setPhoneNumber(phoneNumber: phoneNumber, completion: {})
+    }
+
+    @objc public func setPhoneNumber(phoneNumber: String, completion: @escaping () -> ()) {
         piiEventManager.setPhoneNumber(phoneNumber: phoneNumber, user: user, timestamp: Date())
+        eventProcessor.flush()
+        completion()
     }
     
     @objc public func unsetPhoneNumber() {
+        unsetPhoneNumber(completion: {})
+    }
+    
+    @objc public func unsetPhoneNumber(completion: @escaping () -> ()) {
         piiEventManager.unsetPhoneNumber(user: user, timestamp: Date())
+        eventProcessor.flush()
+        completion()
     }
     
     @objc public func variation(experimentKey: Int, defaultVariation: String = "A") -> String {

--- a/Sources/Hackle/HackleApp.swift
+++ b/Sources/Hackle/HackleApp.swift
@@ -165,13 +165,11 @@ import WebKit
     }
 
     @objc public func setPhoneNumber(phoneNumber: String) {
-        let hackleUser = userManager.resolve(user: user)
-        piiEventManager.setPhoneNumber(phoneNumber: phoneNumber, hackleUser: hackleUser, timestamp: Date())
+        piiEventManager.setPhoneNumber(phoneNumber: phoneNumber, user: user, timestamp: Date())
     }
     
     @objc public func unsetPhoneNumber() {
-        let hackleUser = userManager.resolve(user: user)
-        piiEventManager.unsetPhoneNumber(hackleUser: hackleUser, timestamp: Date())
+        piiEventManager.unsetPhoneNumber(user: user, timestamp: Date())
     }
     
     @objc public func variation(experimentKey: Int, defaultVariation: String = "A") -> String {
@@ -643,6 +641,7 @@ extension HackleApp {
         // - PII
         
         let piiEventManager = DefaultPIIEventManager(
+            userManager: userManager,
             core: core
         )
             

--- a/Sources/Hackle/HackleApp.swift
+++ b/Sources/Hackle/HackleApp.swift
@@ -17,6 +17,7 @@ import WebKit
     private let lifecycleManager: LifecycleManager
     private let pushTokenRegistry: PushTokenRegistry
     private let notificationManager: NotificationManager
+    private let piiEventManager: PIIEventManager
     private let fetchThrottler: Throttler
     private let device: Device
     private let inAppMessageUI: HackleInAppMessageUI
@@ -62,6 +63,7 @@ import WebKit
         lifecycleManager: LifecycleManager,
         pushTokenRegistry: PushTokenRegistry,
         notificationManager: NotificationManager,
+        piiEventManager: PIIEventManager,
         fetchThrottler: Throttler,
         device: Device,
         inAppMessageUI: HackleInAppMessageUI,
@@ -79,6 +81,7 @@ import WebKit
         self.lifecycleManager = lifecycleManager
         self.pushTokenRegistry = pushTokenRegistry
         self.notificationManager = notificationManager
+        self.piiEventManager = piiEventManager
         self.fetchThrottler = fetchThrottler
         self.device = device
         self.inAppMessageUI = inAppMessageUI
@@ -161,6 +164,16 @@ import WebKit
         userManager.syncIfNeeded(updated: updated, completion: completion)
     }
 
+    @objc public func setPhoneNumber(phoneNumber: String) {
+        let hackleUser = userManager.resolve(user: user)
+        piiEventManager.setPhoneNumber(phoneNumber: phoneNumber, hackleUser: hackleUser, timestamp: Date())
+    }
+    
+    @objc public func unsetPhoneNumber() {
+        let hackleUser = userManager.resolve(user: user)
+        piiEventManager.unsetPhoneNumber(hackleUser: hackleUser, timestamp: Date())
+    }
+    
     @objc public func variation(experimentKey: Int, defaultVariation: String = "A") -> String {
         variationDetail(experimentKey: experimentKey, defaultVariation: defaultVariation).variation
     }
@@ -626,6 +639,13 @@ extension HackleApp {
             )
         )
         NotificationHandler.shared.setNotificationDataReceiver(receiver: notificationManager)
+        
+        // - PII
+        
+        let piiEventManager = DefaultPIIEventManager(
+            core: core
+        )
+            
 
         // - UserExplorer
 
@@ -677,6 +697,7 @@ extension HackleApp {
             lifecycleManager: lifecycleManager,
             pushTokenRegistry: pushTokenRegistry,
             notificationManager: notificationManager,
+            piiEventManager: piiEventManager,
             fetchThrottler: throttler,
             device: device,
             inAppMessageUI: inAppMessageUI,
@@ -727,6 +748,9 @@ protocol HackleAppProtocol: AnyObject {
     func setUserProperty(key: String, value: Any?)
     func updateUserProperties(operations: PropertyOperations)
     func resetUser()
+    
+    func setPhoneNumber(phoneNumber: String)
+    func unsetPhoneNumber()
 
     func variation(experimentKey: Int, defaultVariation: String) -> String
     func variationDetail(experimentKey: Int, defaultVariation: String) -> Decision

--- a/Tests/HackleTests/Core/Bridge/HackleBridgeSpecs.swift
+++ b/Tests/HackleTests/Core/Bridge/HackleBridgeSpecs.swift
@@ -289,6 +289,32 @@ class HackleBridgeSpec : QuickSpec {
                 expect(dict["message"] as? String) == "OK"
                 expect(dict["data"]).to(beNil())
             }
+            it("setPhoneNumber") {
+                let mock = MockHackleApp()
+                let bridge = HackleBridge(app: mock)
+                let jsonString = self.createJsonString(command: "setPhoneNumber", parameters: ["phoneNumber": "+821012345678"])
+                let result = bridge.invoke(string: jsonString)
+                
+                expect(mock.setPhoneNumberRef.invokations().count) == 1
+                
+                let dict = result.jsonObject()!
+                expect(dict["success"] as? Bool) == true
+                expect(dict["message"] as? String) == "OK"
+                expect(dict["data"]).to(beNil())
+            }
+            it("unsetPhoneNumber") {
+                let mock = MockHackleApp()
+                let bridge = HackleBridge(app: mock)
+                let jsonString = self.createJsonString(command: "unsetPhoneNumber")
+                let result = bridge.invoke(string: jsonString)
+                
+                expect(mock.unsetPhoneNumberRef.invokations().count) == 1
+                
+                let dict = result.jsonObject()!
+                expect(dict["success"] as? Bool) == true
+                expect(dict["message"] as? String) == "OK"
+                expect(dict["data"]).to(beNil())
+            }
             describe("variation") {
                 context("normal") {
                     it("happy case") {

--- a/Tests/HackleTests/Core/Database/DatabaseSpecs.swift
+++ b/Tests/HackleTests/Core/Database/DatabaseSpecs.swift
@@ -169,10 +169,12 @@ class DatabaseSpec: QuickSpec {
                 concurrentQueue.async {
                     mockDB.execute { _ in
                         executionLog.append(1)
-                        sleep(1)
+                        Thread.sleep(forTimeInterval: 0.1)
                         executionLog.append(2)
                     }
                 }
+                
+                Thread.sleep(forTimeInterval: 0.1)
                 
                 concurrentQueue.async {
                     mockDB.execute { _ in
@@ -180,10 +182,9 @@ class DatabaseSpec: QuickSpec {
                     }
                 }
                 
-
                 expect(executionLog).toEventually(
                     equal([1,2,3]),
-                    timeout: .seconds(2)
+                    timeout: .seconds(1)
                 )
             }
         }

--- a/Tests/HackleTests/Core/Evaluation/Match/EventConditionMatcherSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Match/EventConditionMatcherSpecs.swift
@@ -95,7 +95,7 @@ class DefaultEventValueResolverSpecs: QuickSpec {
                 user: user
             )
 
-            expect(try sut.resolveOrNil(event: event, key: Target.Key(type: .eventProperty, name: "os_name")) as! String) == "iOS"
+            expect(try sut.resolveOrNil(event: event, key: Target.Key(type: .eventProperty, name: "os_name")) as? String) == "iOS"
             expect(try sut.resolveOrNil(event: event, key: Target.Key(type: .eventProperty, name: "app_version"))).to(beNil())
         };
 
@@ -103,7 +103,7 @@ class DefaultEventValueResolverSpecs: QuickSpec {
             let user = HackleUser.builder().identifier(.id, "user").build()
             let event = UserEvents.exposure(user: user, evaluation: experimentEvaluation(), properties: ["a": "b"], timestamp: Date())
 
-            expect(try sut.resolveOrNil(event: event, key: Target.Key(type: .eventProperty, name: "a")) as! String) == "b"
+            expect(try sut.resolveOrNil(event: event, key: Target.Key(type: .eventProperty, name: "a")) as? String) == "b"
             expect(try sut.resolveOrNil(event: event, key: Target.Key(type: .eventProperty, name: "b"))).to(beNil())
         }
 
@@ -121,7 +121,7 @@ class DefaultEventValueResolverSpecs: QuickSpec {
             )
             let event = UserEvents.remoteConfig(user: user, evaluation: evaluation, properties: ["a": "b"], timestamp: Date())
 
-            expect(try sut.resolveOrNil(event: event, key: Target.Key(type: .eventProperty, name: "a")) as! String) == "b"
+            expect(try sut.resolveOrNil(event: event, key: Target.Key(type: .eventProperty, name: "a")) as? String) == "b"
             expect(try sut.resolveOrNil(event: event, key: Target.Key(type: .eventProperty, name: "b"))).to(beNil())
         }
 

--- a/Tests/HackleTests/Core/PII/DefaultPIIEventManagerSpecs.swift
+++ b/Tests/HackleTests/Core/PII/DefaultPIIEventManagerSpecs.swift
@@ -43,5 +43,34 @@ class DefaultPIIEventManagerSpecs: QuickSpec {
             expect(properties?.count).to(equal(1))
             expect(properties?["$phone_number"] as? String).to(equal(phoneNumber))
         }
+        
+        it("invalidate phone number") {
+            // given
+            every(userManager.toHackleUserMock).returns(HackleUser.builder().build())
+            let user = User.builder().deviceId("device_id").build()
+            let phoneNumber = "01012345678"
+            
+            // when
+            sut.setPhoneNumber(phoneNumber: phoneNumber, user: user, timestamp: Date(timeIntervalSince1970: 42))
+            
+            // then
+            verify(exactly: 0) {
+                core.trackMock
+            }
+        }
+        
+        it("unset phone number") {
+            // given
+            every(userManager.toHackleUserMock).returns(HackleUser.builder().build())
+            let user = User.builder().deviceId("device_id").build()
+            
+            // when
+            sut.unsetPhoneNumber(user: user, timestamp: Date(timeIntervalSince1970: 42))
+            
+            // then
+            verify(exactly: 1) {
+                core.trackMock
+            }
+        }
     }
 }

--- a/Tests/HackleTests/Core/PII/DefaultPIIEventManagerSpecs.swift
+++ b/Tests/HackleTests/Core/PII/DefaultPIIEventManagerSpecs.swift
@@ -29,7 +29,7 @@ class DefaultPIIEventManagerSpecs: QuickSpec {
             let phoneNumber = "+821012345678"
             
             // when
-            sut.setPhoneNumber(phoneNumber: phoneNumber, user: user, timestamp: Date(timeIntervalSince1970: 42))
+            sut.setPhoneNumber(phoneNumber: PhoneNumber(value: phoneNumber), timestamp: Date(timeIntervalSince1970: 42))
             
             // then
             verify(exactly: 1) {
@@ -50,7 +50,7 @@ class DefaultPIIEventManagerSpecs: QuickSpec {
             let user = User.builder().deviceId("device_id").build()
             
             // when
-            sut.unsetPhoneNumber(user: user, timestamp: Date(timeIntervalSince1970: 42))
+            sut.unsetPhoneNumber(timestamp: Date(timeIntervalSince1970: 42))
             
             // then
             verify(exactly: 1) {

--- a/Tests/HackleTests/Core/PII/DefaultPIIEventManagerSpecs.swift
+++ b/Tests/HackleTests/Core/PII/DefaultPIIEventManagerSpecs.swift
@@ -44,21 +44,6 @@ class DefaultPIIEventManagerSpecs: QuickSpec {
             expect(properties?["$phone_number"] as? String).to(equal(phoneNumber))
         }
         
-        it("invalidate phone number") {
-            // given
-            every(userManager.toHackleUserMock).returns(HackleUser.builder().build())
-            let user = User.builder().deviceId("device_id").build()
-            let phoneNumber = "01012345678"
-            
-            // when
-            sut.setPhoneNumber(phoneNumber: phoneNumber, user: user, timestamp: Date(timeIntervalSince1970: 42))
-            
-            // then
-            verify(exactly: 0) {
-                core.trackMock
-            }
-        }
-        
         it("unset phone number") {
             // given
             every(userManager.toHackleUserMock).returns(HackleUser.builder().build())

--- a/Tests/HackleTests/Core/PII/DefaultPIIEventManagerSpecs.swift
+++ b/Tests/HackleTests/Core/PII/DefaultPIIEventManagerSpecs.swift
@@ -1,0 +1,47 @@
+//
+//  DefaultPIIEventManagerSpecs.swift
+//  Hackle
+//
+//  Created by sungwoo.yeo on 3/31/25.
+//
+
+import Foundation
+import Quick
+import Nimble
+@testable import Hackle
+
+class DefaultPIIEventManagerSpecs: QuickSpec {
+    override func spec() {
+        var userManager: MockUserManager!
+        var core: MockHackleCore!
+        var sut: DefaultPIIEventManager!
+        
+        beforeEach {
+            userManager = MockUserManager()
+            core = MockHackleCore()
+            sut = DefaultPIIEventManager(userManager: userManager, core: core)
+        }
+        
+        it("set phone number") {
+            // given
+            every(userManager.toHackleUserMock).returns(HackleUser.builder().build())
+            let user = User.builder().deviceId("device_id").build()
+            let phoneNumber = "+821012345678"
+            
+            // when
+            sut.setPhoneNumber(phoneNumber: phoneNumber, user: user, timestamp: Date(timeIntervalSince1970: 42))
+            
+            // then
+            verify(exactly: 1) {
+                core.trackMock
+            }
+            
+            let event = core.trackMock.firstInvokation().arguments.0
+            expect(event.key).to(equal("$secured_properties"))
+            
+            let properties = event.properties?["$set"] as? [String: Any]
+            expect(properties?.count).to(equal(1))
+            expect(properties?["$phone_number"] as? String).to(equal(phoneNumber))
+        }
+    }
+}

--- a/Tests/HackleTests/Core/PII/PhoneNumber/DefaultPhoneNumberSpecs.swift
+++ b/Tests/HackleTests/Core/PII/PhoneNumber/DefaultPhoneNumberSpecs.swift
@@ -12,44 +12,10 @@ import Nimble
 
 class DefaultPhoneNumberSpecs: QuickSpec {
     override func spec() {
-        it("filtered phone number with +") {
-            let phoneNumberCases = [
-                "+821012345678",
-                "+82-10-1234-5678",
-                "+82 10 1234 5678",
-                "+82 10 1234-5678",
-                "+82(10)12345678",
-                "+82(10)1234-5678",
-                "+82(10)1234 5678",
-                "+82-10-1234-5678aaa",
-                "aaa+82 10 1234 5678",
-            ]
-            let expectResult = "+821012345678"
-            
-            for phoneNumber in phoneNumberCases {
-                let result = PhoneNumber.create(phoneNumber: phoneNumber)
-                expect(result.value) == expectResult
-            }
-        }
-        
-        it("filtered phone number") {
-            let phoneNumberCases = [
-                "01012345678",
-                "01012345678",
-                "010-1234-5678",
-                "010 1234 5678",
-                "010 1234-5678",
-                "010(1234)5678",
-                "010(1234)5678",
-                "010(1234)5678aaa",
-                "aaa010 1234 5678",
-            ]
-            let expectResult = "01012345678"
-            
-            for phoneNumber in phoneNumberCases {
-                let result = PhoneNumber.create(phoneNumber: phoneNumber)
-                expect(result.value) == expectResult
-            }
+        it("phone number") {
+            let phoneNumber = "01012345678"
+            let result = PhoneNumber.create(phoneNumber: phoneNumber)
+            expect(result.value) == phoneNumber
         }
     }
 }

--- a/Tests/HackleTests/Core/PII/PhoneNumber/DefaultPhoneNumberSpecs.swift
+++ b/Tests/HackleTests/Core/PII/PhoneNumber/DefaultPhoneNumberSpecs.swift
@@ -12,7 +12,7 @@ import Nimble
 
 class DefaultPhoneNumberSpecs: QuickSpec {
     override func spec() {
-        it("vaildate phone number") {
+        it("filtered phone number with +") {
             let phoneNumberCases = [
                 "+821012345678",
                 "+82-10-1234-5678",
@@ -21,31 +21,34 @@ class DefaultPhoneNumberSpecs: QuickSpec {
                 "+82(10)12345678",
                 "+82(10)1234-5678",
                 "+82(10)1234 5678",
+                "+82-10-1234-5678aaa",
+                "aaa+82 10 1234 5678",
             ]
             let expectResult = "+821012345678"
             
             for phoneNumber in phoneNumberCases {
-                let result = PhoneNumber.tryParse(phoneNumber: phoneNumber)
+                let result = PhoneNumber.filtered(phoneNumber: phoneNumber)
                 expect(result) == expectResult
             }
         }
         
-        it("invalid phone number") {
+        it("filtered phone number") {
             let phoneNumberCases = [
-                "821012345678",
+                "01012345678",
                 "01012345678",
                 "010-1234-5678",
                 "010 1234 5678",
                 "010 1234-5678",
                 "010(1234)5678",
                 "010(1234)5678",
-                "010(1234) 5678",
-                "010(1234) 5678",
+                "010(1234)5678aaa",
+                "aaa010 1234 5678",
             ]
+            let expectResult = "01012345678"
             
             for phoneNumber in phoneNumberCases {
-                let result = PhoneNumber.tryParse(phoneNumber: phoneNumber)
-                expect(result).to(beNil())
+                let result = PhoneNumber.filtered(phoneNumber: phoneNumber)
+                expect(result) == expectResult
             }
         }
     }

--- a/Tests/HackleTests/Core/PII/PhoneNumber/DefaultPhoneNumberSpecs.swift
+++ b/Tests/HackleTests/Core/PII/PhoneNumber/DefaultPhoneNumberSpecs.swift
@@ -1,0 +1,52 @@
+//
+//  DefaultPhoneNumberSpecs.swift
+//  Hackle
+//
+//  Created by sungwoo.yeo on 3/31/25.
+//
+
+import Quick
+import Nimble
+@testable import Hackle
+
+
+class DefaultPhoneNumberSpecs: QuickSpec {
+    override func spec() {
+        it("vaildate phone number") {
+            let phoneNumberCases = [
+                "+821012345678",
+                "+82-10-1234-5678",
+                "+82 10 1234 5678",
+                "+82 10 1234-5678",
+                "+82(10)12345678",
+                "+82(10)1234-5678",
+                "+82(10)1234 5678",
+            ]
+            let expectResult = "+821012345678"
+            
+            for phoneNumber in phoneNumberCases {
+                let result = PhoneNumber.tryParse(phoneNumber: phoneNumber)
+                expect(result) == expectResult
+            }
+        }
+        
+        it("invalid phone number") {
+            let phoneNumberCases = [
+                "821012345678",
+                "01012345678",
+                "010-1234-5678",
+                "010 1234 5678",
+                "010 1234-5678",
+                "010(1234)5678",
+                "010(1234)5678",
+                "010(1234) 5678",
+                "010(1234) 5678",
+            ]
+            
+            for phoneNumber in phoneNumberCases {
+                let result = PhoneNumber.tryParse(phoneNumber: phoneNumber)
+                expect(result).to(beNil())
+            }
+        }
+    }
+}

--- a/Tests/HackleTests/Core/PII/PhoneNumber/DefaultPhoneNumberSpecs.swift
+++ b/Tests/HackleTests/Core/PII/PhoneNumber/DefaultPhoneNumberSpecs.swift
@@ -27,8 +27,8 @@ class DefaultPhoneNumberSpecs: QuickSpec {
             let expectResult = "+821012345678"
             
             for phoneNumber in phoneNumberCases {
-                let result = PhoneNumber.filtered(phoneNumber: phoneNumber)
-                expect(result) == expectResult
+                let result = PhoneNumber.create(phoneNumber: phoneNumber)
+                expect(result.value) == expectResult
             }
         }
         
@@ -47,8 +47,8 @@ class DefaultPhoneNumberSpecs: QuickSpec {
             let expectResult = "01012345678"
             
             for phoneNumber in phoneNumberCases {
-                let result = PhoneNumber.filtered(phoneNumber: phoneNumber)
-                expect(result) == expectResult
+                let result = PhoneNumber.create(phoneNumber: phoneNumber)
+                expect(result.value) == expectResult
             }
         }
     }

--- a/Tests/HackleTests/Core/Sync/PollingSynchronizerSpecs.swift
+++ b/Tests/HackleTests/Core/Sync/PollingSynchronizerSpecs.swift
@@ -112,15 +112,15 @@ class PollingSynchronizerSpecs: QuickSpec {
         it("onChanged") {
             let delegate = MockSynchronizer()
             every(delegate.syncMock).answers({ $0(.success(())) })
-            let sut = PollingSynchronizer(delegate: delegate, scheduler: Schedulers.dispatch(), interval: 0.1)
+            let sut = PollingSynchronizer(delegate: delegate, scheduler: Schedulers.dispatch(), interval: 0.5)
 
             sut.onState(state: .foreground, timestamp: Date())
-            Thread.sleep(forTimeInterval: 0.25)
+            Thread.sleep(forTimeInterval: 1.25)
             verify(exactly: 2) {
                 delegate.syncMock
             }
             sut.onState(state: .background, timestamp: Date())
-            Thread.sleep(forTimeInterval: 0.25)
+            Thread.sleep(forTimeInterval: 1.25)
             verify(exactly: 2) {
                 delegate.syncMock
             }

--- a/Tests/HackleTests/HackleAppSpec.swift
+++ b/Tests/HackleTests/HackleAppSpec.swift
@@ -574,6 +574,20 @@ class HackleAppSpecs: QuickSpec {
                 sut.setPushToken(deviceToken)
                 expect(pushTokenRegistry.registeredToken()).notTo(beNil())
             }
+            
+            it("setPhoneNumber") {
+                sut.setPhoneNumber(phoneNumber: "+821012345678")
+                verify(exactly: 1) {
+                    piiEventManager.toSetPhoneNumberMock
+                }
+            }
+            
+            it("unsetPhoneNumber") {
+                sut.unsetPhoneNumber()
+                verify(exactly: 1) {
+                    piiEventManager.toUnsetPhoneNumberMock
+                }
+            }
         }
     }
 }

--- a/Tests/HackleTests/HackleAppSpec.swift
+++ b/Tests/HackleTests/HackleAppSpec.swift
@@ -12,6 +12,7 @@ class HackleAppSpecs: QuickSpec {
         var userManager: MockUserManager!
         var workspaceManager: WorkspaceManager!
         var notificationManager: MockNotificationManager!
+        var piiEventManager: MockPIIEventManager!
         var sessionManager: MockSessionManager!
         var eventProcessor: MockUserEventProcessor!
         var pushTokenRegistry = DefaultPushTokenRegistry()
@@ -32,6 +33,7 @@ class HackleAppSpecs: QuickSpec {
                 repository: MockWorkspaceConfigRepository()
             )
             notificationManager = MockNotificationManager()
+            piiEventManager = MockPIIEventManager()
             sessionManager = MockSessionManager()
             eventProcessor = MockUserEventProcessor()
             pushTokenRegistry = DefaultPushTokenRegistry()
@@ -67,6 +69,7 @@ class HackleAppSpecs: QuickSpec {
                 lifecycleManager: LifecycleManager.shared,
                 pushTokenRegistry: pushTokenRegistry,
                 notificationManager: notificationManager,
+                piiEventManager: piiEventManager,
                 fetchThrottler: throttler,
                 device: device,
                 inAppMessageUI: inAppMessageUI,

--- a/Tests/HackleTests/Mock/MockHackleApp.swift
+++ b/Tests/HackleTests/Mock/MockHackleApp.swift
@@ -63,6 +63,16 @@ class MockHackleApp : Mock, HackleAppProtocol {
     func resetUser() {
         call(resetUserRef, args: ())
     }
+    
+    lazy var setPhoneNumberRef = MockFunction(self, setPhoneNumber)
+    func setPhoneNumber(phoneNumber: String) {
+        call(setPhoneNumberRef, args: (phoneNumber))
+    }
+    
+    lazy var unsetPhoneNumberRef = MockFunction(self, unsetPhoneNumber)
+    func unsetPhoneNumber() {
+        call(unsetPhoneNumberRef, args: ())
+    }
 
     lazy var variationRef = MockFunction(self, variation as (Int, String) -> String)
     func variation(experimentKey: Int, defaultVariation: String) -> String {

--- a/Tests/HackleTests/Mock/MockPIIEventManager.swift
+++ b/Tests/HackleTests/Mock/MockPIIEventManager.swift
@@ -11,12 +11,12 @@ import Mockery
 
 class MockPIIEventManager: Mock, PIIEventManager {
     lazy var toSetPhoneNumberMock = MockFunction(self, setPhoneNumber)
-    func setPhoneNumber(phoneNumber: String, user: User, timestamp: Date) {
-        call(toSetPhoneNumberMock, args: (phoneNumber, user, timestamp))
+    func setPhoneNumber(phoneNumber: PhoneNumber, timestamp: Date) {
+        call(toSetPhoneNumberMock, args: (phoneNumber, timestamp))
     }
     
     lazy var toUnsetPhoneNumberMock = MockFunction(self, unsetPhoneNumber)
-    func unsetPhoneNumber(user: User, timestamp: Date) {
-        call(toUnsetPhoneNumberMock, args: (user, timestamp))
+    func unsetPhoneNumber(timestamp: Date) {
+        call(toUnsetPhoneNumberMock, args: (timestamp))
     }
 }

--- a/Tests/HackleTests/Mock/MockPIIEventManager.swift
+++ b/Tests/HackleTests/Mock/MockPIIEventManager.swift
@@ -9,11 +9,11 @@ import Foundation
 @testable import Hackle
 
 class MockPIIEventManager: PIIEventManager {
-    func setPhoneNumber(phoneNumber: String, hackleUser: HackleUser, timestamp: Date) {
+    func setPhoneNumber(phoneNumber: String, user: User, timestamp: Date) {
         
     }
     
-    func unsetPhoneNumber(hackleUser: HackleUser, timestamp: Date) {
+    func unsetPhoneNumber(user: User, timestamp: Date) {
         
     }
 }

--- a/Tests/HackleTests/Mock/MockPIIEventManager.swift
+++ b/Tests/HackleTests/Mock/MockPIIEventManager.swift
@@ -1,0 +1,19 @@
+//
+//  MockPIIEventManager.swift
+//  Hackle
+//
+//  Created by sungwoo.yeo on 3/31/25.
+//
+
+import Foundation
+@testable import Hackle
+
+class MockPIIEventManager: PIIEventManager {
+    func setPhoneNumber(phoneNumber: String, hackleUser: HackleUser, timestamp: Date) {
+        
+    }
+    
+    func unsetPhoneNumber(hackleUser: HackleUser, timestamp: Date) {
+        
+    }
+}

--- a/Tests/HackleTests/Mock/MockPIIEventManager.swift
+++ b/Tests/HackleTests/Mock/MockPIIEventManager.swift
@@ -6,14 +6,17 @@
 //
 
 import Foundation
+import Mockery
 @testable import Hackle
 
-class MockPIIEventManager: PIIEventManager {
+class MockPIIEventManager: Mock, PIIEventManager {
+    lazy var toSetPhoneNumberMock = MockFunction(self, setPhoneNumber)
     func setPhoneNumber(phoneNumber: String, user: User, timestamp: Date) {
-        
+        call(toSetPhoneNumberMock, args: (phoneNumber, user, timestamp))
     }
     
+    lazy var toUnsetPhoneNumberMock = MockFunction(self, unsetPhoneNumber)
     func unsetPhoneNumber(user: User, timestamp: Date) {
-        
+        call(toUnsetPhoneNumberMock, args: (user, timestamp))
     }
 }


### PR DESCRIPTION
## 개요
- 전화번호 수집 기능 추가

## 작업 내용
### PIIEventManger 추가
- PII(Personally Identifiable Information)를 관리하기 위한 객체입니다.
- 현재는 `setPhoneNumber`와 `unsetPhoneNumber` 만 지원합니다.

### `setPhoneNumber` 추가
- ~반드시 [e.164](https://en.wikipedia.org/wiki/E.164) 포맷을 만족하는 전화번호만 인자로 전달해야 합니다.~
- ~만족하지 않는 전화번호는 에러로그를 발생시키고 아무런 작업을 하지 않습니다.~
- ~숫자와 특수문자 `+` 를 제외한 문자를 필터링 합니다.~
- ~최대 16자리까지만 PhoneNumber 지정이 가능하며, 필터링 된 문자열에서 앞에서 16자리까지만 유지하고 뒤는 삭제합니다.~
- `$secured_properties`로 `$phone_number` set 이벤트를 발생시킵니다.

### `unsetPhoneNumber` 추가
- `$secured_properties`로 `$phone_number` unset 이벤트를 발생시킵니다.

## 참고
- PushEventTracker를 참고해서 추가했습니다.