### PR TITLE
fix test for swift 6 2 compatibility

### DIFF
--- a/Hackle.xcodeproj/project.pbxproj
+++ b/Hackle.xcodeproj/project.pbxproj
@@ -583,7 +583,7 @@
 		EEA7FCC12C04AE550004F858 /* LifecyclePublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEA7FCC02C04AE550004F858 /* LifecyclePublisher.swift */; };
 		EEA8BD0A26ECFCAC007230D9 /* Quick in Frameworks */ = {isa = PBXBuildFile; productRef = EE67F86425828DC8006CD00A /* Quick */; };
 		EEA8BD0B26ECFCAC007230D9 /* Nimble in Frameworks */ = {isa = PBXBuildFile; productRef = EE67F86B25828DE4006CD00A /* Nimble */; };
-		EEA8BD0C26ECFCAC007230D9 /* Mockery in Frameworks */ = {isa = PBXBuildFile; productRef = EE67F87225828DFF006CD00A /* Mockery */; };
+		EEA8BD0C26ECFCAC007230D9 /* MockingKit in Frameworks */ = {isa = PBXBuildFile; productRef = EE67F87225828DFF006CD00A /* MockingKit */; };
 		EEAC3F2D2B9D54DB00DC498E /* PushPlatformType.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEAC3F2C2B9D54DB00DC498E /* PushPlatformType.swift */; };
 		EEAC3F2F2B9D54E000DC498E /* PushProviderType.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEAC3F2E2B9D54E000DC498E /* PushProviderType.swift */; };
 		EEAC3F312B9D54E600DC498E /* PushTokenRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEAC3F302B9D54E600DC498E /* PushTokenRegistry.swift */; };
@@ -1330,7 +1330,7 @@
 			buildActionMask = 0;
 			files = (
 				EEA8BD0B26ECFCAC007230D9 /* Nimble in Frameworks */,
-				EEA8BD0C26ECFCAC007230D9 /* Mockery in Frameworks */,
+				EEA8BD0C26ECFCAC007230D9 /* MockingKit in Frameworks */,
 				EEA8BD0A26ECFCAC007230D9 /* Quick in Frameworks */,
 				OBJ_43 /* Hackle.framework in Frameworks */,
 			);
@@ -3296,7 +3296,7 @@
 			packageProductDependencies = (
 				EE67F86425828DC8006CD00A /* Quick */,
 				EE67F86B25828DE4006CD00A /* Nimble */,
-				EE67F87225828DFF006CD00A /* Mockery */,
+				EE67F87225828DFF006CD00A /* MockingKit */,
 			);
 			productName = HackleTests;
 			productReference = "Hackle::HackleTests::Product" /* HackleTests.xctest */;
@@ -3327,7 +3327,7 @@
 			packageReferences = (
 				EE67F86325828DC8006CD00A /* XCRemoteSwiftPackageReference "Quick" */,
 				EE67F86A25828DE4006CD00A /* XCRemoteSwiftPackageReference "Nimble" */,
-				EE67F87125828DFF006CD00A /* XCRemoteSwiftPackageReference "Mockery" */,
+				EE67F87125828DFF006CD00A /* XCRemoteSwiftPackageReference "MockingKit" */,
 			);
 			productRefGroup = OBJ_14 /* Products */;
 			projectDirPath = "";
@@ -4303,12 +4303,12 @@
 				minimumVersion = 9.0.0;
 			};
 		};
-		EE67F87125828DFF006CD00A /* XCRemoteSwiftPackageReference "Mockery" */ = {
+		EE67F87125828DFF006CD00A /* XCRemoteSwiftPackageReference "MockingKit" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/danielsaidi/Mockery.git";
+			repositoryURL = "https://github.com/danielsaidi/MockingKit.git";
 			requirement = {
 				kind = exactVersion;
-				version = 0.7.0;
+				version = 1.5.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
@@ -4324,10 +4324,10 @@
 			package = EE67F86A25828DE4006CD00A /* XCRemoteSwiftPackageReference "Nimble" */;
 			productName = Nimble;
 		};
-		EE67F87225828DFF006CD00A /* Mockery */ = {
+		EE67F87225828DFF006CD00A /* MockingKit */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = EE67F87125828DFF006CD00A /* XCRemoteSwiftPackageReference "Mockery" */;
-			productName = Mockery;
+			package = EE67F87125828DFF006CD00A /* XCRemoteSwiftPackageReference "MockingKit" */;
+			productName = MockingKit;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/mattgallagher/CwlCatchException.git",
         "state": {
           "branch": null,
-          "revision": "35f9e770f54ce62dd8526470f14c6e137cef3eea",
-          "version": "2.1.1"
+          "revision": "07b2ba21d361c223e25e3c1e924288742923f08c",
+          "version": "2.2.1"
         }
       },
       {
@@ -15,17 +15,17 @@
         "repositoryURL": "https://github.com/mattgallagher/CwlPreconditionTesting.git",
         "state": {
           "branch": null,
-          "revision": "c21f7bab5ca8eee0a9998bbd17ca1d0eb45d4688",
-          "version": "2.1.0"
+          "revision": "0139c665ebb45e6a9fbdb68aabfd7c39f3fe0071",
+          "version": "2.2.2"
         }
       },
       {
-        "package": "Mockery",
-        "repositoryURL": "https://github.com/danielsaidi/Mockery.git",
+        "package": "MockingKit",
+        "repositoryURL": "https://github.com/danielsaidi/MockingKit.git",
         "state": {
           "branch": null,
-          "revision": "bee41ba4c96d2d4f31129744a1dadbbf2f50a0f1",
-          "version": "0.7.0"
+          "revision": "a1096bb9b149b70147e6fb8294f720989edf72ae",
+          "version": "1.5.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/Quick/Quick.git", .upToNextMinor(from: "3.0.0")),
         .package(url: "https://github.com/Quick/Nimble.git", .upToNextMinor(from: "9.0.0")),
-        .package(url: "https://github.com/danielsaidi/Mockery.git", from: "0.7.0"),
+        .package(url: "https://github.com/danielsaidi/MockingKit.git", from: "1.5.0"),
     ],
     targets: [
         .target(
@@ -45,7 +45,7 @@ let package = Package(
         ),
         .testTarget(
             name: "HackleTests",
-            dependencies: ["Hackle", "Quick", "Nimble", "Mockery"],
+            dependencies: ["Hackle", "Quick", "Nimble", "MockingKit"],
             resources: [
                 .copy("Resources")
             ]

--- a/Tests/HackleTests/Common/HackleNotificationClickActionTypeSpecs.swift
+++ b/Tests/HackleTests/Common/HackleNotificationClickActionTypeSpecs.swift
@@ -8,7 +8,7 @@
 import Foundation
 import Quick
 import Nimble
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class HackleNotificationClickActionTypeSpecs: QuickSpec {

--- a/Tests/HackleTests/Common/PropertiesBuilderSpecs.swift
+++ b/Tests/HackleTests/Common/PropertiesBuilderSpecs.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Quick
 import Nimble
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class PropertiesBuilderSpecs: QuickSpec {

--- a/Tests/HackleTests/Common/UserSpecs.swift
+++ b/Tests/HackleTests/Common/UserSpecs.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Quick
 import Nimble
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class UserSpecs: QuickSpec {

--- a/Tests/HackleTests/Core/Database/MockEventRepository.swift
+++ b/Tests/HackleTests/Core/Database/MockEventRepository.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Quick
 import Nimble
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class MockEventRepository: Mock, EventRepository {

--- a/Tests/HackleTests/Core/Database/MockSQLiteEventRepository.swift
+++ b/Tests/HackleTests/Core/Database/MockSQLiteEventRepository.swift
@@ -8,7 +8,7 @@
 import Foundation
 import Quick
 import Nimble
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class MockSQLiteEventRepository: SQLiteEventRepository {

--- a/Tests/HackleTests/Core/DevTools/MockDevToolsAPI.swift
+++ b/Tests/HackleTests/Core/DevTools/MockDevToolsAPI.swift
@@ -1,5 +1,5 @@
 import Foundation
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class MockDevToolsAPI: Mock, DevToolsAPI {

--- a/Tests/HackleTests/Core/Engagement/MockEngagementListener.swift
+++ b/Tests/HackleTests/Core/Engagement/MockEngagementListener.swift
@@ -1,5 +1,5 @@
 import Foundation
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class MockEngagementListener: Mock, EngagementListener {

--- a/Tests/HackleTests/Core/Evaluation/Action/MockActionResolver.swift
+++ b/Tests/HackleTests/Core/Evaluation/Action/MockActionResolver.swift
@@ -1,5 +1,5 @@
 import Foundation
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class MockActionResolver: Mock, ActionResolver {

--- a/Tests/HackleTests/Core/Evaluation/Bucket/MockBucketer.swift
+++ b/Tests/HackleTests/Core/Evaluation/Bucket/MockBucketer.swift
@@ -3,7 +3,7 @@
 //
 
 import Foundation
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class MockBucketer: Mock, Bucketer {

--- a/Tests/HackleTests/Core/Evaluation/Bucket/MockSlotNumberCalculator.swift
+++ b/Tests/HackleTests/Core/Evaluation/Bucket/MockSlotNumberCalculator.swift
@@ -3,7 +3,7 @@
 //
 
 import Foundation
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class MockSlotNumberCalculator: Mock, SlotNumberCalculator {

--- a/Tests/HackleTests/Core/Evaluation/Container/DefaultContainerResolverSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Container/DefaultContainerResolverSpecs.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Quick
 import Nimble
-import Mockery
+import MockingKit
 @testable import Hackle
 
 

--- a/Tests/HackleTests/Core/Evaluation/Container/MockContainerResolver.swift
+++ b/Tests/HackleTests/Core/Evaluation/Container/MockContainerResolver.swift
@@ -1,5 +1,5 @@
 import Foundation
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class MockContainerResolver: Mock, ContainerResolver {

--- a/Tests/HackleTests/Core/Evaluation/Evaluator/DelegatingEvaluatorSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Evaluator/DelegatingEvaluatorSpecs.swift
@@ -8,7 +8,7 @@
 import Foundation
 import Quick
 import Nimble
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class DelegatingEvaluatorSpecs: QuickSpec {

--- a/Tests/HackleTests/Core/Evaluation/Evaluator/Experiment/ExperimentEvaluatorSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Evaluator/Experiment/ExperimentEvaluatorSpecs.swift
@@ -8,7 +8,7 @@
 import Foundation
 import Quick
 import Nimble
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class ExperimentEvaluatorSpecs: QuickSpec {

--- a/Tests/HackleTests/Core/Evaluation/Evaluator/Experiment/MockExperimentFlowFactory.swift
+++ b/Tests/HackleTests/Core/Evaluation/Evaluator/Experiment/MockExperimentFlowFactory.swift
@@ -1,5 +1,5 @@
 import Foundation
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class MockExperimentFlowFactory: Mock, ExperimentFlowFactory {

--- a/Tests/HackleTests/Core/Evaluation/Evaluator/InAppMessage/Eligibility/MockInAppMessageEligibilityFlowFactory.swift
+++ b/Tests/HackleTests/Core/Evaluation/Evaluator/InAppMessage/Eligibility/MockInAppMessageEligibilityFlowFactory.swift
@@ -1,5 +1,5 @@
 import Foundation
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class MockInAppMessageEligibilityFlowFactory: Mock, InAppMessageEligibilityFlowFactory {

--- a/Tests/HackleTests/Core/Evaluation/Evaluator/MockEvaluationEventRecorder.swift
+++ b/Tests/HackleTests/Core/Evaluation/Evaluator/MockEvaluationEventRecorder.swift
@@ -1,5 +1,5 @@
 import Foundation
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class MockEvaluationEventRecorder: Mock, EvaluationEventRecorder {

--- a/Tests/HackleTests/Core/Evaluation/Evaluator/MockEvaluator.swift
+++ b/Tests/HackleTests/Core/Evaluation/Evaluator/MockEvaluator.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Quick
 import Nimble
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class MockEvaluator: Evaluator {

--- a/Tests/HackleTests/Core/Evaluation/Evaluator/RemoteConfig/RemoteConfigEvaluatorSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Evaluator/RemoteConfig/RemoteConfigEvaluatorSpecs.swift
@@ -8,7 +8,7 @@
 import Foundation
 import Quick
 import Nimble
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class RemoteConfigEvaluatorSpecs: QuickSpec {

--- a/Tests/HackleTests/Core/Evaluation/Flow/EvaluationFlowTestExt.swift
+++ b/Tests/HackleTests/Core/Evaluation/Flow/EvaluationFlowTestExt.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Quick
 import Nimble
-import Mockery
+import MockingKit
 @testable import Hackle
 
 

--- a/Tests/HackleTests/Core/Evaluation/Flow/MockFlowEvaluator.swift
+++ b/Tests/HackleTests/Core/Evaluation/Flow/MockFlowEvaluator.swift
@@ -1,5 +1,5 @@
 import Foundation
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class FlowEvaluatorStub: FlowEvaluator {

--- a/Tests/HackleTests/Core/Evaluation/Match/AbTestConditionMatcherSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Match/AbTestConditionMatcherSpecs.swift
@@ -8,7 +8,7 @@
 import Foundation
 import Quick
 import Nimble
-import Mockery
+import MockingKit
 @testable import Hackle
 
 

--- a/Tests/HackleTests/Core/Evaluation/Match/DefaultConditionMatcherFactorySpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Match/DefaultConditionMatcherFactorySpecs.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Quick
 import Nimble
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class DefaultConditionMatcherFactorySpecs: QuickSpec {

--- a/Tests/HackleTests/Core/Evaluation/Match/DefaultTargetMatcherSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Match/DefaultTargetMatcherSpecs.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Quick
 import Nimble
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class DefaultTargetMatcherSpecs: QuickSpec {

--- a/Tests/HackleTests/Core/Evaluation/Match/DefaultUserValueResolverSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Match/DefaultUserValueResolverSpecs.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Quick
 import Nimble
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class DefaultUserValueResolverSpecs: QuickSpec {

--- a/Tests/HackleTests/Core/Evaluation/Match/DefaultValueOperatorMatcherSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Match/DefaultValueOperatorMatcherSpecs.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Quick
 import Nimble
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class DefaultValueOperatorMatcherSpecs: QuickSpec {

--- a/Tests/HackleTests/Core/Evaluation/Match/ExperimentConditionMatcherSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Match/ExperimentConditionMatcherSpecs.swift
@@ -8,7 +8,7 @@
 import Foundation
 import Quick
 import Nimble
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class ExperimentConditionMatcherSpecs: QuickSpec {

--- a/Tests/HackleTests/Core/Evaluation/Match/FeatureFlagConditionMatcherSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Match/FeatureFlagConditionMatcherSpecs.swift
@@ -8,7 +8,7 @@
 import Foundation
 import Quick
 import Nimble
-import Mockery
+import MockingKit
 @testable import Hackle
 
 

--- a/Tests/HackleTests/Core/Evaluation/Match/MockConditionMatcher.swift
+++ b/Tests/HackleTests/Core/Evaluation/Match/MockConditionMatcher.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Quick
 import Nimble
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class MockConditionMatcher: ConditionMatcher {

--- a/Tests/HackleTests/Core/Evaluation/Match/MockConditionMatcherFactory.swift
+++ b/Tests/HackleTests/Core/Evaluation/Match/MockConditionMatcherFactory.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Quick
 import Nimble
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class MockConditionMatcherFactory: ConditionMatcherFactory {

--- a/Tests/HackleTests/Core/Evaluation/Match/MockExperimentMatcher.swift
+++ b/Tests/HackleTests/Core/Evaluation/Match/MockExperimentMatcher.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class MockExperimentMatcher: Mock, ExperimentMatcher {

--- a/Tests/HackleTests/Core/Evaluation/Match/MockSegmentMatcher.swift
+++ b/Tests/HackleTests/Core/Evaluation/Match/MockSegmentMatcher.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Quick
 import Nimble
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class MockSegmentMatcher: Mock, SegmentMatcher {

--- a/Tests/HackleTests/Core/Evaluation/Match/MockTargetMatcher.swift
+++ b/Tests/HackleTests/Core/Evaluation/Match/MockTargetMatcher.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Quick
 import Nimble
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class MockTargetMatcher: Mock, TargetMatcher {

--- a/Tests/HackleTests/Core/Evaluation/Match/MockUserValueResolver.swift
+++ b/Tests/HackleTests/Core/Evaluation/Match/MockUserValueResolver.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Quick
 import Nimble
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class MockUserValueResolver: Mock, UserValueResolver {

--- a/Tests/HackleTests/Core/Evaluation/Match/MockValueOperatorMatcher.swift
+++ b/Tests/HackleTests/Core/Evaluation/Match/MockValueOperatorMatcher.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Quick
 import Nimble
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class MockValueOperatorMatcher: Mock, ValueOperatorMatcher {

--- a/Tests/HackleTests/Core/Evaluation/Match/OperatorMatcherSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Match/OperatorMatcherSpecs.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Quick
 import Nimble
-import Mockery
+import MockingKit
 @testable import Hackle
 
 

--- a/Tests/HackleTests/Core/Evaluation/Match/UserConditionMatcherSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Match/UserConditionMatcherSpecs.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Quick
 import Nimble
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class UserConditionMatcherSpecs: QuickSpec {

--- a/Tests/HackleTests/Core/Evaluation/Match/ValueMatcherFactorySpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Match/ValueMatcherFactorySpecs.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Quick
 import Nimble
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class ValueMatcherFactorySpecs: QuickSpec {

--- a/Tests/HackleTests/Core/Evaluation/Match/ValueMatcherSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Match/ValueMatcherSpecs.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Quick
 import Nimble
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class ValueMatcherSpecs: QuickSpec {

--- a/Tests/HackleTests/Core/Evaluation/Match/VersionSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Match/VersionSpecs.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Quick
 import Nimble
-import Mockery
+import MockingKit
 @testable import Hackle
 
 

--- a/Tests/HackleTests/Core/Evaluation/Target/DefaultExperimentTargetDeterminerSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Target/DefaultExperimentTargetDeterminerSpecs.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Quick
 import Nimble
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class DefaultExperimentTargetDeterminerSpecs: QuickSpec {

--- a/Tests/HackleTests/Core/Evaluation/Target/DefaultExperimentTargetRuleDeterminerSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Target/DefaultExperimentTargetRuleDeterminerSpecs.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Quick
 import Nimble
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class DefaultTargetRuleDeterminerSpecs: QuickSpec {

--- a/Tests/HackleTests/Core/Evaluation/Target/DefaultOverrideResolverSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Target/DefaultOverrideResolverSpecs.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Quick
 import Nimble
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class DefaultOverrideResolverSpecs: QuickSpec {

--- a/Tests/HackleTests/Core/Evaluation/Target/DefaultRemoteConfigTargetRuleDeterminerSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Target/DefaultRemoteConfigTargetRuleDeterminerSpecs.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Quick
 import Nimble
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class DefaultRemoteConfigTargetRuleDeterminerSpecs: QuickSpec {

--- a/Tests/HackleTests/Core/Evaluation/Target/DefaultRemoteConfigTargetRuleMatcherSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Target/DefaultRemoteConfigTargetRuleMatcherSpecs.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Quick
 import Nimble
-import Mockery
+import MockingKit
 @testable import Hackle
 
 

--- a/Tests/HackleTests/Core/Evaluation/Target/DelegatingManualOverrideStorageSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Target/DelegatingManualOverrideStorageSpecs.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Quick
 import Nimble
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class DelegatingManualOverrideStorageSpecs: QuickSpec {

--- a/Tests/HackleTests/Core/Evaluation/Target/MockExperimentTargetDeterminer.swift
+++ b/Tests/HackleTests/Core/Evaluation/Target/MockExperimentTargetDeterminer.swift
@@ -1,5 +1,5 @@
 import Foundation
-import Mockery
+import MockingKit
 @testable import Hackle
 
 

--- a/Tests/HackleTests/Core/Evaluation/Target/MockExperimentTargetRuleDeterminer.swift
+++ b/Tests/HackleTests/Core/Evaluation/Target/MockExperimentTargetRuleDeterminer.swift
@@ -1,5 +1,5 @@
 import Foundation
-import Mockery
+import MockingKit
 @testable import Hackle
 
 

--- a/Tests/HackleTests/Core/Evaluation/Target/MockOverrideResolver.swift
+++ b/Tests/HackleTests/Core/Evaluation/Target/MockOverrideResolver.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Quick
 import Nimble
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class MockOverrideResolver: Mock, OverrideResolver {

--- a/Tests/HackleTests/Core/Evaluation/Target/MockRemoteConfigTargetRuleDeterminer.swift
+++ b/Tests/HackleTests/Core/Evaluation/Target/MockRemoteConfigTargetRuleDeterminer.swift
@@ -1,5 +1,5 @@
 import Foundation
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class MockRemoteConfigTargetRuleDeterminer: Mock, RemoteConfigTargetRuleDeterminer {

--- a/Tests/HackleTests/Core/Evaluation/Target/MockRemoteConfigTargetRuleMatcher.swift
+++ b/Tests/HackleTests/Core/Evaluation/Target/MockRemoteConfigTargetRuleMatcher.swift
@@ -1,5 +1,5 @@
 import Foundation
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class MockRemoteConfigTargetRuleMatcher: Mock, RemoteConfigTargetRuleMatcher {

--- a/Tests/HackleTests/Core/Event/Dedup/MockUserEventDedupDeterminer.swift
+++ b/Tests/HackleTests/Core/Event/Dedup/MockUserEventDedupDeterminer.swift
@@ -1,5 +1,5 @@
 import Foundation
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class MockUserEventDedupDeterminer: Mock, UserEventDedupDeterminer {

--- a/Tests/HackleTests/Core/Event/DefaultUserEventFactorySpecs.swift
+++ b/Tests/HackleTests/Core/Event/DefaultUserEventFactorySpecs.swift
@@ -8,7 +8,7 @@
 import Foundation
 import Quick
 import Nimble
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class DefaultUserEventFactorySpecs: QuickSpec {

--- a/Tests/HackleTests/Core/Event/DefaultUserEventProcessorSpec.swift
+++ b/Tests/HackleTests/Core/Event/DefaultUserEventProcessorSpec.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Quick
 import Nimble
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class DefaultUserEventProcessorSpec: QuickSpec {

--- a/Tests/HackleTests/Core/Event/MockUserEventBackoffController.swift
+++ b/Tests/HackleTests/Core/Event/MockUserEventBackoffController.swift
@@ -5,7 +5,7 @@
 //  Created by sungwoo.yeo on 7/11/25.
 //
 
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class MockUserEventBackoffController: Mock, UserEventBackoffController {

--- a/Tests/HackleTests/Core/HackleCoreStub.swift
+++ b/Tests/HackleTests/Core/HackleCoreStub.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class HackleCoreStub: HackleCore {

--- a/Tests/HackleTests/Core/InAppMessage/Delay/MockInAppMessageDelayManager.swift
+++ b/Tests/HackleTests/Core/InAppMessage/Delay/MockInAppMessageDelayManager.swift
@@ -1,5 +1,5 @@
 import Foundation
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class MockInAppMessageDelayManager: Mock, InAppMessageDelayManager {

--- a/Tests/HackleTests/Core/InAppMessage/Delay/MockInAppMessageDelayScheduler.swift
+++ b/Tests/HackleTests/Core/InAppMessage/Delay/MockInAppMessageDelayScheduler.swift
@@ -1,5 +1,5 @@
 import Foundation
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class MockInAppMessageDelayScheduler: Mock, InAppMessageDelayScheduler {

--- a/Tests/HackleTests/Core/InAppMessage/Deliver/MockInAppMessageDeliverProcessor.swift
+++ b/Tests/HackleTests/Core/InAppMessage/Deliver/MockInAppMessageDeliverProcessor.swift
@@ -1,5 +1,5 @@
 import Foundation
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class MockInAppMessageDeliverProcessor: Mock, InAppMessageDeliverProcessor {

--- a/Tests/HackleTests/Core/InAppMessage/Evaluation/MockInAppMessageEvaluateProcessor.swift
+++ b/Tests/HackleTests/Core/InAppMessage/Evaluation/MockInAppMessageEvaluateProcessor.swift
@@ -1,5 +1,5 @@
 import Foundation
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class MockInAppMessageEvaluateProcessor: Mock, InAppMessageEvaluateProcessor {

--- a/Tests/HackleTests/Core/InAppMessage/Evaluation/MockInAppMessageIdentifierChecker.swift
+++ b/Tests/HackleTests/Core/InAppMessage/Evaluation/MockInAppMessageIdentifierChecker.swift
@@ -1,5 +1,5 @@
 import Foundation
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class MockInAppMessageIdentifierChecker: Mock, InAppMessageIdentifierChecker {

--- a/Tests/HackleTests/Core/InAppMessage/Evaluation/MockInAppMessageLayoutResolver.swift
+++ b/Tests/HackleTests/Core/InAppMessage/Evaluation/MockInAppMessageLayoutResolver.swift
@@ -1,5 +1,5 @@
 import Foundation
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class MockInAppMessageLayoutResolver: Mock, InAppMessageLayoutResolver {

--- a/Tests/HackleTests/Core/InAppMessage/Present/MockInAppMessagePresentProcessor.swift
+++ b/Tests/HackleTests/Core/InAppMessage/Present/MockInAppMessagePresentProcessor.swift
@@ -1,5 +1,5 @@
 import Foundation
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class MockInAppMessagePresentProcessor: Mock, InAppMessagePresentProcessor {

--- a/Tests/HackleTests/Core/InAppMessage/Present/Presentation/MockInAppMessagePresenter.swift
+++ b/Tests/HackleTests/Core/InAppMessage/Present/Presentation/MockInAppMessagePresenter.swift
@@ -1,5 +1,5 @@
 import Foundation
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class MockInAppMessagePresenter: Mock, InAppMessagePresenter {

--- a/Tests/HackleTests/Core/InAppMessage/Present/Record/MockInAppMessageRecorder.swift
+++ b/Tests/HackleTests/Core/InAppMessage/Present/Record/MockInAppMessageRecorder.swift
@@ -1,5 +1,5 @@
 import Foundation
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class MockInAppMessageRecorder: Mock, InAppMessageRecorder {

--- a/Tests/HackleTests/Core/InAppMessage/Reset/MockInAppMessageResetProcessor.swift
+++ b/Tests/HackleTests/Core/InAppMessage/Reset/MockInAppMessageResetProcessor.swift
@@ -1,5 +1,5 @@
 import Foundation
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class MockInAppMessageResetProcessor: Mock, InAppMessageResetProcessor {

--- a/Tests/HackleTests/Core/InAppMessage/Schedule/Action/MockInAppMessageScheduleActionDeterminer.swift
+++ b/Tests/HackleTests/Core/InAppMessage/Schedule/Action/MockInAppMessageScheduleActionDeterminer.swift
@@ -1,5 +1,5 @@
 import Foundation
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class MockInAppMessageScheduleActionDeterminer: Mock, InAppMessageScheduleActionDeterminer {

--- a/Tests/HackleTests/Core/InAppMessage/Schedule/MockInAppMessageScheduleListener.swift
+++ b/Tests/HackleTests/Core/InAppMessage/Schedule/MockInAppMessageScheduleListener.swift
@@ -1,5 +1,5 @@
 import Foundation
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class MockInAppMessageScheduleListener: Mock, InAppMessageScheduleListener {

--- a/Tests/HackleTests/Core/InAppMessage/Schedule/MockInAppMessageScheduleProcessor.swift
+++ b/Tests/HackleTests/Core/InAppMessage/Schedule/MockInAppMessageScheduleProcessor.swift
@@ -1,5 +1,5 @@
 import Foundation
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class MockInAppMessageScheduleProcessor: Mock, InAppMessageScheduleProcessor {

--- a/Tests/HackleTests/Core/InAppMessage/Schedule/Scheduler/MockInAppMessageScheduler.swift
+++ b/Tests/HackleTests/Core/InAppMessage/Schedule/Scheduler/MockInAppMessageScheduler.swift
@@ -1,5 +1,5 @@
 import Foundation
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class MockInAppMessageScheduler: Mock, InAppMessageScheduler {

--- a/Tests/HackleTests/Core/InAppMessage/Schedule/Scheduler/MockInAppMessageSchedulerFactory.swift
+++ b/Tests/HackleTests/Core/InAppMessage/Schedule/Scheduler/MockInAppMessageSchedulerFactory.swift
@@ -1,5 +1,5 @@
 import Foundation
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class MockInAppMessageSchedulerFactory: Mock, InAppMessageSchedulerFactory {

--- a/Tests/HackleTests/Core/InAppMessage/Trigger/MockInAppMessageTriggerDeterminer.swift
+++ b/Tests/HackleTests/Core/InAppMessage/Trigger/MockInAppMessageTriggerDeterminer.swift
@@ -1,5 +1,5 @@
 import Foundation
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class MockInAppMessageTriggerDeterminer: Mock, InAppMessageTriggerDeterminer {

--- a/Tests/HackleTests/Core/InAppMessage/Trigger/MockInAppMessageTriggerEventMatcher.swift
+++ b/Tests/HackleTests/Core/InAppMessage/Trigger/MockInAppMessageTriggerEventMatcher.swift
@@ -1,5 +1,5 @@
 import Foundation
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class MockInAppMessageTriggerEventMatcher: Mock, InAppMessageTriggerEventMatcher {

--- a/Tests/HackleTests/Core/InAppMessage/Trigger/MockInAppMessageTriggerHandler.swift
+++ b/Tests/HackleTests/Core/InAppMessage/Trigger/MockInAppMessageTriggerHandler.swift
@@ -1,5 +1,5 @@
 import Foundation
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class MockInAppMessageTriggerHandler: Mock, InAppMessageTriggerHandler {

--- a/Tests/HackleTests/Core/InAppMessage/Trigger/MockInAppMessageTriggerProcessor.swift
+++ b/Tests/HackleTests/Core/InAppMessage/Trigger/MockInAppMessageTriggerProcessor.swift
@@ -1,5 +1,5 @@
 import Foundation
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class MockInAppMessageTriggerProcessor: Mock, InAppMessageTriggerProcessor {

--- a/Tests/HackleTests/Core/Invocator/HackleInvocationSpec.swift
+++ b/Tests/HackleTests/Core/Invocator/HackleInvocationSpec.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Quick
 import Nimble
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class HackleInvocationSpec : QuickSpec {
@@ -101,7 +101,8 @@ class HackleInvocationSpec : QuickSpec {
                     let result = invocation.invoke(string: jsonString)
                     
                     expect(mock.setUserRef.invokations().count) == 1
-                    let arguments = mock.setUserRef.firstInvokation().arguments.0
+                    let firstInvokation = mock.setUserRef.firstInvokation()
+                    let arguments = firstInvokation.arguments.0
                     expect(arguments.id) == "foo"
                     expect(arguments.userId) == "bar"
                     expect(arguments.identifiers).to(equal(["foobar": "foofoo", "foobar2": "barbar"]))
@@ -138,7 +139,8 @@ class HackleInvocationSpec : QuickSpec {
                     let result = invocation.invoke(string: jsonString)
                     
                     expect(mock.setUserIdRef.invokations().count) == 1
-                    expect(mock.setUserIdRef.firstInvokation().arguments.0) == "abcd1234"
+                    let tempInvocation = mock.setUserIdRef.firstInvokation()
+                    expect(tempInvocation.arguments.0) == "abcd1234"
                     
                     let dict = result.jsonObject()!
                     expect(dict["success"] as? Bool) == true
@@ -175,7 +177,8 @@ class HackleInvocationSpec : QuickSpec {
                     let result = invocation.invoke(string: jsonString)
                     
                     expect(mock.setDeviceIdRef.invokations().count) == 1
-                    expect(mock.setDeviceIdRef.firstInvokation().arguments.0) == "abcd1234"
+                    let tempInvocation = mock.setDeviceIdRef.firstInvokation()
+                    expect(tempInvocation.arguments.0) == "abcd1234"
                     
                     let dict = result.jsonObject()!
                     expect(dict["success"] as? Bool) == true
@@ -204,7 +207,8 @@ class HackleInvocationSpec : QuickSpec {
                     let result = invocation.invoke(string: jsonString)
                     
                     expect(mock.updateUserPropertiesRef.invokations().count) == 1
-                    let arguments = mock.updateUserPropertiesRef.firstInvokation().arguments.0.asDictionary()
+                    let firstInvokation = mock.updateUserPropertiesRef.firstInvokation()
+                    let arguments = firstInvokation.arguments.0.asDictionary()
                     let set = arguments[PropertyOperation.set]!
                     expect(set.count) == 1
                     expect(set["foo"] as? String) == "bar"
@@ -247,7 +251,8 @@ class HackleInvocationSpec : QuickSpec {
                     let result = invocation.invoke(string: jsonString)
                     
                     expect(mock.updateUserPropertiesRef.invokations().count) == 1
-                    let arguments = mock.updateUserPropertiesRef.firstInvokation().arguments.0.asDictionary()
+                    let firstInvokation = mock.updateUserPropertiesRef.firstInvokation()
+                    let arguments = firstInvokation.arguments.0.asDictionary()
                     
                     let set = arguments[PropertyOperation.set]!
                     expect(set.count) == 3
@@ -296,7 +301,8 @@ class HackleInvocationSpec : QuickSpec {
                     
                     expect(mock.updatePushSubscriptionsRef.invokations().count) == 1
                     
-                    let arguments = mock.updatePushSubscriptionsRef.firstInvokation().arguments
+                    let firstInvokation = mock.updatePushSubscriptionsRef.firstInvokation()
+                    let arguments = firstInvokation.arguments
                     expect(arguments.0.count) == 4
                     
                     let mockEvent = arguments.0.toEvent(key: "mock")
@@ -320,7 +326,8 @@ class HackleInvocationSpec : QuickSpec {
                     
                     expect(mock.updateSmsSubscriptionsRef.invokations().count) == 1
                     
-                    let arguments = mock.updateSmsSubscriptionsRef.firstInvokation().arguments
+                    let firstInvokation = mock.updateSmsSubscriptionsRef.firstInvokation()
+                    let arguments = firstInvokation.arguments
                     expect(arguments.0.count) == 4
                     
                     let mockEvent = arguments.0.toEvent(key: "mock")
@@ -343,7 +350,8 @@ class HackleInvocationSpec : QuickSpec {
                     
                     expect(mock.updateKakaoSubscriptionsRef.invokations().count) == 1
                     
-                    let arguments = mock.updateKakaoSubscriptionsRef.firstInvokation().arguments
+                    let firstInvokation = mock.updateKakaoSubscriptionsRef.firstInvokation()
+                    let arguments = firstInvokation.arguments
                     expect(arguments.0.count) == 4
                     
                     let mockEvent = arguments.0.toEvent(key: "mock")
@@ -410,7 +418,8 @@ class HackleInvocationSpec : QuickSpec {
                         let result = invocation.invoke(string: jsonString)
                         expect(mock.variationDetailRef.invokations().count) == 1
                         
-                        let arguments = mock.variationDetailRef.firstInvokation().arguments
+                        let firstInvokation = mock.variationDetailRef.firstInvokation()
+                        let arguments = firstInvokation.arguments
                         expect(arguments.0) == 123
                         expect(arguments.1).to(beNil())
                         expect(arguments.2) == "D"
@@ -430,7 +439,8 @@ class HackleInvocationSpec : QuickSpec {
                         let result = invocation.invoke(string: jsonString)
                         expect(mock.variationDetailRef.invokations().count) == 1
                         
-                        let arguments = mock.variationDetailRef.firstInvokation().arguments
+                        let firstInvokation = mock.variationDetailRef.firstInvokation()
+                        let arguments = firstInvokation.arguments
                         expect(arguments.0) == 123
                         expect(arguments.1).to(beNil())
                         expect(arguments.2) == "A"
@@ -455,7 +465,8 @@ class HackleInvocationSpec : QuickSpec {
                         let result = invocation.invoke(string: jsonString)
                         expect(mock.variationDetailRef.invokations().count) == 1
                         
-                        let arguments = mock.variationDetailRef.firstInvokation().arguments
+                        let firstInvokation = mock.variationDetailRef.firstInvokation()
+                        let arguments = firstInvokation.arguments
                         expect(arguments.0) == 123
                         expect(arguments.1?.id) == "abcd1234"
                         expect(arguments.2) == "D"
@@ -478,7 +489,8 @@ class HackleInvocationSpec : QuickSpec {
                         let result = invocation.invoke(string: jsonString)
                         expect(mock.variationDetailRef.invokations().count) == 1
                         
-                        let arguments = mock.variationDetailRef.firstInvokation().arguments
+                        let firstInvokation = mock.variationDetailRef.firstInvokation()
+                        let arguments = firstInvokation.arguments
                         expect(arguments.0) == 123
                         expect(arguments.1?.id) == "abcd1234"
                         expect(arguments.2) == "A"
@@ -503,7 +515,8 @@ class HackleInvocationSpec : QuickSpec {
                         let result = invocation.invoke(string: jsonString)
                         expect(mock.variationDetailRef.invokations().count) == 1
                         
-                        let arguments = mock.variationDetailRef.firstInvokation().arguments
+                        let firstInvokation = mock.variationDetailRef.firstInvokation()
+                        let arguments = firstInvokation.arguments
                         expect(arguments.0) == 123
                         expect(arguments.1?.id) == "foo"
                         expect(arguments.2) == "D"
@@ -526,7 +539,8 @@ class HackleInvocationSpec : QuickSpec {
                         let result = invocation.invoke(string: jsonString)
                         expect(mock.variationDetailRef.invokations().count) == 1
                         
-                        let arguments = mock.variationDetailRef.firstInvokation().arguments
+                        let firstInvokation = mock.variationDetailRef.firstInvokation()
+                        let arguments = firstInvokation.arguments
                         expect(arguments.0) == 123
                         expect(arguments.1?.id) == "foo"
                         expect(arguments.2) == "A"
@@ -563,7 +577,8 @@ class HackleInvocationSpec : QuickSpec {
                         let result = invocation.invoke(string: jsonString)
                         expect(mock.variationDetailRef.invokations().count) == 1
                         
-                        let arguments = mock.variationDetailRef.firstInvokation().arguments
+                        let firstInvokation = mock.variationDetailRef.firstInvokation()
+                        let arguments = firstInvokation.arguments
                         expect(arguments.0) == 123
                         expect(arguments.1).to(beNil())
                         expect(arguments.2) == "D"
@@ -591,7 +606,8 @@ class HackleInvocationSpec : QuickSpec {
                         let result = invocation.invoke(string: jsonString)
                         expect(mock.variationDetailRef.invokations().count) == 1
                         
-                        let arguments = mock.variationDetailRef.firstInvokation().arguments
+                        let firstInvokation = mock.variationDetailRef.firstInvokation()
+                        let arguments = firstInvokation.arguments
                         expect(arguments.0) == 123
                         expect(arguments.1).to(beNil())
                         expect(arguments.2) == "A"
@@ -623,7 +639,8 @@ class HackleInvocationSpec : QuickSpec {
                         let result = invocation.invoke(string: jsonString)
                         expect(mock.variationDetailRef.invokations().count) == 1
                         
-                        let arguments = mock.variationDetailRef.firstInvokation().arguments
+                        let firstInvokation = mock.variationDetailRef.firstInvokation()
+                        let arguments = firstInvokation.arguments
                         expect(arguments.0) == 123
                         expect(arguments.1?.id) == "abcd1234"
                         expect(arguments.2) == "D"
@@ -653,7 +670,8 @@ class HackleInvocationSpec : QuickSpec {
                         let result = invocation.invoke(string: jsonString)
                         expect(mock.variationDetailRef.invokations().count) == 1
                         
-                        let arguments = mock.variationDetailRef.firstInvokation().arguments
+                        let firstInvokation = mock.variationDetailRef.firstInvokation()
+                        let arguments = firstInvokation.arguments
                         expect(arguments.0) == 123
                         expect(arguments.1?.id) == "abcd1234"
                         expect(arguments.2) == "A"
@@ -685,7 +703,8 @@ class HackleInvocationSpec : QuickSpec {
                         let result = invocation.invoke(string: jsonString)
                         expect(mock.variationDetailRef.invokations().count) == 1
                         
-                        let arguments = mock.variationDetailRef.firstInvokation().arguments
+                        let firstInvokation = mock.variationDetailRef.firstInvokation()
+                        let arguments = firstInvokation.arguments
                         expect(arguments.0) == 123
                         expect(arguments.1?.id) == "foo"
                         expect(arguments.2) == "D"
@@ -715,7 +734,8 @@ class HackleInvocationSpec : QuickSpec {
                         let result = invocation.invoke(string: jsonString)
                         expect(mock.variationDetailRef.invokations().count) == 1
                         
-                        let arguments = mock.variationDetailRef.firstInvokation().arguments
+                        let firstInvokation = mock.variationDetailRef.firstInvokation()
+                        let arguments = firstInvokation.arguments
                         expect(arguments.0) == 123
                         expect(arguments.1?.id) == "foo"
                         expect(arguments.2) == "A"
@@ -757,7 +777,8 @@ class HackleInvocationSpec : QuickSpec {
                     let result = invocation.invoke(string: jsonString)
                     expect(mock.featureFlagDetailRef.invokations().count) == 1
                         
-                    let arguments = mock.featureFlagDetailRef.firstInvokation().arguments
+                    let firstInvokation = mock.featureFlagDetailRef.firstInvokation()
+                    let arguments = firstInvokation.arguments
                     expect(arguments.0) == 123
                         
                     let dict = result.jsonObject()!
@@ -778,7 +799,8 @@ class HackleInvocationSpec : QuickSpec {
                     let result = invocation.invoke(string: jsonString)
                     expect(mock.featureFlagDetailRef.invokations().count) == 1
                         
-                    let arguments = mock.featureFlagDetailRef.firstInvokation().arguments
+                    let firstInvokation = mock.featureFlagDetailRef.firstInvokation()
+                    let arguments = firstInvokation.arguments
                     expect(arguments.0) == 123
                     expect(arguments.1?.id) == "abcd1234"
                         
@@ -800,7 +822,8 @@ class HackleInvocationSpec : QuickSpec {
                     let result = invocation.invoke(string: jsonString)
                     expect(mock.featureFlagDetailRef.invokations().count) == 1
                         
-                    let arguments = mock.featureFlagDetailRef.firstInvokation().arguments
+                    let firstInvokation = mock.featureFlagDetailRef.firstInvokation()
+                    let arguments = firstInvokation.arguments
                     expect(arguments.0) == 123
                     expect(arguments.1?.id) == "foo"
 
@@ -834,7 +857,8 @@ class HackleInvocationSpec : QuickSpec {
                     let result = invocation.invoke(string: jsonString)
                     expect(mock.featureFlagDetailRef.invokations().count) == 1
                         
-                    let arguments = mock.featureFlagDetailRef.firstInvokation().arguments
+                    let firstInvokation = mock.featureFlagDetailRef.firstInvokation()
+                    let arguments = firstInvokation.arguments
                     expect(arguments.0) == 123
                         
                     let dict = result.jsonObject()!
@@ -862,7 +886,8 @@ class HackleInvocationSpec : QuickSpec {
                     let result = invocation.invoke(string: jsonString)
                     expect(mock.featureFlagDetailRef.invokations().count) == 1
                         
-                    let arguments = mock.featureFlagDetailRef.firstInvokation().arguments
+                    let firstInvokation = mock.featureFlagDetailRef.firstInvokation()
+                    let arguments = firstInvokation.arguments
                     expect(arguments.0) == 123
                     expect(arguments.1?.id) == "abcd1234"
                         
@@ -891,7 +916,8 @@ class HackleInvocationSpec : QuickSpec {
                     let result = invocation.invoke(string: jsonString)
                     expect(mock.featureFlagDetailRef.invokations().count) == 1
                         
-                    let arguments = mock.featureFlagDetailRef.firstInvokation().arguments
+                    let firstInvokation = mock.featureFlagDetailRef.firstInvokation()
+                    let arguments = firstInvokation.arguments
                     expect(arguments.0) == 123
                     expect(arguments.1?.id) == "foo"
 
@@ -931,7 +957,8 @@ class HackleInvocationSpec : QuickSpec {
                         
                         expect(mock.trackRef.invokations().count) == 1
                         
-                        let arguments = mock.trackRef.firstInvokation().arguments
+                        let firstInvokation = mock.trackRef.firstInvokation()
+                        let arguments = firstInvokation.arguments
                         expect(arguments.0.key) == "abcd1234"
                         
                         let dict = result.jsonObject()!
@@ -950,7 +977,8 @@ class HackleInvocationSpec : QuickSpec {
                         
                         expect(mock.trackRef.invokations().count) == 1
                         
-                        let arguments = mock.trackRef.firstInvokation().arguments
+                        let firstInvokation = mock.trackRef.firstInvokation()
+                        let arguments = firstInvokation.arguments
                         expect(arguments.0.key) == "abcd1234"
                         expect(arguments.1?.id) == "foo"
                         
@@ -970,7 +998,8 @@ class HackleInvocationSpec : QuickSpec {
                         
                         expect(mock.trackRef.invokations().count) == 1
                         
-                        let arguments = mock.trackRef.firstInvokation().arguments
+                        let firstInvokation = mock.trackRef.firstInvokation()
+                        let arguments = firstInvokation.arguments
                         expect(arguments.0.key) == "abcd1234"
                         expect(arguments.1?.id) == "foo"
                         
@@ -1001,7 +1030,8 @@ class HackleInvocationSpec : QuickSpec {
                         
                         expect(mock.trackRef.invokations().count) == 1
                         
-                        let arguments = mock.trackRef.firstInvokation().arguments
+                        let firstInvokation = mock.trackRef.firstInvokation()
+                        let arguments = firstInvokation.arguments
                         expect(arguments.0.key) == "foo"
                         expect(arguments.0.value) == 1234
                         expect(arguments.0.properties!.count) == 3
@@ -1040,7 +1070,8 @@ class HackleInvocationSpec : QuickSpec {
                         
                         expect(mock.trackRef.invokations().count) == 1
                         
-                        let arguments = mock.trackRef.firstInvokation().arguments
+                        let firstInvokation = mock.trackRef.firstInvokation()
+                        let arguments = firstInvokation.arguments
                         expect(arguments.0.key) == "foo"
                         expect(arguments.0.value) == 1234
                         expect(arguments.0.properties!.count) == 3
@@ -1080,7 +1111,8 @@ class HackleInvocationSpec : QuickSpec {
                         
                         expect(mock.trackRef.invokations().count) == 1
                         
-                        let arguments = mock.trackRef.firstInvokation().arguments
+                        let firstInvokation = mock.trackRef.firstInvokation()
+                        let arguments = firstInvokation.arguments
                         expect(arguments.0.key) == "foo"
                         expect(arguments.0.value) == 1234
                         expect(arguments.0.properties!.count) == 3
@@ -1237,7 +1269,8 @@ class HackleInvocationSpec : QuickSpec {
                             let jsonString = self.createJsonString(command: "remoteConfig", parameters: parameters)
                             let result = invocation.invoke(string: jsonString)
                             expect(mock.remoteConfigRef.invokations().count) == 1
-                            let arguments = mock.remoteConfigRef.firstInvokation().arguments
+                            let firstInvokation = mock.remoteConfigRef.firstInvokation()
+                            let arguments = firstInvokation.arguments
                             expect(arguments.2?.userId) == "abcd1234"
                             let dict = result.jsonObject()!
                             expect(dict["success"] as? Bool) == true
@@ -1255,7 +1288,8 @@ class HackleInvocationSpec : QuickSpec {
                             let jsonString = self.createJsonString(command: "remoteConfig", parameters: parameters)
                             let result = invocation.invoke(string: jsonString)
                             expect(mock.remoteConfigRef.invokations().count) == 1
-                            let arguments = mock.remoteConfigRef.firstInvokation().arguments
+                            let firstInvokation = mock.remoteConfigRef.firstInvokation()
+                            let arguments = firstInvokation.arguments
                             expect(arguments.2?.userId) == "abcd1234"
                             let dict = result.jsonObject()!
                             expect(dict["success"] as? Bool) == true
@@ -1273,7 +1307,8 @@ class HackleInvocationSpec : QuickSpec {
                             let jsonString = self.createJsonString(command: "remoteConfig", parameters: parameters)
                             let result = invocation.invoke(string: jsonString)
                             expect(mock.remoteConfigRef.invokations().count) == 1
-                            let arguments = mock.remoteConfigRef.firstInvokation().arguments
+                            let firstInvokation = mock.remoteConfigRef.firstInvokation()
+                            let arguments = firstInvokation.arguments
                             expect(arguments.2?.userId) == "abcd1234"
                             let dict = result.jsonObject()!
                             expect(dict["success"] as? Bool) == true
@@ -1291,7 +1326,8 @@ class HackleInvocationSpec : QuickSpec {
                             let jsonString = self.createJsonString(command: "remoteConfig", parameters: parameters)
                             let result = invocation.invoke(string: jsonString)
                             expect(mock.remoteConfigRef.invokations().count) == 1
-                            let arguments = mock.remoteConfigRef.firstInvokation().arguments
+                            let firstInvokation = mock.remoteConfigRef.firstInvokation()
+                            let arguments = firstInvokation.arguments
                             expect(arguments.2?.userId) == "abcd1234"
 
                             let dict = result.jsonObject()!
@@ -1310,7 +1346,8 @@ class HackleInvocationSpec : QuickSpec {
                             let jsonString = self.createJsonString(command: "remoteConfig", parameters: parameters)
                             let result = invocation.invoke(string: jsonString)
                             expect(mock.remoteConfigRef.invokations().count) == 1
-                            let arguments = mock.remoteConfigRef.firstInvokation().arguments
+                            let firstInvokation = mock.remoteConfigRef.firstInvokation()
+                            let arguments = firstInvokation.arguments
                             expect(arguments.2?.userId) == "abcd1234"
 
                             let dict = result.jsonObject()!
@@ -1329,7 +1366,8 @@ class HackleInvocationSpec : QuickSpec {
                             let jsonString = self.createJsonString(command: "remoteConfig", parameters: parameters)
                             let result = invocation.invoke(string: jsonString)
                             expect(mock.remoteConfigRef.invokations().count) == 1
-                            let arguments = mock.remoteConfigRef.firstInvokation().arguments
+                            let firstInvokation = mock.remoteConfigRef.firstInvokation()
+                            let arguments = firstInvokation.arguments
                             expect(arguments.2?.userId) == "abcd1234"
 
                             let dict = result.jsonObject()!
@@ -1350,7 +1388,8 @@ class HackleInvocationSpec : QuickSpec {
                             let jsonString = self.createJsonString(command: "remoteConfig", parameters: parameters)
                             let result = invocation.invoke(string: jsonString)
                             expect(mock.remoteConfigRef.invokations().count) == 1
-                            let arguments = mock.remoteConfigRef.firstInvokation().arguments
+                            let firstInvokation = mock.remoteConfigRef.firstInvokation()
+                            let arguments = firstInvokation.arguments
                             expect(arguments.2?.id) == "abcd1234"
 
                             let dict = result.jsonObject()!
@@ -1370,7 +1409,8 @@ class HackleInvocationSpec : QuickSpec {
                             let jsonString = self.createJsonString(command: "remoteConfig", parameters: parameters)
                             let result = invocation.invoke(string: jsonString)
                             expect(mock.remoteConfigRef.invokations().count) == 1
-                            let arguments = mock.remoteConfigRef.firstInvokation().arguments
+                            let firstInvokation = mock.remoteConfigRef.firstInvokation()
+                            let arguments = firstInvokation.arguments
                             expect(arguments.2?.id) == "abcd1234"
 
                             let dict = result.jsonObject()!
@@ -1389,7 +1429,8 @@ class HackleInvocationSpec : QuickSpec {
                             let jsonString = self.createJsonString(command: "remoteConfig", parameters: parameters)
                             let result = invocation.invoke(string: jsonString)
                             expect(mock.remoteConfigRef.invokations().count) == 1
-                            let arguments = mock.remoteConfigRef.firstInvokation().arguments
+                            let firstInvokation = mock.remoteConfigRef.firstInvokation()
+                            let arguments = firstInvokation.arguments
                             expect(arguments.2?.id) == "abcd1234"
 
                             let dict = result.jsonObject()!
@@ -1408,7 +1449,8 @@ class HackleInvocationSpec : QuickSpec {
                             let jsonString = self.createJsonString(command: "remoteConfig", parameters: parameters)
                             let result = invocation.invoke(string: jsonString)
                             expect(mock.remoteConfigRef.invokations().count) == 1
-                            let arguments = mock.remoteConfigRef.firstInvokation().arguments
+                            let firstInvokation = mock.remoteConfigRef.firstInvokation()
+                            let arguments = firstInvokation.arguments
                             expect(arguments.2?.id) == "abcd1234"
 
                             let dict = result.jsonObject()!
@@ -1427,7 +1469,8 @@ class HackleInvocationSpec : QuickSpec {
                             let jsonString = self.createJsonString(command: "remoteConfig", parameters: parameters)
                             let result = invocation.invoke(string: jsonString)
                             expect(mock.remoteConfigRef.invokations().count) == 1
-                            let arguments = mock.remoteConfigRef.firstInvokation().arguments
+                            let firstInvokation = mock.remoteConfigRef.firstInvokation()
+                            let arguments = firstInvokation.arguments
                             expect(arguments.2?.id) == "abcd1234"
 
                             let dict = result.jsonObject()!
@@ -1446,7 +1489,8 @@ class HackleInvocationSpec : QuickSpec {
                             let jsonString = self.createJsonString(command: "remoteConfig", parameters: parameters)
                             let result = invocation.invoke(string: jsonString)
                             expect(mock.remoteConfigRef.invokations().count) == 1
-                            let arguments = mock.remoteConfigRef.firstInvokation().arguments
+                            let firstInvokation = mock.remoteConfigRef.firstInvokation()
+                            let arguments = firstInvokation.arguments
                             expect(arguments.2?.id) == "abcd1234"
 
                             let dict = result.jsonObject()!

--- a/Tests/HackleTests/Core/Lifecycle/DefaultAppStateManagerSpecs.swift
+++ b/Tests/HackleTests/Core/Lifecycle/DefaultAppStateManagerSpecs.swift
@@ -25,16 +25,16 @@ class DefaultAppStateManagerSpecs: QuickSpec {
                 verify(exactly: 1) {
                     listener.onStateMock
                 }
-                expect(listener.onStateMock.firstInvokation().arguments.0).to(equal(.foreground))
+                expect(listener.onStateMock.firstInvokation().arguments.0).to(equal(Optional(.foreground)))
             }
             it("didEnterBackground") {
                 sut.onLifecycle(lifecycle: .didEnterBackground(top: nil), timestamp: Date(timeIntervalSince1970: 42))
                 queue.await()
-                expect(sut.currentState).to(equal(.background))
+                expect(sut.currentState).to(equal(Optional(.background)))
                 verify(exactly: 1) {
                     listener.onStateMock
                 }
-                expect(listener.onStateMock.firstInvokation().arguments.0).to(equal(.background))
+                expect(listener.onStateMock.firstInvokation().arguments.0).to(equal(Optional(.background)))
             }
 
             it("do nothing") {
@@ -43,7 +43,7 @@ class DefaultAppStateManagerSpecs: QuickSpec {
                 sut.onLifecycle(lifecycle: .viewWillDisappear(vc: UIViewController(), top: UIViewController()), timestamp: Date(timeIntervalSince1970: 42))
                 sut.onLifecycle(lifecycle: .viewDidDisappear(vc: UIViewController(), top: UIViewController()), timestamp: Date(timeIntervalSince1970: 42))
                 queue.await()
-                expect(sut.currentState).to(equal(.background))
+                expect(sut.currentState).to(equal(Optional(.background)))
                 verify(exactly: 0) {
                     listener.onStateMock
                 }
@@ -51,3 +51,4 @@ class DefaultAppStateManagerSpecs: QuickSpec {
         }
     }
 }
+

--- a/Tests/HackleTests/Core/Lifecycle/MockAppStateListener.swift
+++ b/Tests/HackleTests/Core/Lifecycle/MockAppStateListener.swift
@@ -1,5 +1,5 @@
 import Foundation
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class MockAppStateListener: Mock, AppStateListener {

--- a/Tests/HackleTests/Core/Lifecycle/MockLifecycleListener.swift
+++ b/Tests/HackleTests/Core/Lifecycle/MockLifecycleListener.swift
@@ -1,5 +1,5 @@
 import Foundation
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class MockLifecycleListener: Mock, LifecycleListener {

--- a/Tests/HackleTests/Core/Metrics/CounterSpecs.swift
+++ b/Tests/HackleTests/Core/Metrics/CounterSpecs.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Quick
 import Nimble
-import Mockery
+import MockingKit
 @testable import Hackle
 
 

--- a/Tests/HackleTests/Core/Metrics/Cumulative/CumulativeCounterSpecs.swift
+++ b/Tests/HackleTests/Core/Metrics/Cumulative/CumulativeCounterSpecs.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Quick
 import Nimble
-import Mockery
+import MockingKit
 @testable import Hackle
 
 

--- a/Tests/HackleTests/Core/Metrics/Cumulative/CumulativeMetricRegistrySpecs.swift
+++ b/Tests/HackleTests/Core/Metrics/Cumulative/CumulativeMetricRegistrySpecs.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Quick
 import Nimble
-import Mockery
+import MockingKit
 @testable import Hackle
 
 

--- a/Tests/HackleTests/Core/Metrics/Cumulative/CumulativeTimerSpecs.swift
+++ b/Tests/HackleTests/Core/Metrics/Cumulative/CumulativeTimerSpecs.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Quick
 import Nimble
-import Mockery
+import MockingKit
 @testable import Hackle
 
 

--- a/Tests/HackleTests/Core/Metrics/Delegate/DelegatingCounterSpecs.swift
+++ b/Tests/HackleTests/Core/Metrics/Delegate/DelegatingCounterSpecs.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Quick
 import Nimble
-import Mockery
+import MockingKit
 @testable import Hackle
 
 

--- a/Tests/HackleTests/Core/Metrics/Delegate/DelegatingMetricRegistrySpecs.swift
+++ b/Tests/HackleTests/Core/Metrics/Delegate/DelegatingMetricRegistrySpecs.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Quick
 import Nimble
-import Mockery
+import MockingKit
 @testable import Hackle
 
 

--- a/Tests/HackleTests/Core/Metrics/Delegate/DelegatingTimerSpecs.swift
+++ b/Tests/HackleTests/Core/Metrics/Delegate/DelegatingTimerSpecs.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Quick
 import Nimble
-import Mockery
+import MockingKit
 @testable import Hackle
 
 

--- a/Tests/HackleTests/Core/Metrics/Flush/FlushCounterSpecs.swift
+++ b/Tests/HackleTests/Core/Metrics/Flush/FlushCounterSpecs.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Quick
 import Nimble
-import Mockery
+import MockingKit
 @testable import Hackle
 
 

--- a/Tests/HackleTests/Core/Metrics/Flush/FlushMetricRegistrySpecs.swift
+++ b/Tests/HackleTests/Core/Metrics/Flush/FlushMetricRegistrySpecs.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Quick
 import Nimble
-import Mockery
+import MockingKit
 @testable import Hackle
 
 

--- a/Tests/HackleTests/Core/Metrics/Flush/FlushTimerSpecs.swift
+++ b/Tests/HackleTests/Core/Metrics/Flush/FlushTimerSpecs.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Quick
 import Nimble
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class FlushTimerSpecs: QuickSpec {

--- a/Tests/HackleTests/Core/Metrics/MetricFieldSpecs.swift
+++ b/Tests/HackleTests/Core/Metrics/MetricFieldSpecs.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Quick
 import Nimble
-import Mockery
+import MockingKit
 @testable import Hackle
 
 

--- a/Tests/HackleTests/Core/Metrics/MetricSpecs.swift
+++ b/Tests/HackleTests/Core/Metrics/MetricSpecs.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Quick
 import Nimble
-import Mockery
+import MockingKit
 @testable import Hackle
 
 

--- a/Tests/HackleTests/Core/Metrics/MetricsSpecs.swift
+++ b/Tests/HackleTests/Core/Metrics/MetricsSpecs.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Quick
 import Nimble
-import Mockery
+import MockingKit
 @testable import Hackle
 
 

--- a/Tests/HackleTests/Core/Metrics/Noop/NoopCounterSpecs.swift
+++ b/Tests/HackleTests/Core/Metrics/Noop/NoopCounterSpecs.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Quick
 import Nimble
-import Mockery
+import MockingKit
 @testable import Hackle
 
 

--- a/Tests/HackleTests/Core/Metrics/Noop/NoopTimerSpecs.swift
+++ b/Tests/HackleTests/Core/Metrics/Noop/NoopTimerSpecs.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Quick
 import Nimble
-import Mockery
+import MockingKit
 @testable import Hackle
 
 

--- a/Tests/HackleTests/Core/Metrics/Push/PushMetricRegistrySpecs.swift
+++ b/Tests/HackleTests/Core/Metrics/Push/PushMetricRegistrySpecs.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Quick
 import Nimble
-import Mockery
+import MockingKit
 @testable import Hackle
 
 

--- a/Tests/HackleTests/Core/Metrics/TimerSpecs.swift
+++ b/Tests/HackleTests/Core/Metrics/TimerSpecs.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Quick
 import Nimble
-import Mockery
+import MockingKit
 @testable import Hackle
 
 

--- a/Tests/HackleTests/Core/MockHackleCore.swift
+++ b/Tests/HackleTests/Core/MockHackleCore.swift
@@ -1,5 +1,5 @@
 import Foundation
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class MockHackleCore: Mock, HackleCore {

--- a/Tests/HackleTests/Core/Notification/NotificationEventSpecs.swift
+++ b/Tests/HackleTests/Core/Notification/NotificationEventSpecs.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Quick
 import Nimble
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class NotificationEventSpecs: QuickSpec {

--- a/Tests/HackleTests/Core/Notification/NotificationManagerSpecs.swift
+++ b/Tests/HackleTests/Core/Notification/NotificationManagerSpecs.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Quick
 import Nimble
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class NotificationManagerSpec: QuickSpec {

--- a/Tests/HackleTests/Core/Push/MockPushEventTracker.swift
+++ b/Tests/HackleTests/Core/Push/MockPushEventTracker.swift
@@ -1,5 +1,5 @@
 import Foundation
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class MockPushEventTracker: Mock, PushEventTracker {

--- a/Tests/HackleTests/Core/Push/Token/MockPushTokenListener.swift
+++ b/Tests/HackleTests/Core/Push/Token/MockPushTokenListener.swift
@@ -1,5 +1,5 @@
 import Foundation
-import Mockery
+import MockingKit
 @testable import Hackle
 
 

--- a/Tests/HackleTests/Core/Screen/MockScreenListener.swift
+++ b/Tests/HackleTests/Core/Screen/MockScreenListener.swift
@@ -1,5 +1,5 @@
 import Foundation
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class MockScreenListener: Mock, ScreenListener {

--- a/Tests/HackleTests/Core/Screen/MockScreenManager.swift
+++ b/Tests/HackleTests/Core/Screen/MockScreenManager.swift
@@ -1,5 +1,5 @@
 import Foundation
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class MockScreeManager: Mock, ScreenManager {

--- a/Tests/HackleTests/Core/Session/DefaultSessionManagerSpecs.swift
+++ b/Tests/HackleTests/Core/Session/DefaultSessionManagerSpecs.swift
@@ -1,7 +1,7 @@
 //import Foundation
 //import Quick
 //import Nimble
-//import Mockery
+//import MockingKit
 //@testable import Hackle
 //
 //class DefaultSessionManagerSpecs: QuickSpec {

--- a/Tests/HackleTests/Core/Session/MockSessionManager.swift
+++ b/Tests/HackleTests/Core/Session/MockSessionManager.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Quick
 import Nimble
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class MockSessionManager: Mock, SessionManager {

--- a/Tests/HackleTests/Core/Session/SessionEventTrackerSpecs.swift
+++ b/Tests/HackleTests/Core/Session/SessionEventTrackerSpecs.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Quick
 import Nimble
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class SessionEventTrackerSpecs: QuickSpec {

--- a/Tests/HackleTests/Core/Sync/MockSynchronizer.swift
+++ b/Tests/HackleTests/Core/Sync/MockSynchronizer.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class MockSynchronizer: Mock, Synchronizer {

--- a/Tests/HackleTests/Core/User/MockUserCohortFetcher.swift
+++ b/Tests/HackleTests/Core/User/MockUserCohortFetcher.swift
@@ -1,5 +1,5 @@
 import Foundation
-import Mockery
+import MockingKit
 @testable import Hackle
 
 

--- a/Tests/HackleTests/Core/User/MockUserListener.swift
+++ b/Tests/HackleTests/Core/User/MockUserListener.swift
@@ -1,5 +1,5 @@
 import Foundation
-import Mockery
+import MockingKit
 @testable import Hackle
 
 

--- a/Tests/HackleTests/Core/User/MockUserManager.swift
+++ b/Tests/HackleTests/Core/User/MockUserManager.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Quick
 import Nimble
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class MockUserManager: Mock, UserManager {

--- a/Tests/HackleTests/Core/User/MockUserTargetFetcher.swift
+++ b/Tests/HackleTests/Core/User/MockUserTargetFetcher.swift
@@ -6,7 +6,7 @@
 //
 
 @testable import Hackle
-import Mockery
+import MockingKit
 
 class MockUserTargetFetcher: Mock, UserTargetEventsFetcher {
 

--- a/Tests/HackleTests/Core/Utilities/ObjectsSpec.swift
+++ b/Tests/HackleTests/Core/Utilities/ObjectsSpec.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Quick
 import Nimble
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class ObjectsSpec: QuickSpec {

--- a/Tests/HackleTests/Core/Utilities/Time/ClockSpecs.swift
+++ b/Tests/HackleTests/Core/Utilities/Time/ClockSpecs.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Quick
 import Nimble
-import Mockery
+import MockingKit
 @testable import Hackle
 
 

--- a/Tests/HackleTests/Core/Utilities/Time/TimeUnitSpecs.swift
+++ b/Tests/HackleTests/Core/Utilities/Time/TimeUnitSpecs.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Quick
 import Nimble
-import Mockery
+import MockingKit
 @testable import Hackle
 
 

--- a/Tests/HackleTests/Core/Workspace/WorkspaceManagerSpecs.swift
+++ b/Tests/HackleTests/Core/Workspace/WorkspaceManagerSpecs.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Nimble
 import Quick
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class WorkspaceManagerSpecs: QuickSpec {

--- a/Tests/HackleTests/Mock/MockHackleApp.swift
+++ b/Tests/HackleTests/Mock/MockHackleApp.swift
@@ -1,5 +1,5 @@
 import Foundation
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class MockHackleAppCore : Mock, HackleAppCore {

--- a/Tests/HackleTests/Mock/MockHasher.swift
+++ b/Tests/HackleTests/Mock/MockHasher.swift
@@ -3,7 +3,7 @@
 //
 
 import Foundation
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class MockHasher: Mock, Hasher {
@@ -11,6 +11,6 @@ class MockHasher: Mock, Hasher {
     lazy var mockHash = MockReference(hash)
 
     func hash(data: String, seed: Int32) -> Int32 {
-        invoke(mockHash, args: (data, seed))
+        call(mockHash, args: (data, seed))
     }
 }

--- a/Tests/HackleTests/Mock/MockHttpClient.swift
+++ b/Tests/HackleTests/Mock/MockHttpClient.swift
@@ -3,7 +3,7 @@
 //
 
 import Foundation
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class MockHttpClient: Mock, HttpClient {

--- a/Tests/HackleTests/Mock/MockHttpWorkspaceFetcher.swift
+++ b/Tests/HackleTests/Mock/MockHttpWorkspaceFetcher.swift
@@ -1,5 +1,5 @@
 import Foundation
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class MockHttpWorkspaceFetcher: Mock, HttpWorkspaceFetcher {

--- a/Tests/HackleTests/Mock/MockModels.swift
+++ b/Tests/HackleTests/Mock/MockModels.swift
@@ -3,7 +3,7 @@
 //
 
 import Foundation
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class MockBucket: Mock, Bucket {

--- a/Tests/HackleTests/Mock/MockScheduler.swift
+++ b/Tests/HackleTests/Mock/MockScheduler.swift
@@ -3,7 +3,7 @@
 //
 
 import Foundation
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class MockScheduler: Mock, Scheduler {

--- a/Tests/HackleTests/Mock/MockUserEventDispatcher.swift
+++ b/Tests/HackleTests/Mock/MockUserEventDispatcher.swift
@@ -3,7 +3,7 @@
 //
 
 import Foundation
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class MockUserEventDispatcher: Mock, UserEventDispatcher {

--- a/Tests/HackleTests/Mock/MockUserEventProcessor.swift
+++ b/Tests/HackleTests/Mock/MockUserEventProcessor.swift
@@ -3,7 +3,7 @@
 //
 
 import Foundation
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class MockUserEventProcessor: Mock, UserEventProcessor {

--- a/Tests/HackleTests/Mock/MockWorkspace.swift
+++ b/Tests/HackleTests/Mock/MockWorkspace.swift
@@ -3,7 +3,7 @@
 //
 
 import Foundation
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class MockWorkspace: Mock, Workspace {

--- a/Tests/HackleTests/Mock/MockWorkspaceFetcher.swift
+++ b/Tests/HackleTests/Mock/MockWorkspaceFetcher.swift
@@ -5,7 +5,7 @@
 import Foundation
 
 import Foundation
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class MockWorkspaceFetcher: Mock, WorkspaceFetcher {

--- a/Tests/HackleTests/Mock/Mocks.swift
+++ b/Tests/HackleTests/Mock/Mocks.swift
@@ -4,7 +4,7 @@
 
 import Nimble
 import Quick
-import Mockery
+import MockingKit
 
 
 class StubScope<T, R> {
@@ -65,7 +65,7 @@ func every<T, R>(_ mockFunction: MockFunction<T, Result<R, Error>>) -> ThrowStub
 func verify<T, R>(exactly: Int? = nil, _ mockFunction: () -> MockFunction<T, R>) {
     let mockFunc = mockFunction()
 
-    let invocations = mockFunc.mock.invokations(of: mockFunc.mockReference)
+    let invocations = mockFunc.mock.calls(to: mockFunc.mockReference)
 
     if let exactly = exactly {
         expect(invocations.count).to(equal(exactly))
@@ -85,16 +85,16 @@ struct MockFunction<T, R> {
         self.mockReference = MockReference(function)
     }
 
-    func firstInvokation() -> MockInvokation<T, R> {
+    func firstInvokation() -> MockCall<T, R> {
         invokations().first!
     }
 
-    func lastInvokation() -> MockInvokation<T, R> {
+    func lastInvokation() -> MockCall<T, R> {
         invokations().last!
     }
 
-    func invokations() -> [MockInvokation<T, R>] {
-        mock.invokations(of: mockReference)
+    func invokations() -> [MockCall<T, R>] {
+        mock.calls(to: mockReference)
     }
 
     func wasCalled() -> Bool {
@@ -126,7 +126,7 @@ extension Mockable {
         line: UInt = #line,
         functionCall: StaticString = #function
     ) -> R {
-        invoke(function.mockReference, args: args, fallback: fallback(file: file, line: line, functionCall: functionCall))
+        call(function.mockReference, args: args, fallback: fallback(file: file, line: line, functionCall: functionCall))
     }
 
     func call<T, R>(
@@ -136,7 +136,7 @@ extension Mockable {
         line: UInt = #line,
         functionCall: StaticString = #function
     ) throws -> R {
-        try invoke(function.mockReference, args: args, fallback: fallback(file: file, line: line, functionCall: functionCall)).get()
+        try call(function.mockReference, args: args, fallback: fallback(file: file, line: line, functionCall: functionCall)).get()
     }
 
     private func fallback<R>(
@@ -153,7 +153,7 @@ extension Mockable {
     }
 
     func call<T, R>(_ function: MockFunction<T, R?>, args: T) -> R? {
-        invoke(function.mockReference, args: args)
+        call(function.mockReference, args: args)
     }
 }
 

--- a/Tests/HackleTests/UI/InAppMessageUI/Event/MockInAppMessageActionHandler.swift
+++ b/Tests/HackleTests/UI/InAppMessageUI/Event/MockInAppMessageActionHandler.swift
@@ -1,5 +1,5 @@
 import Foundation
-import Mockery
+import MockingKit
 @testable import Hackle
 
 

--- a/Tests/HackleTests/UI/InAppMessageUI/Event/MockInAppMessageEventProcessor.swift
+++ b/Tests/HackleTests/UI/InAppMessageUI/Event/MockInAppMessageEventProcessor.swift
@@ -1,5 +1,5 @@
 import Foundation
-import Mockery
+import MockingKit
 @testable import Hackle
 
 

--- a/Tests/HackleTests/UI/InAppMessageUI/Event/MockInAppMessageEventTracker.swift
+++ b/Tests/HackleTests/UI/InAppMessageUI/Event/MockInAppMessageEventTracker.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class MockInAppMessageEventTracker: Mock, InAppMessageEventTracker {

--- a/Tests/HackleTests/UI/Internal/MockUrlHandler.swift
+++ b/Tests/HackleTests/UI/Internal/MockUrlHandler.swift
@@ -1,5 +1,5 @@
 import Foundation
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class MockUrlHandler: Mock, UrlHandler {

--- a/Tests/HackleTests/UI/Notification/NotificationClickActionSpecs.swift
+++ b/Tests/HackleTests/UI/Notification/NotificationClickActionSpecs.swift
@@ -8,7 +8,7 @@
 import Foundation
 import Quick
 import Nimble
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class NotificationClickActionSpecs: QuickSpec {

--- a/Tests/HackleTests/UI/Notification/NotificationDataSpecs.swift
+++ b/Tests/HackleTests/UI/Notification/NotificationDataSpecs.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Quick
 import Nimble
-import Mockery
+import MockingKit
 @testable import Hackle
 
 class NotificationDataSpecs: QuickSpec {


### PR DESCRIPTION
## 개요
swift 6.2에서 테스트가 실행안되는 버그 픽스

## 작업 내용
### Mockery 패키지 버전 업데이트
- `Mockery` -> `MockingKit`
  - 동일한 패키지지만 이름이 변경됨
- `0.7.0` -> `1.5.0`
- 변경된 api 맞게 코드 수정

### swift 6.2 빌드 에러 픽스
- 일부 에러가 나는 구문 수정
- 테스트 코드만 수정하였습니다.