### PR TITLE
fix: use window bounds instead of screen bounds for floating button

### DIFF
--- a/.github/workflows/update_javascript_sdk.yml
+++ b/.github/workflows/update_javascript_sdk.yml
@@ -98,7 +98,7 @@ jobs:
             Sources/Hackle/Resources/ \
             Sources/Hackle/UI/InAppMessageUI/Views/Html/InAppMessageUIHtmlViewBridgeScript.swift \
             Package.swift
-          git commit -m "chore: update javascript sdk to $JS_SDK_VERSION"
+          git commit -m "chore: update @hackler/javascript-sdk@$JS_SDK_VERSION"
           git push origin "$FEATURE_BRANCH"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -110,13 +110,8 @@ jobs:
         run: |
           gh pr create \
             --base "$DEV_BRANCH" \
-            --title "chore: update javascript sdk to $JS_SDK_VERSION" \
-            --body "hackle-javascript-sdk \`$JS_SDK_VERSION\` 업데이트
-
-          ## Changes
-          - \`hackle-javascript-sdk-${JS_SDK_VERSION}.min.js\` 추가 (npm UMD build)
-          - 기존 JS SDK 파일 삭제
-          - \`javascriptSdkVersion\` 상수 업데이트
-          - \`Package.swift\` 리소스 참조 업데이트
+            --title "[Automation] Update @hackler/javascript-sdk@$JS_SDK_VERSION" \
+            --body "## Description
+          - Update @hackler/javascript-sdk@$JS_SDK_VERSION
 
           > **Note:** \`Hackle.xcodeproj\`는 수동으로 업데이트 필요"

--- a/Sources/Hackle/UI/ExplorerUI/HackleUserExplorerView.swift
+++ b/Sources/Hackle/UI/ExplorerUI/HackleUserExplorerView.swift
@@ -30,7 +30,7 @@ class HackleUserExplorerView {
         }
 
         if self.button == nil {
-            self.button = self.createButton()
+            self.button = self.createButton(in: window)
         }
         let button = self.button!
         window.addSubview(button)
@@ -45,10 +45,9 @@ class HackleUserExplorerView {
         self.button = nil
     }
 
-    private func createButton() -> HackleUserExplorerButton {
-        let rect = UIUtils.currentScreen.bounds
-        let width = rect.size.width
-        let height = rect.size.height
+    private func createButton(in window: UIWindow) -> HackleUserExplorerButton {
+        let width = window.bounds.width
+        let height = window.bounds.height
         let offset = offset()
         let button = HackleUserExplorerButton(frame: CGRect(
             x: width - 50,
@@ -62,22 +61,26 @@ class HackleUserExplorerView {
     }
 
     @objc func onTouch(sender: UIPanGestureRecognizer) {
+        guard let button = self.button,
+              let superview = button.superview else {
+            Log.debug("FloatingButton: button or superview is nil during drag")
+            return
+        }
         let translation = sender.translation(in: button)
 
         let barHeight = barHeight()
         let bottomOffset = offset()
 
-        let rect = UIUtils.currentScreen.bounds
-        let width = rect.size.width
-        let height = rect.size.height
+        let width = superview.bounds.width
+        let height = superview.bounds.height
 
-        var newY = min(button!.center.y + translation.y, height - bottomOffset)
-        newY = max(barHeight + (button!.bounds.height / 2), newY)
+        var newY = min(button.center.y + translation.y, height - bottomOffset)
+        newY = max(barHeight + (button.bounds.height / 2), newY)
 
-        var newX = min(button!.center.x + translation.x, width)
-        newX = max(button!.bounds.width / 2, newX)
+        var newX = min(button.center.x + translation.x, width)
+        newX = max(button.bounds.width / 2, newX)
 
-        button!.center = CGPoint(x: newX, y: newY)
+        button.center = CGPoint(x: newX, y: newY)
         sender.setTranslation(CGPoint(x: 0, y: 0), in: button)
     }
 


### PR DESCRIPTION
## 개요
Mac Catalyst / 멀티윈도우 환경에서 플로팅 버튼 위치가 잘못 계산되는 문제를 수정합니다. 
`UIUtils.currentScreen.bounds` 대신 `window.bounds`를 사용하도록 변경하였습니다.

## 작업 내용
- `HackleUserExplorerView`에서 플로팅 버튼 생성 및 드래그 시 `UIScreen.bounds` 대신 `UIWindow.bounds` 기준으로 좌표를 계산하도록 수정
- 드래그 핸들러에서 `button`/`superview` nil 체크 guard 추가
