### PR TITLE
fix: resolve WebView memory leak in HackleUIDelegate

### DIFF
--- a/Hackle.xcodeproj/project.pbxproj
+++ b/Hackle.xcodeproj/project.pbxproj
@@ -59,6 +59,7 @@
 		7E9F7E892B6CCC3700A6B0B8 /* MockFileStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E9F7E882B6CCC3700A6B0B8 /* MockFileStorage.swift */; };
 		7EE320D82B56707800105A6C /* workspace_config.json in Resources */ = {isa = PBXBuildFile; fileRef = 7EE320D72B56707800105A6C /* workspace_config.json */; };
 		7EE320DA2B5692D900105A6C /* workspace_response.json in Resources */ = {isa = PBXBuildFile; fileRef = 7EE320D92B5692D900105A6C /* workspace_response.json */; };
+		B203A5842F8E17BD00BDAD31 /* HackleUIDelegateSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = B203A5832F8E17BD00BDAD31 /* HackleUIDelegateSpecs.swift */; };
 		B20B23142E56F0100019EAA7 /* MimeType.swift in Sources */ = {isa = PBXBuildFile; fileRef = B20B23132E56F0040019EAA7 /* MimeType.swift */; };
 		B20B234E2E56FB980019EAA7 /* MimeTypeSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = B20B234D2E56FB910019EAA7 /* MimeTypeSpecs.swift */; };
 		B21078412E90C21F00D26B60 /* BundleVersionInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = B21078402E90C21500D26B60 /* BundleVersionInfo.swift */; };
@@ -789,6 +790,7 @@
 		7E9F7E882B6CCC3700A6B0B8 /* MockFileStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockFileStorage.swift; sourceTree = "<group>"; };
 		7EE320D72B56707800105A6C /* workspace_config.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = workspace_config.json; sourceTree = "<group>"; };
 		7EE320D92B5692D900105A6C /* workspace_response.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = workspace_response.json; sourceTree = "<group>"; };
+		B203A5832F8E17BD00BDAD31 /* HackleUIDelegateSpecs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HackleUIDelegateSpecs.swift; sourceTree = "<group>"; };
 		B20B23132E56F0040019EAA7 /* MimeType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MimeType.swift; sourceTree = "<group>"; };
 		B20B234D2E56FB910019EAA7 /* MimeTypeSpecs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MimeTypeSpecs.swift; sourceTree = "<group>"; };
 		B21078402E90C21500D26B60 /* BundleVersionInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundleVersionInfo.swift; sourceTree = "<group>"; };
@@ -1508,6 +1510,7 @@
 				EE55B4942F63C72100A36359 /* Invocation */,
 				B26AC2912E4C5AA300AAE56F /* InvocationDtoSpecs.swift */,
 				7E64779A2AD4F19D00971F20 /* HackleInvocationSpec.swift */,
+				B203A5832F8E17BD00BDAD31 /* HackleUIDelegateSpecs.swift */,
 				B2FCB8BF2EB1B069001C6B14 /* HackleJavascriptBridgeSpecs.swift */,
 			);
 			path = Invocator;
@@ -4289,6 +4292,7 @@
 				EE543CDD2C09AA8600F64BFA /* MockViewManager.swift in Sources */,
 				EE29DA6B29CD82C200B1FEAA /* ClockSpecs.swift in Sources */,
 				EE29DA9229CD82C200B1FEAA /* DefaultBucketerSpec.swift in Sources */,
+				B203A5842F8E17BD00BDAD31 /* HackleUIDelegateSpecs.swift in Sources */,
 				7E0F05472AD7BA6800631B42 /* MockRemoteConfig.swift in Sources */,
 				7E9F7E892B6CCC3700A6B0B8 /* MockFileStorage.swift in Sources */,
 				EEF895912A4971DE00722CF6 /* InAppMessageMatcherStub.swift in Sources */,

--- a/Sources/Hackle/Invocator/Web/HackleUIDelegate.swift
+++ b/Sources/Hackle/Invocator/Web/HackleUIDelegate.swift
@@ -5,7 +5,7 @@ import WebKit
 class HackleUIDelegate: NSObject, WKUIDelegate {
 
     private let invocator: HackleInvocator
-    private weak var uiDelegate: WKUIDelegate?
+    private nonisolated(unsafe) weak var uiDelegate: WKUIDelegate?
 
     init(invocator: HackleInvocator, uiDelegate: WKUIDelegate? = nil) {
         self.invocator = invocator

--- a/Sources/Hackle/Invocator/Web/HackleUIDelegate.swift
+++ b/Sources/Hackle/Invocator/Web/HackleUIDelegate.swift
@@ -1,10 +1,11 @@
 import Foundation
 import WebKit
 
+@MainActor
 class HackleUIDelegate: NSObject, WKUIDelegate {
 
     private let invocator: HackleInvocator
-    private nonisolated(unsafe) weak var uiDelegate: WKUIDelegate?
+    private weak var uiDelegate: WKUIDelegate?
 
     init(invocator: HackleInvocator, uiDelegate: WKUIDelegate? = nil) {
         self.invocator = invocator

--- a/Sources/Hackle/Invocator/Web/HackleUIDelegate.swift
+++ b/Sources/Hackle/Invocator/Web/HackleUIDelegate.swift
@@ -4,7 +4,7 @@ import WebKit
 class HackleUIDelegate: NSObject, WKUIDelegate {
 
     private let invocator: HackleInvocator
-    private nonisolated let uiDelegate: WKUIDelegate?
+    private nonisolated(unsafe) weak var uiDelegate: WKUIDelegate?
 
     init(invocator: HackleInvocator, uiDelegate: WKUIDelegate? = nil) {
         self.invocator = invocator

--- a/Sources/Hackle/Invocator/Web/HackleUIDelegate.swift
+++ b/Sources/Hackle/Invocator/Web/HackleUIDelegate.swift
@@ -12,7 +12,7 @@ class HackleUIDelegate: NSObject, WKUIDelegate {
         self.uiDelegate = uiDelegate
     }
 
-    @MainActor func webView(_ webView: WKWebView, runJavaScriptTextInputPanelWithPrompt prompt: String, defaultText: String?, initiatedByFrame frame: WKFrameInfo, completionHandler: @escaping @MainActor @Sendable (String?) -> Void) {
+    func webView(_ webView: WKWebView, runJavaScriptTextInputPanelWithPrompt prompt: String, defaultText: String?, initiatedByFrame frame: WKFrameInfo, completionHandler: @escaping @MainActor @Sendable (String?) -> Void) {
         let processable = invocator.isInvocableString(string: prompt)
         if (processable) {
             let result = invocator.invoke(string: prompt)

--- a/Tests/HackleTests/Invocator/HackleUIDelegateSpecs.swift
+++ b/Tests/HackleTests/Invocator/HackleUIDelegateSpecs.swift
@@ -139,6 +139,69 @@ class HackleUIDelegateSpecs: QuickSpec {
             }
         }
 
+        describe("weak uiDelegate reference") {
+
+            it("should not retain uiDelegate") {
+                MainActor.assumeIsolated {
+                    var mockDelegate: MockWKUIDelegate? = MockWKUIDelegate()
+                    weak var weakRef = mockDelegate
+
+                    let sut = HackleUIDelegate(invocator: mockInvocator, uiDelegate: mockDelegate)
+                    _ = sut
+                    mockDelegate = nil
+
+                    expect(weakRef).to(beNil())
+                }
+            }
+
+            it("responds(to:) should return false after uiDelegate is deallocated") {
+                MainActor.assumeIsolated {
+                    var mockDelegate: MockWKUIDelegate? = MockWKUIDelegate()
+                    let sut = HackleUIDelegate(invocator: mockInvocator, uiDelegate: mockDelegate)
+                    mockDelegate = nil
+
+                    let selector = #selector(MockWKUIDelegate.customMethod)
+                    expect(sut.responds(to: selector)) == false
+                }
+            }
+
+            it("forwardingTarget(for:) should return nil after uiDelegate is deallocated") {
+                MainActor.assumeIsolated {
+                    var mockDelegate: MockWKUIDelegate? = MockWKUIDelegate()
+                    let sut = HackleUIDelegate(invocator: mockInvocator, uiDelegate: mockDelegate)
+                    mockDelegate = nil
+
+                    let selector = #selector(MockWKUIDelegate.customMethod)
+                    let target = sut.forwardingTarget(for: selector)
+                    expect(target).to(beNil())
+                }
+            }
+
+            it("should call completionHandler with nil after uiDelegate is deallocated") {
+                MainActor.assumeIsolated {
+                    var mockDelegate: MockWKUIDelegate? = MockWKUIDelegate()
+                    let sut = HackleUIDelegate(invocator: mockInvocator, uiDelegate: mockDelegate)
+                    mockInvocator.invocable = false
+                    mockDelegate = nil
+
+                    let webView = WKWebView()
+                    let frame = WKFrameInfo()
+                    var callbackResult: String? = "not_called"
+
+                    sut.webView(
+                        webView,
+                        runJavaScriptTextInputPanelWithPrompt: "prompt",
+                        defaultText: nil,
+                        initiatedByFrame: frame
+                    ) { result in
+                        callbackResult = result
+                    }
+
+                    expect(callbackResult).to(beNil())
+                }
+            }
+        }
+
         describe("forwardingTarget(for:)") {
 
             it("should return self for selectors HackleUIDelegate handles") {

--- a/Tests/HackleTests/Invocator/HackleUIDelegateSpecs.swift
+++ b/Tests/HackleTests/Invocator/HackleUIDelegateSpecs.swift
@@ -13,104 +13,6 @@ class HackleUIDelegateSpecs: QuickSpec {
             mockInvocator = MockInvocator()
         }
 
-        describe("webView runJavaScriptTextInputPanelWithPrompt") {
-
-            it("invocable prompt should invoke and return result via completionHandler") {
-                MainActor.assumeIsolated {
-                    let sut = HackleUIDelegate(invocator: mockInvocator)
-                    mockInvocator.invocable = true
-                    mockInvocator.invokeResult = "{\"result\":\"ok\"}"
-
-                    let webView = WKWebView()
-                    let frame = WKFrameInfo()
-                    var callbackResult: String? = "not_called"
-
-                    sut.webView(
-                        webView,
-                        runJavaScriptTextInputPanelWithPrompt: "test_prompt",
-                        defaultText: nil,
-                        initiatedByFrame: frame
-                    ) { result in
-                        callbackResult = result
-                    }
-
-                    expect(mockInvocator.invokedString) == "test_prompt"
-                    expect(callbackResult) == "{\"result\":\"ok\"}"
-                }
-            }
-
-            it("non-invocable prompt without uiDelegate should call completionHandler with nil") {
-                MainActor.assumeIsolated {
-                    let sut = HackleUIDelegate(invocator: mockInvocator, uiDelegate: nil)
-                    mockInvocator.invocable = false
-
-                    let webView = WKWebView()
-                    let frame = WKFrameInfo()
-                    var callbackResult: String? = "not_called"
-
-                    sut.webView(
-                        webView,
-                        runJavaScriptTextInputPanelWithPrompt: "non_hackle_prompt",
-                        defaultText: nil,
-                        initiatedByFrame: frame
-                    ) { result in
-                        callbackResult = result
-                    }
-
-                    expect(callbackResult).to(beNil())
-                }
-            }
-
-            it("non-invocable prompt with uiDelegate should forward to uiDelegate") {
-                MainActor.assumeIsolated {
-                    let mockUIDelegate = MockWKUIDelegate()
-                    let sut = HackleUIDelegate(invocator: mockInvocator, uiDelegate: mockUIDelegate)
-                    mockInvocator.invocable = false
-
-                    let webView = WKWebView()
-                    let frame = WKFrameInfo()
-                    var callbackResult: String? = "not_called"
-
-                    sut.webView(
-                        webView,
-                        runJavaScriptTextInputPanelWithPrompt: "external_prompt",
-                        defaultText: "default",
-                        initiatedByFrame: frame
-                    ) { result in
-                        callbackResult = result
-                    }
-
-                    expect(mockUIDelegate.promptCalled) == true
-                    expect(mockUIDelegate.receivedPrompt) == "external_prompt"
-                    expect(mockUIDelegate.receivedDefaultText) == "default"
-                    expect(callbackResult) == "delegated_result"
-                }
-            }
-
-            it("non-invocable prompt with uiDelegate that does not implement prompt method should call completionHandler with nil") {
-                MainActor.assumeIsolated {
-                    let minimalDelegate = MinimalWKUIDelegate()
-                    let sut = HackleUIDelegate(invocator: mockInvocator, uiDelegate: minimalDelegate)
-                    mockInvocator.invocable = false
-
-                    let webView = WKWebView()
-                    let frame = WKFrameInfo()
-                    var callbackResult: String? = "not_called"
-
-                    sut.webView(
-                        webView,
-                        runJavaScriptTextInputPanelWithPrompt: "some_prompt",
-                        defaultText: nil,
-                        initiatedByFrame: frame
-                    ) { result in
-                        callbackResult = result
-                    }
-
-                    expect(callbackResult).to(beNil())
-                }
-            }
-        }
-
         describe("responds(to:)") {
 
             it("should return true for selectors HackleUIDelegate responds to") {
@@ -176,30 +78,6 @@ class HackleUIDelegateSpecs: QuickSpec {
                     expect(target).to(beNil())
                 }
             }
-
-            it("should call completionHandler with nil after uiDelegate is deallocated") {
-                MainActor.assumeIsolated {
-                    var mockDelegate: MockWKUIDelegate? = MockWKUIDelegate()
-                    let sut = HackleUIDelegate(invocator: mockInvocator, uiDelegate: mockDelegate)
-                    mockInvocator.invocable = false
-                    mockDelegate = nil
-
-                    let webView = WKWebView()
-                    let frame = WKFrameInfo()
-                    var callbackResult: String? = "not_called"
-
-                    sut.webView(
-                        webView,
-                        runJavaScriptTextInputPanelWithPrompt: "prompt",
-                        defaultText: nil,
-                        initiatedByFrame: frame
-                    ) { result in
-                        callbackResult = result
-                    }
-
-                    expect(callbackResult).to(beNil())
-                }
-            }
         }
 
         describe("forwardingTarget(for:)") {
@@ -261,13 +139,6 @@ private class MockWKUIDelegate: NSObject, WKUIDelegate {
     var promptCalled = false
     var receivedPrompt: String?
     var receivedDefaultText: String?
-
-    func webView(_ webView: WKWebView, runJavaScriptTextInputPanelWithPrompt prompt: String, defaultText: String?, initiatedByFrame frame: WKFrameInfo, completionHandler: @escaping @MainActor @Sendable (String?) -> Void) {
-        promptCalled = true
-        receivedPrompt = prompt
-        receivedDefaultText = defaultText
-        completionHandler("delegated_result")
-    }
 
     @objc func customMethod() {}
 }


### PR DESCRIPTION
## 개요
`HackleUIDelegate`가 `uiDelegate`를 strong reference로 보유하여 WebView 메모리 누수가 발생하는 문제를 수정합니다.
`uiDelegate` 프로퍼티를 `weak var`로 변경하고, 클래스 레벨에 `@MainActor`를 적용하여 `nonisolated(unsafe)`를 제거하였습니다.

## 작업 내용
- `uiDelegate`를 `nonisolated let` → `nonisolated(unsafe) weak var`로 변경하여 메모리 누수 해결
- 클래스 레벨 `@MainActor` 적용 및 메서드 레벨 중복 어노테이션 제거
- weak reference 동작 검증 테스트 추가