### PR TITLE
add internal property

### DIFF
--- a/Sources/Hackle/Common/Event.swift
+++ b/Sources/Hackle/Common/Event.swift
@@ -9,11 +9,13 @@ import Foundation
     let key: String
     let value: Double?
     let properties: [String: Any]?
+    var internalProperties: [String: Any]?
 
     init(key: String, value: Double? = nil, properties: [String: Any]? = nil) {
         self.key = key
         self.value = value
         self.properties = properties
+        self.internalProperties = nil
     }
 
     @objc public static func builder(_ key: String) -> HackleEventBuilder {
@@ -26,6 +28,7 @@ import Foundation
     private let key: String
     private var value: Double? = nil
     private var properties: PropertiesBuilder = PropertiesBuilder()
+    private var internalProperties: PropertiesBuilder? = nil
 
     init(key: String) {
         self.key = key
@@ -51,6 +54,25 @@ import Foundation
     }
 
     @objc public func build() -> Event {
-        Event(key: key, value: value, properties: properties.build())
+        let event = Event(key: key, value: value, properties: properties.build())
+        event.addInternalProperties(internalProperties?.build())
+        return event
+    }
+}
+
+extension Event {
+    fileprivate func addInternalProperties(_ internalProperties: [String: Any]?) {
+        self.internalProperties = internalProperties
+    }
+}
+
+extension HackleEventBuilder {
+    func internalProperty(_ key: String, _ value: Any?) -> HackleEventBuilder {
+        if internalProperties == nil {
+            internalProperties = PropertiesBuilder()
+        }
+        
+        internalProperties?.add(key, value)
+        return self
     }
 }

--- a/Sources/Hackle/Common/Event.swift
+++ b/Sources/Hackle/Common/Event.swift
@@ -67,6 +67,7 @@ extension Event {
 }
 
 extension HackleEventBuilder {
+    @discardableResult
     func internalProperty(_ key: String, _ value: Any?) -> HackleEventBuilder {
         if internalProperties == nil {
             internalProperties = PropertiesBuilder()

--- a/Sources/Hackle/Core/Event/UserEvent.swift
+++ b/Sources/Hackle/Core/Event/UserEvent.swift
@@ -25,6 +25,7 @@ enum UserEvents {
         user: HackleUser,
         evaluation: ExperimentEvaluation,
         properties: [String: Any],
+        internalProperties: [String: Any],
         timestamp: Date
     ) -> UserEvents.Exposure {
         Exposure(
@@ -35,7 +36,8 @@ enum UserEvents {
             variationId: evaluation.variationId,
             variationKey: evaluation.variationKey,
             decisionReason: evaluation.reason,
-            properties: properties
+            properties: properties,
+            internalProperties: internalProperties
         )
     }
 
@@ -58,6 +60,7 @@ enum UserEvents {
         user: HackleUser,
         evaluation: RemoteConfigEvaluation,
         properties: [String: Any],
+        internalProperties: [String: Any],
         timestamp: Date
     ) -> UserEvents.RemoteConfig {
         RemoteConfig(
@@ -67,7 +70,8 @@ enum UserEvents {
             parameter: evaluation.parameter,
             valueId: evaluation.valueId,
             decisionReason: evaluation.reason,
-            properties: properties
+            properties: properties,
+            internalProperties: internalProperties
         )
     }
 
@@ -81,8 +85,9 @@ enum UserEvents {
         let variationKey: Variation.Key
         let decisionReason: String
         let properties: [String: Any]
+        let internalProperties: [String: Any]
 
-        init(insertId: String, timestamp: Date, user: HackleUser, experiment: Experiment, variationId: Variation.Id?, variationKey: Variation.Key, decisionReason: String, properties: [String: Any]) {
+        init(insertId: String, timestamp: Date, user: HackleUser, experiment: Experiment, variationId: Variation.Id?, variationKey: Variation.Key, decisionReason: String, properties: [String: Any], internalProperties: [String: Any]) {
             self.insertId = insertId
             self.timestamp = timestamp
             self.user = user
@@ -91,6 +96,7 @@ enum UserEvents {
             self.variationKey = variationKey
             self.decisionReason = decisionReason
             self.properties = properties
+            self.internalProperties = internalProperties
         }
 
         func with(user: HackleUser) -> UserEvent {
@@ -102,7 +108,8 @@ enum UserEvents {
                 variationId: variationId,
                 variationKey: variationKey,
                 decisionReason: decisionReason,
-                properties: properties
+                properties: properties,
+                internalProperties: internalProperties
             )
         }
     }
@@ -143,8 +150,9 @@ enum UserEvents {
         let valueId: Int64?
         let decisionReason: String
         let properties: [String: Any]
+        let internalProperties: [String: Any]
 
-        init(insertId: String, timestamp: Date, user: HackleUser, parameter: RemoteConfigParameter, valueId: Int64?, decisionReason: String, properties: [String: Any]) {
+        init(insertId: String, timestamp: Date, user: HackleUser, parameter: RemoteConfigParameter, valueId: Int64?, decisionReason: String, properties: [String: Any], internalProperties: [String: Any]) {
             self.insertId = insertId
             self.timestamp = timestamp
             self.user = user
@@ -152,6 +160,7 @@ enum UserEvents {
             self.valueId = valueId
             self.decisionReason = decisionReason
             self.properties = properties
+            self.internalProperties = internalProperties
         }
 
         func with(user: HackleUser) -> UserEvent {
@@ -162,7 +171,8 @@ enum UserEvents {
                 parameter: parameter,
                 valueId: valueId,
                 decisionReason: decisionReason,
-                properties: properties
+                properties: properties,
+                internalProperties: internalProperties
             )
         }
     }

--- a/Sources/Hackle/Core/Event/UserEventDispatcher.swift
+++ b/Sources/Hackle/Core/Event/UserEventDispatcher.swift
@@ -143,6 +143,7 @@ extension UserEvents.Exposure {
         dto["variationKey"] = variationKey
         dto["decisionReason"] = decisionReason
         dto["properties"] = properties
+        dto["internalProperties"] = internalProperties
 
         return dto
     }
@@ -168,6 +169,9 @@ extension UserEvents.Track {
         if let properties = event.properties {
             dto["properties"] = properties
         }
+        if let internalProperties = event.internalProperties {
+            dto["internalProperties"] = internalProperties
+        }
         return dto
     }
 }
@@ -190,6 +194,7 @@ extension UserEvents.RemoteConfig {
         dto["valueId"] = valueId
         dto["decisionReason"] = decisionReason
         dto["properties"] = properties
+        dto["internalProperties"] = internalProperties
 
         return dto
     }

--- a/Sources/Hackle/Core/Event/UserEventFactory.swift
+++ b/Sources/Hackle/Core/Event/UserEventFactory.swift
@@ -14,10 +14,12 @@ protocol UserEventFactory {
 
 class DefaultUserEventFactory: UserEventFactory {
 
+    private let workspaceFetcher: WorkspaceFetcher
     private let clock: Clock
     private let internalProperties: PropertiesBuilder
 
-    init(clock: Clock) {
+    init(workspaceFetcher: WorkspaceFetcher, clock: Clock) {
+        self.workspaceFetcher = workspaceFetcher
         self.clock = clock
         self.internalProperties = PropertiesBuilder()
     }
@@ -28,6 +30,7 @@ class DefaultUserEventFactory: UserEventFactory {
 
     private static let EXPERIMENT_VERSION_KEY = "$experiment_version"
     private static let EXECUTION_VERSION_KEY = "$execution_version"
+    private static let WORKSPACE_CONFIG_LAST_MODIFIED_AT_KEY = "$config_last_modified_at"
 
     func create(request: EvaluatorRequest, evaluation: EvaluatorEvaluation) throws -> [UserEvent] {
 
@@ -55,6 +58,10 @@ class DefaultUserEventFactory: UserEventFactory {
         timestamp: Date,
         properties: PropertiesBuilder
     ) throws -> UserEvent? {
+        
+        if let lastModifiedAt = workspaceFetcher.lastModified {
+            internalProperties.add(DefaultUserEventFactory.WORKSPACE_CONFIG_LAST_MODIFIED_AT_KEY, lastModifiedAt)
+        }
 
         switch evaluation {
         case let evaluation as ExperimentEvaluation:

--- a/Sources/Hackle/Core/Event/UserEventFactory.swift
+++ b/Sources/Hackle/Core/Event/UserEventFactory.swift
@@ -15,9 +15,11 @@ protocol UserEventFactory {
 class DefaultUserEventFactory: UserEventFactory {
 
     private let clock: Clock
+    private let internalProperties: PropertiesBuilder
 
     init(clock: Clock) {
         self.clock = clock
+        self.internalProperties = PropertiesBuilder()
     }
 
     private static let CONFIG_ID_PROPERTY_KEY = "$parameterConfigurationId"
@@ -63,6 +65,7 @@ class DefaultUserEventFactory: UserEventFactory {
                 user: request.user,
                 evaluation: evaluation,
                 properties: properties.build(),
+                internalProperties: internalProperties.build(),
                 timestamp: timestamp
             )
         case let evaluation as RemoteConfigEvaluation:
@@ -71,6 +74,7 @@ class DefaultUserEventFactory: UserEventFactory {
                 user: request.user,
                 evaluation: evaluation,
                 properties: properties.build(),
+                internalProperties: internalProperties.build(),
                 timestamp: timestamp
             )
         case _ as InAppMessageEvaluation:

--- a/Sources/Hackle/Core/HackleCore.swift
+++ b/Sources/Hackle/Core/HackleCore.swift
@@ -70,7 +70,7 @@ class DefaultHackleCore: HackleCore {
             remoteConfigEvaluator: remoteConfigEvaluator,
             inAppMessageEvaluator: inAppMessageEvaluator,
             workspaceFetcher: workspaceFetcher,
-            eventFactory: DefaultUserEventFactory(clock: SystemClock.shared),
+            eventFactory: DefaultUserEventFactory(workspaceFetcher: workspaceFetcher, clock: SystemClock.shared),
             eventProcessor: eventProcessor,
             clock: SystemClock.shared
         )

--- a/Sources/Hackle/Core/InAppMessage/InAppMessageDeterminer.swift
+++ b/Sources/Hackle/Core/InAppMessage/InAppMessageDeterminer.swift
@@ -59,7 +59,7 @@ class DefaultInAppMessageDeterminer: InAppMessageDeterminer {
             message: message,
             user: event.user,
             properties: properties,
-            eventInsertId: event.insertId,
+            triggerEventId: event.insertId,
             decisionReasion: decision.reason
         )
     }

--- a/Sources/Hackle/Core/InAppMessage/InAppMessageDeterminer.swift
+++ b/Sources/Hackle/Core/InAppMessage/InAppMessageDeterminer.swift
@@ -59,6 +59,7 @@ class DefaultInAppMessageDeterminer: InAppMessageDeterminer {
             message: message,
             user: event.user,
             properties: properties,
+            eventInsertId: event.insertId,
             decisionReasion: decision.reason
         )
     }

--- a/Sources/Hackle/Core/InAppMessage/InAppMessagePresentationContext.swift
+++ b/Sources/Hackle/Core/InAppMessage/InAppMessagePresentationContext.swift
@@ -14,13 +14,15 @@ class InAppMessagePresentationContext {
     let message: InAppMessage.Message
     let user: HackleUser
     let properties: [String: Any]
+    let eventInsertId: String
     let decisionReasion: String
 
-    init(inAppMessage: InAppMessage, message: InAppMessage.Message, user: HackleUser, properties: [String: Any], decisionReasion: String) {
+    init(inAppMessage: InAppMessage, message: InAppMessage.Message, user: HackleUser, properties: [String: Any], eventInsertId: String, decisionReasion: String) {
         self.inAppMessage = inAppMessage
         self.message = message
         self.user = user
         self.properties = properties
+        self.eventInsertId = eventInsertId
         self.decisionReasion = decisionReasion
     }
 }

--- a/Sources/Hackle/Core/InAppMessage/InAppMessagePresentationContext.swift
+++ b/Sources/Hackle/Core/InAppMessage/InAppMessagePresentationContext.swift
@@ -14,15 +14,15 @@ class InAppMessagePresentationContext {
     let message: InAppMessage.Message
     let user: HackleUser
     let properties: [String: Any]
-    let eventInsertId: String
+    let triggerEventId: String
     let decisionReasion: String
 
-    init(inAppMessage: InAppMessage, message: InAppMessage.Message, user: HackleUser, properties: [String: Any], eventInsertId: String, decisionReasion: String) {
+    init(inAppMessage: InAppMessage, message: InAppMessage.Message, user: HackleUser, properties: [String: Any], triggerEventId: String, decisionReasion: String) {
         self.inAppMessage = inAppMessage
         self.message = message
         self.user = user
         self.properties = properties
-        self.eventInsertId = eventInsertId
+        self.triggerEventId = triggerEventId
         self.decisionReasion = decisionReasion
     }
 }

--- a/Sources/Hackle/Core/Workspace/WorkspaceFetcher.swift
+++ b/Sources/Hackle/Core/Workspace/WorkspaceFetcher.swift
@@ -5,5 +5,6 @@
 import Foundation
 
 protocol WorkspaceFetcher {
+    var lastModified: String? { get }
     func fetch() -> Workspace?
 }

--- a/Sources/Hackle/Core/Workspace/WorkspaceManager.swift
+++ b/Sources/Hackle/Core/Workspace/WorkspaceManager.swift
@@ -12,7 +12,7 @@ class WorkspaceManager: WorkspaceFetcher, Synchronizer {
     private let httpWorkspaceFetcher: HttpWorkspaceFetcher
     private let repository: WorkspaceConfigRepository
 
-    private var lastModified: String? = nil
+    private(set) var lastModified: String? = nil
     private var workspace: Workspace? = nil
 
     init(httpWorkspaceFetcher: HttpWorkspaceFetcher, repository: WorkspaceConfigRepository) {

--- a/Sources/Hackle/UI/InAppMessageUI/Event/InAppMessageEventTracker.swift
+++ b/Sources/Hackle/UI/InAppMessageUI/Event/InAppMessageEventTracker.swift
@@ -72,7 +72,7 @@ private extension HackleEventBuilder {
         property("in_app_message_id", context.inAppMessage.id)
         property("in_app_message_key", context.inAppMessage.key)
         property("in_app_message_display_type", context.message.layout.displayType.rawValue)
-        internalProperty("$trigger_event_insert_id", context.eventInsertId)
+        internalProperty("$trigger_event_insert_id", context.triggerEventId)
         return self
     }
 }

--- a/Sources/Hackle/UI/InAppMessageUI/Event/InAppMessageEventTracker.swift
+++ b/Sources/Hackle/UI/InAppMessageUI/Event/InAppMessageEventTracker.swift
@@ -41,12 +41,14 @@ class DefaultInAppMessageEventTracker: InAppMessageEventTracker {
                 .property("image_url", context.message.images.map {
                     $0.imagePath
                 })
+                .internalProperty("trigger_event_insert_id", context.eventInsertId)
                 .build()
         case .imageImpression(let image, let order):
             return Event.builder(DefaultInAppMessageEventTracker.IMAGE_IMPRESSION_EVENT_KEY)
                 .properties(context: context)
                 .property("image_url", image.imagePath)
                 .property("image_order", order)
+                .internalProperty("trigger_event_insert_id", context.eventInsertId)
                 .build()
         case .close:
             return Event.builder(DefaultInAppMessageEventTracker.CLOSE_EVENT_KEY)
@@ -54,6 +56,7 @@ class DefaultInAppMessageEventTracker: InAppMessageEventTracker {
                 .property("in_app_message_id", context.inAppMessage.id)
                 .property("in_app_message_key", context.inAppMessage.key)
                 .property("in_app_message_display_type", context.message.layout.displayType.rawValue)
+                .internalProperty("trigger_event_insert_id", context.eventInsertId)
                 .build()
         case .action(let action, let area, let button, let image, let imageOrder):
             return Event.builder(DefaultInAppMessageEventTracker.ACTION_EVENT_KEY)
@@ -64,6 +67,7 @@ class DefaultInAppMessageEventTracker: InAppMessageEventTracker {
                 .property("button_text", button?.text)
                 .property("image_url", image?.imagePath)
                 .property("image_order", imageOrder)
+                .internalProperty("trigger_event_insert_id", context.eventInsertId)
                 .build()
         }
     }

--- a/Sources/Hackle/UI/InAppMessageUI/Event/InAppMessageEventTracker.swift
+++ b/Sources/Hackle/UI/InAppMessageUI/Event/InAppMessageEventTracker.swift
@@ -41,22 +41,16 @@ class DefaultInAppMessageEventTracker: InAppMessageEventTracker {
                 .property("image_url", context.message.images.map {
                     $0.imagePath
                 })
-                .internalProperty("trigger_event_insert_id", context.eventInsertId)
                 .build()
         case .imageImpression(let image, let order):
             return Event.builder(DefaultInAppMessageEventTracker.IMAGE_IMPRESSION_EVENT_KEY)
                 .properties(context: context)
                 .property("image_url", image.imagePath)
                 .property("image_order", order)
-                .internalProperty("trigger_event_insert_id", context.eventInsertId)
                 .build()
         case .close:
             return Event.builder(DefaultInAppMessageEventTracker.CLOSE_EVENT_KEY)
-                .properties(context.properties)
-                .property("in_app_message_id", context.inAppMessage.id)
-                .property("in_app_message_key", context.inAppMessage.key)
-                .property("in_app_message_display_type", context.message.layout.displayType.rawValue)
-                .internalProperty("trigger_event_insert_id", context.eventInsertId)
+                .properties(context: context)
                 .build()
         case .action(let action, let area, let button, let image, let imageOrder):
             return Event.builder(DefaultInAppMessageEventTracker.ACTION_EVENT_KEY)
@@ -67,7 +61,6 @@ class DefaultInAppMessageEventTracker: InAppMessageEventTracker {
                 .property("button_text", button?.text)
                 .property("image_url", image?.imagePath)
                 .property("image_order", imageOrder)
-                .internalProperty("trigger_event_insert_id", context.eventInsertId)
                 .build()
         }
     }
@@ -79,6 +72,7 @@ private extension HackleEventBuilder {
         property("in_app_message_id", context.inAppMessage.id)
         property("in_app_message_key", context.inAppMessage.key)
         property("in_app_message_display_type", context.message.layout.displayType.rawValue)
+        internalProperty("$trigger_event_insert_id", context.eventInsertId)
         return self
     }
 }

--- a/Tests/HackleTests/Core/Evaluation/Match/EventConditionMatcherSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Match/EventConditionMatcherSpecs.swift
@@ -101,7 +101,7 @@ class DefaultEventValueResolverSpecs: QuickSpec {
 
         it("EXPOSURE") {
             let user = HackleUser.builder().identifier(.id, "user").build()
-            let event = UserEvents.exposure(user: user, evaluation: experimentEvaluation(), properties: ["a": "b"], timestamp: Date())
+            let event = UserEvents.exposure(user: user, evaluation: experimentEvaluation(), properties: ["a": "b"], internalProperties: ["internal": "a"], timestamp: Date())
 
             expect(try sut.resolveOrNil(event: event, key: Target.Key(type: .eventProperty, name: "a")) as? String) == "b"
             expect(try sut.resolveOrNil(event: event, key: Target.Key(type: .eventProperty, name: "b"))).to(beNil())
@@ -119,7 +119,7 @@ class DefaultEventValueResolverSpecs: QuickSpec {
                 reason: DecisionReason.TARGET_RULE_MATCH,
                 properties: PropertiesBuilder()
             )
-            let event = UserEvents.remoteConfig(user: user, evaluation: evaluation, properties: ["a": "b"], timestamp: Date())
+            let event = UserEvents.remoteConfig(user: user, evaluation: evaluation, properties: ["a": "b"], internalProperties: ["internal": "a"], timestamp: Date())
 
             expect(try sut.resolveOrNil(event: event, key: Target.Key(type: .eventProperty, name: "a")) as? String) == "b"
             expect(try sut.resolveOrNil(event: event, key: Target.Key(type: .eventProperty, name: "b"))).to(beNil())
@@ -128,7 +128,7 @@ class DefaultEventValueResolverSpecs: QuickSpec {
         it("Unsupported type") {
 
             let user = HackleUser.builder().identifier(.id, "user").build()
-            let event = UserEvents.exposure(user: user, evaluation: experimentEvaluation(), properties: ["a": "b"], timestamp: Date())
+            let event = UserEvents.exposure(user: user, evaluation: experimentEvaluation(), properties: ["a": "b"], internalProperties: ["internal": "a"], timestamp: Date())
 
             func check(type: Target.KeyType) {
                 expect(try sut.resolveOrNil(event: event, key: Target.Key(type: type, name: "a")))

--- a/Tests/HackleTests/Core/Event/Dedup/DelegatingUserEventDedupDeterminerSpecs.swift
+++ b/Tests/HackleTests/Core/Event/Dedup/DelegatingUserEventDedupDeterminerSpecs.swift
@@ -21,7 +21,8 @@ class DelegatingUserEventDedupDeterminerSpecs: QuickSpec {
                 variationId: 14,
                 variationKey: "A",
                 decisionReason: DecisionReason.TRAFFIC_ALLOCATED,
-                properties: [:]
+                properties: [:],
+                internalProperties: [:]
             )
 
 
@@ -44,7 +45,8 @@ class DelegatingUserEventDedupDeterminerSpecs: QuickSpec {
                 variationId: 14,
                 variationKey: "A",
                 decisionReason: DecisionReason.TRAFFIC_ALLOCATED,
-                properties: [:]
+                properties: [:],
+                internalProperties: [:]
             )
 
 
@@ -70,7 +72,8 @@ class DelegatingUserEventDedupDeterminerSpecs: QuickSpec {
                 variationId: 14,
                 variationKey: "A",
                 decisionReason: DecisionReason.TRAFFIC_ALLOCATED,
-                properties: [:]
+                properties: [:],
+                internalProperties: [:]
             )
 
 

--- a/Tests/HackleTests/Core/Event/Dedup/ExposureEventDedupDeterminerSpec.swift
+++ b/Tests/HackleTests/Core/Event/Dedup/ExposureEventDedupDeterminerSpec.swift
@@ -47,7 +47,8 @@ class ExposureEventDedupDeterminerSpec: QuickSpec {
                     variationId: 14,
                     variationKey: "A",
                     decisionReason: DecisionReason.TRAFFIC_ALLOCATED,
-                    properties: [:]
+                    properties: [:],
+                    internalProperties: [:]
                 )
 
                 // when
@@ -69,7 +70,8 @@ class ExposureEventDedupDeterminerSpec: QuickSpec {
                     variationId: 14,
                     variationKey: "A",
                     decisionReason: DecisionReason.TRAFFIC_ALLOCATED,
-                    properties: [:]
+                    properties: [:],
+                    internalProperties: [:]
                 )
 
                 let secondEvent = UserEvents.Exposure(
@@ -80,7 +82,8 @@ class ExposureEventDedupDeterminerSpec: QuickSpec {
                     variationId: 14,
                     variationKey: "A",
                     decisionReason: DecisionReason.TRAFFIC_ALLOCATED,
-                    properties: [:]
+                    properties: [:],
+                    internalProperties: [:]
                 )
 
                 expect(exposureEventDedupDeterminerSut.isDedupTarget(event: firstEvent)) == false
@@ -99,7 +102,8 @@ class ExposureEventDedupDeterminerSpec: QuickSpec {
                     variationId: 14,
                     variationKey: "A",
                     decisionReason: DecisionReason.TRAFFIC_ALLOCATED,
-                    properties: [:]
+                    properties: [:],
+                    internalProperties: [:]
                 )
 
                 let secondEvent = UserEvents.Exposure(
@@ -110,7 +114,8 @@ class ExposureEventDedupDeterminerSpec: QuickSpec {
                     variationId: 14,
                     variationKey: "A",
                     decisionReason: DecisionReason.TRAFFIC_ALLOCATED,
-                    properties: [:]
+                    properties: [:],
+                    internalProperties: [:]
                 )
 
                 expect(exposureEventDedupDeterminerSut.isDedupTarget(event: firstEvent)) == false
@@ -129,7 +134,8 @@ class ExposureEventDedupDeterminerSpec: QuickSpec {
                     variationId: 14,
                     variationKey: "A",
                     decisionReason: DecisionReason.TRAFFIC_ALLOCATED,
-                    properties: [:]
+                    properties: [:],
+                    internalProperties: [:]
                 )
 
                 let secondEvent = UserEvents.Exposure(
@@ -140,7 +146,8 @@ class ExposureEventDedupDeterminerSpec: QuickSpec {
                     variationId: 14,
                     variationKey: "A",
                     decisionReason: DecisionReason.TRAFFIC_ALLOCATED,
-                    properties: [:]
+                    properties: [:],
+                    internalProperties: [:]
                 )
 
                 expect(exposureEventDedupDeterminerSut.isDedupTarget(event: firstEvent)) == false
@@ -158,7 +165,8 @@ class ExposureEventDedupDeterminerSpec: QuickSpec {
                     variationId: 14,
                     variationKey: "A",
                     decisionReason: DecisionReason.TRAFFIC_ALLOCATED,
-                    properties: [:]
+                    properties: [:],
+                    internalProperties: [:]
                 )
 
                 let secondEvent = UserEvents.Exposure(
@@ -169,7 +177,8 @@ class ExposureEventDedupDeterminerSpec: QuickSpec {
                     variationId: 14,
                     variationKey: "A",
                     decisionReason: DecisionReason.TRAFFIC_ALLOCATED,
-                    properties: [:]
+                    properties: [:],
+                    internalProperties: [:]
                 )
 
                 expect(exposureEventDedupDeterminerSut.isDedupTarget(event: firstEvent)) == false
@@ -187,7 +196,8 @@ class ExposureEventDedupDeterminerSpec: QuickSpec {
                     variationId: 14,
                     variationKey: "B",
                     decisionReason: DecisionReason.TRAFFIC_ALLOCATED,
-                    properties: [:]
+                    properties: [:],
+                    internalProperties: [:]
                 )
 
                 let secondEvent = UserEvents.Exposure(
@@ -198,7 +208,8 @@ class ExposureEventDedupDeterminerSpec: QuickSpec {
                     variationId: 14,
                     variationKey: "A",
                     decisionReason: DecisionReason.EXPERIMENT_PAUSED,
-                    properties: [:]
+                    properties: [:],
+                    internalProperties: [:]
                 )
 
                 expect(exposureEventDedupDeterminerSut.isDedupTarget(event: firstEvent)) == false
@@ -214,7 +225,8 @@ class ExposureEventDedupDeterminerSpec: QuickSpec {
                     variationId: 14,
                     variationKey: "A",
                     decisionReason: DecisionReason.TRAFFIC_ALLOCATED,
-                    properties: [:]
+                    properties: [:],
+                    internalProperties: [:]
                 )
 
                 let secondEvent = UserEvents.Exposure(
@@ -225,7 +237,8 @@ class ExposureEventDedupDeterminerSpec: QuickSpec {
                     variationId: 14,
                     variationKey: "A",
                     decisionReason: DecisionReason.TRAFFIC_ALLOCATED,
-                    properties: [:]
+                    properties: [:],
+                    internalProperties: [:]
                 )
 
                 expect(exposureEventDedupDeterminerSut.isDedupTarget(event: firstEvent)) == false
@@ -244,7 +257,8 @@ class ExposureEventDedupDeterminerSpec: QuickSpec {
                     variationId: 14,
                     variationKey: "A",
                     decisionReason: DecisionReason.TRAFFIC_ALLOCATED,
-                    properties: [:]
+                    properties: [:],
+                    internalProperties: [:]
                 )
 
                 let secondEvent = UserEvents.Exposure(
@@ -255,7 +269,8 @@ class ExposureEventDedupDeterminerSpec: QuickSpec {
                     variationId: 14,
                     variationKey: "A",
                     decisionReason: DecisionReason.TRAFFIC_ALLOCATED,
-                    properties: [:]
+                    properties: [:],
+                    internalProperties: [:]
                 )
 
                 expect(exposureEventDedupDeterminerSut.isDedupTarget(event: firstEvent)) == false
@@ -277,7 +292,8 @@ class ExposureEventDedupDeterminerSpec: QuickSpec {
                     variationId: 14,
                     variationKey: "A",
                     decisionReason: DecisionReason.TRAFFIC_ALLOCATED,
-                    properties: [:]
+                    properties: [:],
+                    internalProperties: [:]
                 )
 
                 let secondEvent = UserEvents.Exposure(
@@ -288,7 +304,8 @@ class ExposureEventDedupDeterminerSpec: QuickSpec {
                     variationId: 14,
                     variationKey: "A",
                     decisionReason: DecisionReason.TRAFFIC_ALLOCATED,
-                    properties: [:]
+                    properties: [:],
+                    internalProperties: [:]
                 )
                 
                 expect(sut.isDedupTarget(event: firstEvent)) == false
@@ -303,7 +320,8 @@ class ExposureEventDedupDeterminerSpec: QuickSpec {
                         variationId: 14,
                         variationKey: "A",
                         decisionReason: DecisionReason.TRAFFIC_ALLOCATED,
-                        properties: [:]
+                        properties: [:],
+                        internalProperties: [:]
                     )
                     _ = sut.isDedupTarget(event: event)
                 }
@@ -327,7 +345,8 @@ class ExposureEventDedupDeterminerSpec: QuickSpec {
                     variationId: 14,
                     variationKey: "A",
                     decisionReason: DecisionReason.TRAFFIC_ALLOCATED,
-                    properties: [:]
+                    properties: [:],
+                    internalProperties: [:]
                 )
 
                 let event2 = UserEvents.Exposure(
@@ -338,7 +357,8 @@ class ExposureEventDedupDeterminerSpec: QuickSpec {
                     variationId: 14,
                     variationKey: "A",
                     decisionReason: DecisionReason.TRAFFIC_ALLOCATED,
-                    properties: [:]
+                    properties: [:],
+                    internalProperties: [:]
                 )
 
                 let event3 = UserEvents.Exposure(
@@ -349,7 +369,8 @@ class ExposureEventDedupDeterminerSpec: QuickSpec {
                     variationId: 14,
                     variationKey: "A",
                     decisionReason: DecisionReason.TRAFFIC_ALLOCATED,
-                    properties: [:]
+                    properties: [:],
+                    internalProperties: [:]
                 )
 
                 let event4 = UserEvents.Exposure(
@@ -360,7 +381,8 @@ class ExposureEventDedupDeterminerSpec: QuickSpec {
                     variationId: 14,
                     variationKey: "A",
                     decisionReason: DecisionReason.TRAFFIC_ALLOCATED,
-                    properties: [:]
+                    properties: [:],
+                    internalProperties: [:]
                 )
 
                 expect(exposureEventDedupDeterminerSut.isDedupTarget(event: event1)) == false
@@ -383,7 +405,8 @@ class ExposureEventDedupDeterminerSpec: QuickSpec {
                     variationId: 14,
                     variationKey: "A",
                     decisionReason: DecisionReason.TRAFFIC_ALLOCATED,
-                    properties: [:]
+                    properties: [:],
+                    internalProperties: [:]
                 )
 
                 let event2 = UserEvents.Exposure(
@@ -394,7 +417,8 @@ class ExposureEventDedupDeterminerSpec: QuickSpec {
                     variationId: 14,
                     variationKey: "A",
                     decisionReason: DecisionReason.TRAFFIC_ALLOCATED,
-                    properties: [:]
+                    properties: [:],
+                    internalProperties: [:]
                 )
 
                 let event3 = UserEvents.Exposure(
@@ -405,7 +429,8 @@ class ExposureEventDedupDeterminerSpec: QuickSpec {
                     variationId: 14,
                     variationKey: "A",
                     decisionReason: DecisionReason.TRAFFIC_ALLOCATED,
-                    properties: [:]
+                    properties: [:],
+                    internalProperties: [:]
                 )
 
                 let event4 = UserEvents.Exposure(
@@ -416,7 +441,8 @@ class ExposureEventDedupDeterminerSpec: QuickSpec {
                     variationId: 14,
                     variationKey: "A",
                     decisionReason: DecisionReason.TRAFFIC_ALLOCATED,
-                    properties: [:]
+                    properties: [:],
+                    internalProperties: [:]
                 )
 
                 expect(exposureEventDedupDeterminerSut.isDedupTarget(event: event1)) == false
@@ -439,7 +465,8 @@ class ExposureEventDedupDeterminerSpec: QuickSpec {
                     variationId: 14,
                     variationKey: "A",
                     decisionReason: DecisionReason.TRAFFIC_ALLOCATED,
-                    properties: [:]
+                    properties: [:],
+                    internalProperties: [:]
                 )
 
                 let event2 = UserEvents.Exposure(
@@ -450,7 +477,8 @@ class ExposureEventDedupDeterminerSpec: QuickSpec {
                     variationId: 14,
                     variationKey: "A",
                     decisionReason: DecisionReason.TRAFFIC_ALLOCATED,
-                    properties: [:]
+                    properties: [:],
+                    internalProperties: [:]
                 )
 
                 let event3 = UserEvents.Exposure(
@@ -461,7 +489,8 @@ class ExposureEventDedupDeterminerSpec: QuickSpec {
                     variationId: 14,
                     variationKey: "A",
                     decisionReason: DecisionReason.TRAFFIC_ALLOCATED,
-                    properties: [:]
+                    properties: [:],
+                    internalProperties: [:]
                 )
 
                 let event4 = UserEvents.Exposure(
@@ -472,7 +501,8 @@ class ExposureEventDedupDeterminerSpec: QuickSpec {
                     variationId: 14,
                     variationKey: "A",
                     decisionReason: DecisionReason.TRAFFIC_ALLOCATED,
-                    properties: [:]
+                    properties: [:],
+                    internalProperties: [:]
                 )
 
                 expect(exposureEventDedupDeterminerSut.isDedupTarget(event: event1)) == false

--- a/Tests/HackleTests/Core/Event/Dedup/RemoteConfigEventDedupDeterminerSpecs.swift
+++ b/Tests/HackleTests/Core/Event/Dedup/RemoteConfigEventDedupDeterminerSpecs.swift
@@ -27,7 +27,8 @@ class RemoteConfigEventDedupDeterminerSpecs: QuickSpec {
                 ),
                 valueId: 320,
                 decisionReason: DecisionReason.DEFAULT_RULE,
-                properties: [:]
+                properties: [:],
+                internalProperties: [:]
             )
 
             let key = sut.cacheKey(event: event)

--- a/Tests/HackleTests/Core/Event/DefaultUserEventFactorySpecs.swift
+++ b/Tests/HackleTests/Core/Event/DefaultUserEventFactorySpecs.swift
@@ -15,7 +15,7 @@ class DefaultUserEventFactorySpecs: QuickSpec {
     override func spec() {
 
         it("create") {
-            let sut = DefaultUserEventFactory(clock: ClockStub())
+            let sut = DefaultUserEventFactory(workspaceFetcher: WorkspaceFetcherStub(), clock: ClockStub())
 
             let context = Evaluators.context()
 
@@ -79,6 +79,7 @@ class DefaultUserEventFactorySpecs: QuickSpec {
             expect(exposure1.properties["$parameterConfigurationId"] as? Int64) == 42
             expect(exposure1.properties["$experiment_version"] as? Int) == 1
             expect(exposure1.properties["$execution_version"] as? Int) == 1
+            expect(exposure1.internalProperties["$config_last_modified_at"] as? String) == "Tue, 01 Jan 2000 00:00:00 GMT"
 
             expect(events[2]).to(beAnInstanceOf(UserEvents.Exposure.self))
             let exposure2 = events[2] as! UserEvents.Exposure
@@ -93,10 +94,11 @@ class DefaultUserEventFactorySpecs: QuickSpec {
             expect(exposure2.properties["$targetingRootId"] as? Int64) == 1
             expect(exposure2.properties["$experiment_version"] as? Int) == 2
             expect(exposure2.properties["$execution_version"] as? Int) == 3
+            expect(exposure1.internalProperties["$config_last_modified_at"] as? String) == "Tue, 01 Jan 2000 00:00:00 GMT"
         }
 
         it("create in-app message events") {
-            let sut = DefaultUserEventFactory(clock: ClockStub())
+            let sut = DefaultUserEventFactory(workspaceFetcher: WorkspaceFetcherStub(), clock: ClockStub())
 
             let context = Evaluators.context()
             let evaluation1 = experimentEvaluation(reason: DecisionReason.TRAFFIC_ALLOCATED, experiment: experiment(id: 1), variationId: 42, variationKey: "B")
@@ -127,6 +129,7 @@ class DefaultUserEventFactorySpecs: QuickSpec {
             expect(exposure1.properties["$targetingRootId"] as? Int64) == 1
             expect(exposure1.properties["$experiment_version"] as? Int) == 1
             expect(exposure1.properties["$execution_version"] as? Int) == 1
+            expect(exposure1.internalProperties["$config_last_modified_at"] as? String) == "Tue, 01 Jan 2000 00:00:00 GMT"
         }
     }
 
@@ -141,6 +144,14 @@ class DefaultUserEventFactorySpecs: QuickSpec {
 
         func tick() -> UInt64 {
             42
+        }
+    }
+    
+    class WorkspaceFetcherStub: WorkspaceFetcher {
+        var lastModified: String? = "Tue, 01 Jan 2000 00:00:00 GMT"
+        
+        func fetch() -> Workspace? {
+            MockWorkspace()
         }
     }
 }

--- a/Tests/HackleTests/Core/Event/UserEventSpecs.swift
+++ b/Tests/HackleTests/Core/Event/UserEventSpecs.swift
@@ -10,7 +10,7 @@ class UserEventSpecs: QuickSpec {
                 let parameterConfiguration = ParameterConfigurationEntity(id: 42, parameters: [:])
                 let evaluation = ExperimentEvaluation(reason: DecisionReason.TRAFFIC_ALLOCATED, targetEvaluations: [], experiment: experiment(), variationId: 42, variationKey: "A", config: parameterConfiguration)
                 let user = HackleUser.of(userId: "test_id")
-                let event = UserEvents.exposure(user: user, evaluation: evaluation, properties: ["a": "1"], timestamp: Date(timeIntervalSince1970: 42))
+                let event = UserEvents.exposure(user: user, evaluation: evaluation, properties: ["a": "1"], internalProperties: ["internal": "b"], timestamp: Date(timeIntervalSince1970: 42))
                 let newUser = HackleUser.of(userId: "new")
                 let actual = event.with(user: newUser)
 
@@ -23,6 +23,7 @@ class UserEventSpecs: QuickSpec {
                 expect(exposureEvent.timestamp) == event.timestamp
                 expect(exposureEvent.decisionReason) == event.decisionReason
                 expect(exposureEvent.properties["a"]).to(be("1"))
+                expect(exposureEvent.internalProperties["internal"]).to(be("b"))
             }
         }
 
@@ -31,7 +32,7 @@ class UserEventSpecs: QuickSpec {
                 let parameter = RemoteConfigParameter(id: 42, key: "key", type: .string, identifierType: "$id", targetRules: [], defaultValue: RemoteConfigParameter.Value(id: 43, rawValue: HackleValue.string("dv")))
                 let user = HackleUser.of(userId: "id")
                 let evaluation = RemoteConfigEvaluation(reason: DecisionReason.DEFAULT_RULE, targetEvaluations: [], parameter: parameter, valueId: 42, value: .string("42"), properties: ["1": "2"])
-                let event = UserEvents.remoteConfig(user: user, evaluation: evaluation, properties: ["1": "2"], timestamp: Date(timeIntervalSince1970: 42))
+                let event = UserEvents.remoteConfig(user: user, evaluation: evaluation, properties: ["1": "2"], internalProperties: ["internal": "a"], timestamp: Date(timeIntervalSince1970: 42))
                 let newUser = HackleUser.of(userId: "new")
                 let actual = event.with(user: newUser)
                 let remoteConfigEvent = actual as! UserEvents.RemoteConfig
@@ -41,6 +42,7 @@ class UserEventSpecs: QuickSpec {
                 expect(remoteConfigEvent.valueId) == 42
                 expect(remoteConfigEvent.decisionReason) == DecisionReason.DEFAULT_RULE
                 expect(remoteConfigEvent.properties["1"] as? String) == "2"
+                expect(remoteConfigEvent.internalProperties["internal"] as? String) == "a"
             }
         }
     }

--- a/Tests/HackleTests/Core/Event/UserEventsTestExt.swift
+++ b/Tests/HackleTests/Core/Event/UserEventsTestExt.swift
@@ -29,6 +29,7 @@ extension UserEvents {
             user: HackleUser.builder().identifier(.id, "user").build(),
             evaluation: experimentEvaluation(),
             properties: [:],
+            internalProperties: [:],
             timestamp: Date()
         )
     }

--- a/Tests/HackleTests/Core/Model/InAppMessageTestExt.swift
+++ b/Tests/HackleTests/Core/Model/InAppMessageTestExt.swift
@@ -187,10 +187,10 @@ extension InAppMessage {
         inAppMessage: InAppMessage = .create(),
         message: InAppMessage.Message = InAppMessage.message(),
         user: HackleUser = HackleUser.builder().identifier(.id, "user").build(),
-        eventInsertId: String = UUID().uuidString.lowercased(),
+        triggerEventId: String = UUID().uuidString.lowercased(),
         properties: [String: Any] = [:],
         decisionReason: String = DecisionReason.DEFAULT_RULE
     ) -> InAppMessagePresentationContext {
-        InAppMessagePresentationContext(inAppMessage: inAppMessage, message: message, user: user, properties: properties, eventInsertId: eventInsertId, decisionReasion: decisionReason)
+        InAppMessagePresentationContext(inAppMessage: inAppMessage, message: message, user: user, properties: properties, triggerEventId: triggerEventId, decisionReasion: decisionReason)
     }
 }

--- a/Tests/HackleTests/Core/Model/InAppMessageTestExt.swift
+++ b/Tests/HackleTests/Core/Model/InAppMessageTestExt.swift
@@ -187,9 +187,10 @@ extension InAppMessage {
         inAppMessage: InAppMessage = .create(),
         message: InAppMessage.Message = InAppMessage.message(),
         user: HackleUser = HackleUser.builder().identifier(.id, "user").build(),
+        eventInsertId: String = UUID().uuidString.lowercased(),
         properties: [String: Any] = [:],
         decisionReason: String = DecisionReason.DEFAULT_RULE
     ) -> InAppMessagePresentationContext {
-        InAppMessagePresentationContext(inAppMessage: inAppMessage, message: message, user: user, properties: properties, decisionReasion: decisionReason)
+        InAppMessagePresentationContext(inAppMessage: inAppMessage, message: message, user: user, properties: properties, eventInsertId: eventInsertId, decisionReasion: decisionReason)
     }
 }

--- a/Tests/HackleTests/Core/Workspace/ResourcesWorkspaceFetcher.swift
+++ b/Tests/HackleTests/Core/Workspace/ResourcesWorkspaceFetcher.swift
@@ -10,7 +10,7 @@ import Foundation
 
 
 class ResourcesWorkspaceFetcher: WorkspaceFetcher {
-
+    var lastModified: String?
     private let workspace: Workspace
 
     init(fileName: String) {

--- a/Tests/HackleTests/Mock/MockUserEvent.swift
+++ b/Tests/HackleTests/Mock/MockUserEvent.swift
@@ -10,17 +10,20 @@ class MockUserEvent: UserEvent {
     var type: UserEventType
     var user: HackleUser
     var timestamp: Date
+    var internalProperties: [String : Any]
 
     init(
         insertId: String = UUID().uuidString.lowercased(),
         user: HackleUser = HackleUser.builder().identifier(.id, "user").build(),
         timestamp: Date = Date(),
-        type: UserEventType = .exposure
+        type: UserEventType = .exposure,
+        internalProperties: [String: Any] = [:]
     ) {
         self.insertId = insertId
         self.type = type
         self.user = user
         self.timestamp = timestamp
+        self.internalProperties = internalProperties
     }
 
     func with(user: HackleUser) -> UserEvent {

--- a/Tests/HackleTests/Mock/MockWorkspaceFetcher.swift
+++ b/Tests/HackleTests/Mock/MockWorkspaceFetcher.swift
@@ -9,8 +9,9 @@ import Mockery
 @testable import Hackle
 
 class MockWorkspaceFetcher: Mock, WorkspaceFetcher {
-
+    var lastModified: String?
     lazy var fetchMock = MockFunction(self, fetch)
+    
 
     func fetch() -> Workspace? {
         call(fetchMock, args: ())


### PR DESCRIPTION
## 개요
internal propertise를 추가했습니다.

## 작업내용
### UserEvent에 internalProperties를 추가했습니다.
- inAppMessage Track 이벤트에 `$trigger_event_insert_id`를 추가했습니다.
- Exposure와 RemoteConfig 이벤트에 `$config_last_modified_at`를 추가했습니다.

### WorkspaceFetcher protocol에 `lastModified`를 추가했습니다.

### 기타 수정사항
- inAppMessage close track 이벤트가 다른 inAppMesage track 이벤트와 동일하게 프로퍼티를 처리하도록 수정했습니다.

## 참고
- track 이벤트는 기존에 internalProperties를 수집하고 있어 `$trigger_event_insert_id`가 수집되는 것을 확인했습니다.