### PR TITLE
chore: upgrade Quick 7.6.x / Nimble 13.8.x and migrate tests

### DIFF
--- a/.github/workflows/create_dev_branch.yml
+++ b/.github/workflows/create_dev_branch.yml
@@ -1,0 +1,45 @@
+name: prepare dev branch
+
+on:
+  workflow_call:
+    inputs:
+      new_version:
+        description: 'New SDK version for dev branch (e.g. 2.67.0)'
+        required: true
+        type: string
+    outputs:
+      branch_name:
+        description: 'Dev branch name'
+        value: ${{ jobs.prepare.outputs.branch_name }}
+
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      branch_name: ${{ steps.branch.outputs.branch_name }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.PAT }}
+          fetch-depth: 0
+
+      - name: Create or checkout dev branch
+        id: branch
+        run: |
+          DEV_BRANCH="dev-${{ inputs.new_version }}"
+          echo "branch_name=$DEV_BRANCH" >> $GITHUB_OUTPUT
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          if git ls-remote --heads origin "$DEV_BRANCH" | grep -q "$DEV_BRANCH"; then
+            echo "Dev branch $DEV_BRANCH already exists, checking out"
+            git fetch origin "$DEV_BRANCH"
+            git checkout "$DEV_BRANCH"
+          else
+            echo "Creating new dev branch $DEV_BRANCH"
+            git checkout -b "$DEV_BRANCH"
+            git push origin "$DEV_BRANCH"
+          fi

--- a/.github/workflows/update_javascript_sdk.yml
+++ b/.github/workflows/update_javascript_sdk.yml
@@ -1,0 +1,117 @@
+name: update javascript sdk
+
+on:
+  repository_dispatch:
+    types: [update-javascript-sdk]
+
+jobs:
+  calculate-version:
+    runs-on: ubuntu-latest
+    outputs:
+      new_version: ${{ steps.version.outputs.new_version }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Calculate next minor version
+        id: version
+        run: |
+          CURRENT=$(sed -n -E 's/.*static let CURRENT = "([0-9]+\.[0-9]+\.[0-9]+)".*/\1/p' Sources/Hackle/Core/Utilities/SdkVersion.swift)
+          if [[ -z "$CURRENT" ]]; then
+            echo "Error: Failed to parse current SDK version"
+            exit 1
+          fi
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT"
+          NEXT_MINOR=$((MINOR + 1))
+          NEW_VERSION="${MAJOR}.${NEXT_MINOR}.0"
+          echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
+
+  prepare-dev-branch:
+    needs: calculate-version
+    uses: ./.github/workflows/create_dev_branch.yml
+    with:
+      new_version: ${{ needs.calculate-version.outputs.new_version }}
+    secrets: inherit
+
+  update-js-sdk:
+    needs: [calculate-version, prepare-dev-branch]
+    runs-on: ubuntu-latest
+    env:
+      JS_SDK_VERSION: ${{ github.event.client_payload.js_sdk_version }}
+
+    steps:
+      - name: Validate input
+        run: |
+          if [[ -z "$JS_SDK_VERSION" ]]; then
+            echo "Error: js_sdk_version is required"
+            exit 1
+          fi
+          if [[ ! "$JS_SDK_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Error: js_sdk_version must be in X.Y.Z format"
+            exit 1
+          fi
+          echo "JS SDK version: $JS_SDK_VERSION"
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare-dev-branch.outputs.branch_name }}
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Download JS SDK from npm
+        run: |
+          npm pack "@hackler/javascript-sdk@$JS_SDK_VERSION" --pack-destination /tmp
+          cd /tmp
+          tar xzf hackler-javascript-sdk-*.tgz
+          if [[ ! -f /tmp/package/lib/index.browser.umd.min.js ]]; then
+            echo "Error: index.browser.umd.min.js not found in npm package"
+            exit 1
+          fi
+
+      - name: Replace JS SDK file
+        run: |
+          cp /tmp/package/lib/index.browser.umd.min.js \
+            "Sources/Hackle/Resources/hackle-javascript-sdk-${JS_SDK_VERSION}.min.js"
+          ls "Sources/Hackle/Resources/hackle-javascript-sdk-${JS_SDK_VERSION}.min.js" || \
+            { echo "Error: JS SDK file not found after copy"; exit 1; }
+          find Sources/Hackle/Resources -name "hackle-javascript-sdk-*.min.js" \
+            ! -name "hackle-javascript-sdk-${JS_SDK_VERSION}.min.js" -delete
+
+      - name: Update source references
+        run: |
+          sed -i -E "s/(static let javascriptSdkVersion = \")[^\"]+\"/\1${JS_SDK_VERSION}\"/" \
+            Sources/Hackle/UI/InAppMessageUI/Views/Html/InAppMessageUIHtmlViewBridgeScript.swift
+
+          sed -i -E "s/\.process\(\"Resources\/hackle-javascript-sdk-[^\"]+\.min\.js\"\)/.process(\"Resources\/hackle-javascript-sdk-${JS_SDK_VERSION}.min.js\")/" \
+            Package.swift
+
+      - name: Commit and push
+        run: |
+          FEATURE_BRANCH="update-javascript-sdk-$JS_SDK_VERSION"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$FEATURE_BRANCH"
+          git add \
+            Sources/Hackle/Resources/ \
+            Sources/Hackle/UI/InAppMessageUI/Views/Html/InAppMessageUIHtmlViewBridgeScript.swift \
+            Package.swift
+          git commit -m "chore: update @hackler/javascript-sdk@$JS_SDK_VERSION"
+          git push origin "$FEATURE_BRANCH"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DEV_BRANCH: ${{ needs.prepare-dev-branch.outputs.branch_name }}
+        run: |
+          gh pr create \
+            --base "$DEV_BRANCH" \
+            --title "[Automation] Update @hackler/javascript-sdk@$JS_SDK_VERSION" \
+            --body "## Description
+          - Update @hackler/javascript-sdk@$JS_SDK_VERSION
+
+          > **Note:** \`Hackle.xcodeproj\`는 수동으로 업데이트 필요"

--- a/Hackle.podspec
+++ b/Hackle.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 spec.name          = "Hackle"
 spec.module_name   = "Hackle"
-spec.version       = "3.2.1"
+spec.version       = "3.2.2"
 spec.summary       = "Hackle Sdk for iOS"
 spec.homepage      = "https://www.hackle.io"
 spec.license       = { :type => "Apache License, Version 2.0", :file => "LICENSE" }

--- a/Hackle.xcodeproj/project.pbxproj
+++ b/Hackle.xcodeproj/project.pbxproj
@@ -59,6 +59,7 @@
 		7E9F7E892B6CCC3700A6B0B8 /* MockFileStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E9F7E882B6CCC3700A6B0B8 /* MockFileStorage.swift */; };
 		7EE320D82B56707800105A6C /* workspace_config.json in Resources */ = {isa = PBXBuildFile; fileRef = 7EE320D72B56707800105A6C /* workspace_config.json */; };
 		7EE320DA2B5692D900105A6C /* workspace_response.json in Resources */ = {isa = PBXBuildFile; fileRef = 7EE320D92B5692D900105A6C /* workspace_response.json */; };
+		B203A5842F8E17BD00BDAD31 /* HackleUIDelegateSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = B203A5832F8E17BD00BDAD31 /* HackleUIDelegateSpecs.swift */; };
 		B20B23142E56F0100019EAA7 /* MimeType.swift in Sources */ = {isa = PBXBuildFile; fileRef = B20B23132E56F0040019EAA7 /* MimeType.swift */; };
 		B20B234E2E56FB980019EAA7 /* MimeTypeSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = B20B234D2E56FB910019EAA7 /* MimeTypeSpecs.swift */; };
 		B21078412E90C21F00D26B60 /* BundleVersionInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = B21078402E90C21500D26B60 /* BundleVersionInfo.swift */; };
@@ -789,6 +790,7 @@
 		7E9F7E882B6CCC3700A6B0B8 /* MockFileStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockFileStorage.swift; sourceTree = "<group>"; };
 		7EE320D72B56707800105A6C /* workspace_config.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = workspace_config.json; sourceTree = "<group>"; };
 		7EE320D92B5692D900105A6C /* workspace_response.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = workspace_response.json; sourceTree = "<group>"; };
+		B203A5832F8E17BD00BDAD31 /* HackleUIDelegateSpecs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HackleUIDelegateSpecs.swift; sourceTree = "<group>"; };
 		B20B23132E56F0040019EAA7 /* MimeType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MimeType.swift; sourceTree = "<group>"; };
 		B20B234D2E56FB910019EAA7 /* MimeTypeSpecs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MimeTypeSpecs.swift; sourceTree = "<group>"; };
 		B21078402E90C21500D26B60 /* BundleVersionInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundleVersionInfo.swift; sourceTree = "<group>"; };
@@ -1508,6 +1510,7 @@
 				EE55B4942F63C72100A36359 /* Invocation */,
 				B26AC2912E4C5AA300AAE56F /* InvocationDtoSpecs.swift */,
 				7E64779A2AD4F19D00971F20 /* HackleInvocationSpec.swift */,
+				B203A5832F8E17BD00BDAD31 /* HackleUIDelegateSpecs.swift */,
 				B2FCB8BF2EB1B069001C6B14 /* HackleJavascriptBridgeSpecs.swift */,
 			);
 			path = Invocator;
@@ -4289,6 +4292,7 @@
 				EE543CDD2C09AA8600F64BFA /* MockViewManager.swift in Sources */,
 				EE29DA6B29CD82C200B1FEAA /* ClockSpecs.swift in Sources */,
 				EE29DA9229CD82C200B1FEAA /* DefaultBucketerSpec.swift in Sources */,
+				B203A5842F8E17BD00BDAD31 /* HackleUIDelegateSpecs.swift in Sources */,
 				7E0F05472AD7BA6800631B42 /* MockRemoteConfig.swift in Sources */,
 				7E9F7E892B6CCC3700A6B0B8 /* MockFileStorage.swift in Sources */,
 				EEF895912A4971DE00722CF6 /* InAppMessageMatcherStub.swift in Sources */,

--- a/Hackle.xcodeproj/project.pbxproj
+++ b/Hackle.xcodeproj/project.pbxproj
@@ -4767,7 +4767,7 @@
 			repositoryURL = "https://github.com/Quick/Quick.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 3.0.0;
+				minimumVersion = 7.0.0;
 			};
 		};
 		EE67F86A25828DE4006CD00A /* XCRemoteSwiftPackageReference "Nimble" */ = {
@@ -4775,7 +4775,7 @@
 			repositoryURL = "https://github.com/Quick/Nimble.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 9.0.0;
+				minimumVersion = 13.0.0;
 			};
 		};
 		EE67F87125828DFF006CD00A /* XCRemoteSwiftPackageReference "MockingKit" */ = {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,52 +1,77 @@
 {
-  "object": {
-    "pins": [
-      {
-        "package": "CwlCatchException",
-        "repositoryURL": "https://github.com/mattgallagher/CwlCatchException.git",
-        "state": {
-          "branch": null,
-          "revision": "07b2ba21d361c223e25e3c1e924288742923f08c",
-          "version": "2.2.1"
-        }
-      },
-      {
-        "package": "CwlPreconditionTesting",
-        "repositoryURL": "https://github.com/mattgallagher/CwlPreconditionTesting.git",
-        "state": {
-          "branch": null,
-          "revision": "0139c665ebb45e6a9fbdb68aabfd7c39f3fe0071",
-          "version": "2.2.2"
-        }
-      },
-      {
-        "package": "MockingKit",
-        "repositoryURL": "https://github.com/danielsaidi/MockingKit.git",
-        "state": {
-          "branch": null,
-          "revision": "a1096bb9b149b70147e6fb8294f720989edf72ae",
-          "version": "1.5.0"
-        }
-      },
-      {
-        "package": "Nimble",
-        "repositoryURL": "https://github.com/Quick/Nimble.git",
-        "state": {
-          "branch": null,
-          "revision": "7a54aaf19a8ef16f67787c260fda81ead7ba4d67",
-          "version": "9.0.1"
-        }
-      },
-      {
-        "package": "Quick",
-        "repositoryURL": "https://github.com/Quick/Quick.git",
-        "state": {
-          "branch": null,
-          "revision": "71c90eda2ab14b2110b22222d4b373163126561c",
-          "version": "3.0.1"
-        }
+  "pins" : [
+    {
+      "identity" : "cwlcatchexception",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattgallagher/CwlCatchException.git",
+      "state" : {
+        "revision" : "07b2ba21d361c223e25e3c1e924288742923f08c",
+        "version" : "2.2.1"
       }
-    ]
-  },
-  "version": 1
+    },
+    {
+      "identity" : "cwlpreconditiontesting",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattgallagher/CwlPreconditionTesting.git",
+      "state" : {
+        "revision" : "0139c665ebb45e6a9fbdb68aabfd7c39f3fe0071",
+        "version" : "2.2.2"
+      }
+    },
+    {
+      "identity" : "mockingkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/danielsaidi/MockingKit.git",
+      "state" : {
+        "revision" : "a1096bb9b149b70147e6fb8294f720989edf72ae",
+        "version" : "1.5.0"
+      }
+    },
+    {
+      "identity" : "nimble",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Quick/Nimble.git",
+      "state" : {
+        "revision" : "cc945f7bdf3b485adedc315e18685c065059b4ca",
+        "version" : "13.8.0"
+      }
+    },
+    {
+      "identity" : "quick",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Quick/Quick.git",
+      "state" : {
+        "revision" : "1163a1b1b114a657c7432b63dd1f92ce99fe11a6",
+        "version" : "7.6.2"
+      }
+    },
+    {
+      "identity" : "swift-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-algorithms.git",
+      "state" : {
+        "revision" : "87e50f483c54e6efd60e885f7f5aa946cee68023",
+        "version" : "1.2.1"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser.git",
+      "state" : {
+        "revision" : "626b5b7b2f45e1b0b1c6f4a309296d1d21d7311b",
+        "version" : "1.7.1"
+      }
+    },
+    {
+      "identity" : "swift-numerics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-numerics.git",
+      "state" : {
+        "revision" : "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
+        "version" : "1.1.1"
+      }
+    }
+  ],
+  "version" : 2
 }

--- a/Package.swift
+++ b/Package.swift
@@ -12,8 +12,8 @@ let package = Package(
         .library(name: "Hackle", targets: ["Hackle"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/Quick/Quick.git", .upToNextMinor(from: "3.0.0")),
-        .package(url: "https://github.com/Quick/Nimble.git", .upToNextMinor(from: "9.0.0")),
+        .package(url: "https://github.com/Quick/Quick.git", .upToNextMinor(from: "7.6.0")),
+        .package(url: "https://github.com/Quick/Nimble.git", .upToNextMinor(from: "13.8.0")),
         .package(url: "https://github.com/danielsaidi/MockingKit.git", from: "1.5.0"),
     ],
     targets: [

--- a/Sources/Hackle/Core/Utilities/SdkVersion.swift
+++ b/Sources/Hackle/Core/Utilities/SdkVersion.swift
@@ -5,5 +5,5 @@
 import Foundation
 
 class SdkVersion {
-    static let CURRENT = "3.2.1"
+    static let CURRENT = "3.2.2"
 }

--- a/Sources/Hackle/Invocator/Web/HackleUIDelegate.swift
+++ b/Sources/Hackle/Invocator/Web/HackleUIDelegate.swift
@@ -1,17 +1,18 @@
 import Foundation
 import WebKit
 
+@MainActor
 class HackleUIDelegate: NSObject, WKUIDelegate {
 
     private let invocator: HackleInvocator
-    private nonisolated let uiDelegate: WKUIDelegate?
+    private nonisolated(unsafe) weak var uiDelegate: WKUIDelegate?
 
     init(invocator: HackleInvocator, uiDelegate: WKUIDelegate? = nil) {
         self.invocator = invocator
         self.uiDelegate = uiDelegate
     }
 
-    @MainActor func webView(_ webView: WKWebView, runJavaScriptTextInputPanelWithPrompt prompt: String, defaultText: String?, initiatedByFrame frame: WKFrameInfo, completionHandler: @escaping @MainActor @Sendable (String?) -> Void) {
+    func webView(_ webView: WKWebView, runJavaScriptTextInputPanelWithPrompt prompt: String, defaultText: String?, initiatedByFrame frame: WKFrameInfo, completionHandler: @escaping @MainActor @Sendable (String?) -> Void) {
         let processable = invocator.isInvocableString(string: prompt)
         if (processable) {
             let result = invocator.invoke(string: prompt)

--- a/Tests/HackleTests/Common/HackleInAppMessageActionTypeSpecs.swift
+++ b/Tests/HackleTests/Common/HackleInAppMessageActionTypeSpecs.swift
@@ -10,7 +10,7 @@ import Nimble
 @testable import Hackle
 
 class HackleInAppMessageActionTypeSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
         describe("HackleInAppMessageActionType") {
             it("rawValue로 초기화가 정상 동작한다") {
                 expect(HackleInAppMessageActionType(rawValue: "CLOSE")) == .close

--- a/Tests/HackleTests/Common/HackleNotificationClickActionTypeSpecs.swift
+++ b/Tests/HackleTests/Common/HackleNotificationClickActionTypeSpecs.swift
@@ -12,7 +12,7 @@ import MockingKit
 @testable import Hackle
 
 class HackleNotificationClickActionTypeSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
         it("from valid string") {
             expect(HackleNotificationClickActionType(rawValue: "LINK")).to(equal(HackleNotificationClickActionType.link))
             expect(HackleNotificationClickActionType(rawValue: "APP_OPEN")).to(equal(HackleNotificationClickActionType.appOpen))

--- a/Tests/HackleTests/Common/HacklePushSubscriptionStatusSpecs.swift
+++ b/Tests/HackleTests/Common/HacklePushSubscriptionStatusSpecs.swift
@@ -11,7 +11,7 @@ import Nimble
 
 @available(*, deprecated, message: "")
 class HacklePushSubscriptionStatusSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
         describe("HacklePushSubscriptionStatus") {
             it("rawValue로 초기화가 정상 동작한다") {
                 expect(HacklePushSubscriptionStatus(rawValue: "SUBSCRIBED")) == .subscribed

--- a/Tests/HackleTests/Common/HackleSubscriptionSpecs.swift
+++ b/Tests/HackleTests/Common/HackleSubscriptionSpecs.swift
@@ -10,7 +10,7 @@ import Nimble
 @testable import Hackle
 
 class HackleSubscriptionSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
         describe("HackleSubscriptionStatus") {
             it("should initialize with raw value") {
                 expect(HackleSubscriptionStatus(rawValue: "SUBSCRIBED")).to(equal(.subscribed))

--- a/Tests/HackleTests/Common/HackleWebViewConfigSpecs.swift
+++ b/Tests/HackleTests/Common/HackleWebViewConfigSpecs.swift
@@ -11,7 +11,7 @@ import Nimble
 @testable import Hackle
 
 class HackleWebViewConfigSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
         describe("HackleWebViewConfig") {
 
             describe("builder") {

--- a/Tests/HackleTests/Common/PropertiesBuilderSpecs.swift
+++ b/Tests/HackleTests/Common/PropertiesBuilderSpecs.swift
@@ -13,7 +13,7 @@ class PropertiesBuilderSpecs: QuickSpec {
         }
     }
 
-    override func spec() {
+    override class func spec() {
         it("valid raw value") {
             expect(NSDictionary(dictionary: PropertiesBuilder().add("key", 1).build()).isEqual(to: ["key": 1])).to(beTrue())
             expect(NSDictionary(dictionary: PropertiesBuilder().add("key", "1").build()).isEqual(to: ["key": "1"])).to(beTrue())

--- a/Tests/HackleTests/Common/PropertiesBuilderSpecs.swift
+++ b/Tests/HackleTests/Common/PropertiesBuilderSpecs.swift
@@ -6,7 +6,7 @@ import MockingKit
 
 class PropertiesBuilderSpecs: QuickSpec {
 
-    func equals(_ p1: [String: Any], _ p2: [String: Any]) {
+    static func equals(_ p1: [String: Any], _ p2: [String: Any]) {
         expect(p1.count) == p2.count
         for (key, value) in p1 {
             expect(PropertyOperators.equals(value, p2[key] as Any)) == true
@@ -80,15 +80,15 @@ class PropertiesBuilderSpecs: QuickSpec {
                 .add("b", 4, setOnce: true)
                 .build()
 
-            self.equals(properties, ["a": 2, "b": 3])
+            equals(properties, ["a": 2, "b": 3])
         }
 
         it("setOnce2") {
             let p1 = ["k1": 1, "k2": 1]
             let p2 = ["k1": 2, "k2": 2]
 
-            self.equals(PropertiesBuilder().add(p1).add(p2).build(), ["k1": 2, "k2": 2])
-            self.equals(PropertiesBuilder().add(p1).add(p2, setOnce: true).build(), ["k1": 1, "k2": 1])
+            equals(PropertiesBuilder().add(p1).add(p2).build(), ["k1": 2, "k2": 2])
+            equals(PropertiesBuilder().add(p1).add(p2, setOnce: true).build(), ["k1": 1, "k2": 1])
         }
 
         it("add system properties") {
@@ -97,7 +97,7 @@ class PropertiesBuilderSpecs: QuickSpec {
                 .add("set", ["age": 32])
                 .build()
             expect(properties.count) == 1
-            self.equals(properties["$set"] as! [String: Any], ["age": 30])
+            equals(properties["$set"] as! [String: Any], ["age": 30])
         }
 
         it("remove") {
@@ -137,7 +137,7 @@ class PropertiesBuilderSpecs: QuickSpec {
                 }
                 .build()
 
-            self.equals(properties, ["age": 84, "location": "Seoul"])
+            equals(properties, ["age": 84, "location": "Seoul"])
         }
     }
 }

--- a/Tests/HackleTests/Common/PropertyOperationSpecs.swift
+++ b/Tests/HackleTests/Common/PropertyOperationSpecs.swift
@@ -12,7 +12,7 @@ class PropertyOperationSpecs: QuickSpec {
         }
     }
 
-    override func spec() {
+    override class func spec() {
 
         describe("PropertyOperation") {
             it("key") {

--- a/Tests/HackleTests/Common/PropertyOperationSpecs.swift
+++ b/Tests/HackleTests/Common/PropertyOperationSpecs.swift
@@ -5,7 +5,7 @@ import Nimble
 
 class PropertyOperationSpecs: QuickSpec {
 
-    func equals(_ p1: [String: Any], _ p2: [String: Any]) {
+    static func equals(_ p1: [String: Any], _ p2: [String: Any]) {
         expect(p1.count) == p2.count
         for (key, value) in p1 {
             expect(PropertyOperators.equals(value, p2[key] as Any)) == true
@@ -99,16 +99,16 @@ class PropertyOperationSpecs: QuickSpec {
 
                 expect(event.key) == "$properties"
 
-                self.equals(event.properties!["$set"] as! [String: Any], ["set1": 42, "set2": ["a", "b"]])
-                self.equals(event.properties!["$setOnce"] as! [String: Any], ["setOnce": 43])
-                self.equals(event.properties!["$unset"] as! [String: Any], ["unset": "-"])
-                self.equals(event.properties!["$increment"] as! [String: Any], ["increment": 44])
-                self.equals(event.properties!["$append"] as! [String: Any], ["append": 45])
-                self.equals(event.properties!["$appendOnce"] as! [String: Any], ["appendOnce": 46])
-                self.equals(event.properties!["$prepend"] as! [String: Any], ["prepend": 47])
-                self.equals(event.properties!["$prependOnce"] as! [String: Any], ["prependOnce": 48])
-                self.equals(event.properties!["$remove"] as! [String: Any], ["remove": 49])
-                self.equals(event.properties!["$clearAll"] as! [String: Any], ["clearAll": "-"])
+                equals(event.properties!["$set"] as! [String: Any], ["set1": 42, "set2": ["a", "b"]])
+                equals(event.properties!["$setOnce"] as! [String: Any], ["setOnce": 43])
+                equals(event.properties!["$unset"] as! [String: Any], ["unset": "-"])
+                equals(event.properties!["$increment"] as! [String: Any], ["increment": 44])
+                equals(event.properties!["$append"] as! [String: Any], ["append": 45])
+                equals(event.properties!["$appendOnce"] as! [String: Any], ["appendOnce": 46])
+                equals(event.properties!["$prepend"] as! [String: Any], ["prepend": 47])
+                equals(event.properties!["$prependOnce"] as! [String: Any], ["prependOnce": 48])
+                equals(event.properties!["$remove"] as! [String: Any], ["remove": 49])
+                equals(event.properties!["$clearAll"] as! [String: Any], ["clearAll": "-"])
             }
         }
     }

--- a/Tests/HackleTests/Common/ScreenBuilderSpecs.swift
+++ b/Tests/HackleTests/Common/ScreenBuilderSpecs.swift
@@ -6,7 +6,7 @@ import MockingKit
 
 class ScreenBuilderSpecs: QuickSpec {
 
-    override func spec() {
+    override class func spec() {
 
         describe("HackleScreenBuilder") {
 

--- a/Tests/HackleTests/Common/UserSpecs.swift
+++ b/Tests/HackleTests/Common/UserSpecs.swift
@@ -5,7 +5,7 @@ import MockingKit
 @testable import Hackle
 
 class UserSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
         it("builder") {
             let user = HackleUserBuilder()
                 .id("id")

--- a/Tests/HackleTests/Core/Application/ApplicationEventTrackerSpec.swift
+++ b/Tests/HackleTests/Core/Application/ApplicationEventTrackerSpec.swift
@@ -5,7 +5,7 @@ import MockingKit
 @testable import Hackle
 
 class ApplicationEventTrackerSpec: QuickSpec {
-    override func spec() {
+    override class func spec() {
         var userManager: MockUserManager!
         var core: MockHackleCore!
         var sut: ApplicationEventTracker!

--- a/Tests/HackleTests/Core/Application/Install/ApplicationInstallDeterminerSpec.swift
+++ b/Tests/HackleTests/Core/Application/Install/ApplicationInstallDeterminerSpec.swift
@@ -4,7 +4,7 @@ import Nimble
 @testable import Hackle
 
 class ApplicationInstallDeterminerSpec: QuickSpec {
-    override func spec() {
+    override class func spec() {
         var sut: ApplicationInstallDeterminer!
 
         describe("determine") {

--- a/Tests/HackleTests/Core/Application/Install/ApplicationInstallStateManagerSpec.swift
+++ b/Tests/HackleTests/Core/Application/Install/ApplicationInstallStateManagerSpec.swift
@@ -4,7 +4,7 @@ import Nimble
 @testable import Hackle
 
 class ApplicationInstallStateManagerSpec: QuickSpec {
-    override func spec() {
+    override class func spec() {
         var clock: Clock!
         var repository: KeyValueRepository!
         var determiner: ApplicationInstallDeterminer!

--- a/Tests/HackleTests/Core/Database/DatabaseSpecs.swift
+++ b/Tests/HackleTests/Core/Database/DatabaseSpecs.swift
@@ -11,7 +11,7 @@ import Nimble
 import Foundation
 
 class DatabaseSpec: QuickSpec {
-    override func spec() {
+    override class func spec() {
         describe("Database") {
             var mockDB: MockDatabase!
             let testLabel = "TestDatabase"

--- a/Tests/HackleTests/Core/Database/SQLiteEventRepositorySpec.swift
+++ b/Tests/HackleTests/Core/Database/SQLiteEventRepositorySpec.swift
@@ -11,7 +11,7 @@ import Quick
 @testable import Hackle
 
 class SQLiteEventRepositorySpec: QuickSpec {
-    override func spec() {
+    override class func spec() {
         var sut: MockSQLiteEventRepository!
 
         beforeEach {

--- a/Tests/HackleTests/Core/Database/UserDefaultKeyValueRepositorySpecs.swift
+++ b/Tests/HackleTests/Core/Database/UserDefaultKeyValueRepositorySpecs.swift
@@ -11,7 +11,7 @@ import Nimble
 @testable import Hackle
 
 class UserDefaultsKeyValueRepositorySpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
         describe("UserDefaultsKeyValueRepository") {
             var repository: UserDefaultsKeyValueRepository!
             let testSuiteName = "com.test.userDefaultsRepositorySpec"

--- a/Tests/HackleTests/Core/DefaultHackleCoreSpecs.swift
+++ b/Tests/HackleTests/Core/DefaultHackleCoreSpecs.swift
@@ -4,7 +4,7 @@ import Nimble
 @testable import Hackle
 
 class DefaultHackleCoreSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
 
         let user = HackleUser.of(userId: "test")
 

--- a/Tests/HackleTests/Core/Engagement/EngagementEventTrackerSpecs.swift
+++ b/Tests/HackleTests/Core/Engagement/EngagementEventTrackerSpecs.swift
@@ -4,7 +4,7 @@ import Nimble
 @testable import Hackle
 
 class EngagementEventTrackerSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
         var userManager: MockUserManager!
         var core: MockHackleCore!
         var sut: EngagementEventTracker!

--- a/Tests/HackleTests/Core/Engagement/EngagementManagerSpecs.swift
+++ b/Tests/HackleTests/Core/Engagement/EngagementManagerSpecs.swift
@@ -5,7 +5,7 @@ import UIKit
 @testable import Hackle
 
 class EngagementManagerSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
         let user = User.builder().build()
         var userManager: MockUserManager!
         var screenManager: MockScreeManager!

--- a/Tests/HackleTests/Core/Evaluation/Action/DefaultActionResolverSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Action/DefaultActionResolverSpecs.swift
@@ -31,7 +31,7 @@ class DefaultActionResolverSpecs: QuickSpec {
                     let actual = try sut.resolveOrNil(request: request, action: action)
 
                     // then
-                    expect(actual as AnyObject).to(beIdenticalTo(variation as AnyObject))
+                    expect(actual as! MockVariation).to(beIdenticalTo(variation))
                 }
 
 
@@ -172,7 +172,7 @@ class DefaultActionResolverSpecs: QuickSpec {
                     let actual = try sut.resolveOrNil(request: request, action: action)
 
                     // then
-                    expect(actual as AnyObject).to(beIdenticalTo(variation as AnyObject))
+                    expect(actual as! MockVariation).to(beIdenticalTo(variation))
                 }
             }
         }

--- a/Tests/HackleTests/Core/Evaluation/Action/DefaultActionResolverSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Action/DefaultActionResolverSpecs.swift
@@ -31,7 +31,7 @@ class DefaultActionResolverSpecs: QuickSpec {
                     let actual = try sut.resolveOrNil(request: request, action: action)
 
                     // then
-                    expect(actual as! MockVariation).to(beIdenticalTo(variation))
+                    expect(actual as? MockVariation).to(beIdenticalTo(variation))
                 }
 
 
@@ -172,7 +172,7 @@ class DefaultActionResolverSpecs: QuickSpec {
                     let actual = try sut.resolveOrNil(request: request, action: action)
 
                     // then
-                    expect(actual as! MockVariation).to(beIdenticalTo(variation))
+                    expect(actual as? MockVariation).to(beIdenticalTo(variation))
                 }
             }
         }

--- a/Tests/HackleTests/Core/Evaluation/Action/DefaultActionResolverSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Action/DefaultActionResolverSpecs.swift
@@ -5,7 +5,7 @@ import Nimble
 
 class DefaultActionResolverSpecs: QuickSpec {
 
-    override func spec() {
+    override class func spec() {
 
         var bucketer: MockBucketer!
         var sut: DefaultActionResolver!

--- a/Tests/HackleTests/Core/Evaluation/Action/DefaultActionResolverSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Action/DefaultActionResolverSpecs.swift
@@ -31,7 +31,7 @@ class DefaultActionResolverSpecs: QuickSpec {
                     let actual = try sut.resolveOrNil(request: request, action: action)
 
                     // then
-                    expect(actual).to(beIdenticalTo(variation))
+                    expect(actual as AnyObject).to(beIdenticalTo(variation as AnyObject))
                 }
 
 
@@ -172,7 +172,7 @@ class DefaultActionResolverSpecs: QuickSpec {
                     let actual = try sut.resolveOrNil(request: request, action: action)
 
                     // then
-                    expect(actual).to(beIdenticalTo(variation))
+                    expect(actual as AnyObject).to(beIdenticalTo(variation as AnyObject))
                 }
             }
         }

--- a/Tests/HackleTests/Core/Evaluation/Bucket/DefaultBucketerSpec.swift
+++ b/Tests/HackleTests/Core/Evaluation/Bucket/DefaultBucketerSpec.swift
@@ -31,7 +31,7 @@ class DefaultBucketerSpec: QuickSpec {
                 let actual = sut.bucketing(bucket: bucket, identifier: "test_id")
 
                 // then
-                expect(actual).to(beIdenticalTo(slot))
+                expect(actual as AnyObject).to(beIdenticalTo(slot as AnyObject))
                 expect(bucket.mockGetSlotOrNil.invokations().count) == 1
                 expect(bucket.mockGetSlotOrNil.invokations()[0].arguments) == 320
             }

--- a/Tests/HackleTests/Core/Evaluation/Bucket/DefaultBucketerSpec.swift
+++ b/Tests/HackleTests/Core/Evaluation/Bucket/DefaultBucketerSpec.swift
@@ -31,7 +31,7 @@ class DefaultBucketerSpec: QuickSpec {
                 let actual = sut.bucketing(bucket: bucket, identifier: "test_id")
 
                 // then
-                expect(actual as! MockSlot).to(beIdenticalTo(slot))
+                expect(actual as? MockSlot).to(beIdenticalTo(slot))
                 expect(bucket.mockGetSlotOrNil.invokations().count) == 1
                 expect(bucket.mockGetSlotOrNil.invokations()[0].arguments) == 320
             }

--- a/Tests/HackleTests/Core/Evaluation/Bucket/DefaultBucketerSpec.swift
+++ b/Tests/HackleTests/Core/Evaluation/Bucket/DefaultBucketerSpec.swift
@@ -31,7 +31,7 @@ class DefaultBucketerSpec: QuickSpec {
                 let actual = sut.bucketing(bucket: bucket, identifier: "test_id")
 
                 // then
-                expect(actual as AnyObject).to(beIdenticalTo(slot as AnyObject))
+                expect(actual as! MockSlot).to(beIdenticalTo(slot))
                 expect(bucket.mockGetSlotOrNil.invokations().count) == 1
                 expect(bucket.mockGetSlotOrNil.invokations()[0].arguments) == 320
             }

--- a/Tests/HackleTests/Core/Evaluation/Bucket/DefaultBucketerSpec.swift
+++ b/Tests/HackleTests/Core/Evaluation/Bucket/DefaultBucketerSpec.swift
@@ -8,7 +8,7 @@ import Nimble
 @testable import Hackle
 
 class DefaultBucketerSpec: QuickSpec {
-    override func spec() {
+    override class func spec() {
 
         var slotNumberCalculator: MockSlotNumberCalculator!
         var sut: DefaultBucketer!

--- a/Tests/HackleTests/Core/Evaluation/Bucket/DefaultSlotNumberCalculatorSpec.swift
+++ b/Tests/HackleTests/Core/Evaluation/Bucket/DefaultSlotNumberCalculatorSpec.swift
@@ -8,7 +8,7 @@ import Nimble
 @testable import Hackle
 
 class DefaultSlotNumberCalculatorSpec: QuickSpec {
-    override func spec() {
+    override class func spec() {
         let sut = DefaultSlotNumberCalculator(hasher: Murmur3Hasher())
 
         it("calculate") {

--- a/Tests/HackleTests/Core/Evaluation/Bucket/Murmur3HasherSpec.swift
+++ b/Tests/HackleTests/Core/Evaluation/Bucket/Murmur3HasherSpec.swift
@@ -8,7 +8,7 @@ import Nimble
 @testable import Hackle
 
 class Murmur3HasherSpec: QuickSpec {
-    override func spec() {
+    override class func spec() {
 
         let sut = Murmur3Hasher()
 

--- a/Tests/HackleTests/Core/Evaluation/Container/DefaultContainerResolverSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Container/DefaultContainerResolverSpecs.swift
@@ -6,7 +6,7 @@ import MockingKit
 
 
 class DefaultContainerResolverSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
 
         var bucketer: MockBucketer!
         var sut: DefaultContainerResolver!

--- a/Tests/HackleTests/Core/Evaluation/Evaluator/DefaultEvaluationEventRecorderSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Evaluator/DefaultEvaluationEventRecorderSpecs.swift
@@ -4,7 +4,7 @@ import Nimble
 @testable import Hackle
 
 class DefaultEvaluationEventRecorderSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
 
         var eventFactory: MockUserEventFactory!
         var eventProcessor: MockUserEventProcessor!

--- a/Tests/HackleTests/Core/Evaluation/Evaluator/DelegatingEvaluatorSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Evaluator/DelegatingEvaluatorSpecs.swift
@@ -12,7 +12,7 @@ import MockingKit
 @testable import Hackle
 
 class DelegatingEvaluatorSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
 
         it("evaluate") {
             let sut = DelegatingEvaluator()

--- a/Tests/HackleTests/Core/Evaluation/Evaluator/EvaluatorContextSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Evaluator/EvaluatorContextSpecs.swift
@@ -55,18 +55,18 @@ class EvaluatorContextSpecs: QuickSpec {
             let targetEvaluations2 = context.targetEvaluations
             expect(targetEvaluations1.count).to(equal(1))
             expect(targetEvaluations2.count).to(equal(2))
-            expect(context.get(experiment)).to(beIdenticalTo(evaluation2))
+            expect(context.get(experiment) as AnyObject).to(beIdenticalTo(evaluation2 as AnyObject))
         }
 
         it("properties") {
             let context = Evaluators.context()
             let p1 = context.properties
-            expect(p1).to(be([:]))
+            expect(p1.isEmpty) == true
 
             context.setProperty("a", 1)
             let p2 = context.properties
 
-            expect(p1).to(be([:]))
+            expect(p1.isEmpty) == true
             expect(p2["a"] as? Int).to(equal(1))
         }
     }

--- a/Tests/HackleTests/Core/Evaluation/Evaluator/EvaluatorContextSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Evaluator/EvaluatorContextSpecs.swift
@@ -55,18 +55,18 @@ class EvaluatorContextSpecs: QuickSpec {
             let targetEvaluations2 = context.targetEvaluations
             expect(targetEvaluations1.count).to(equal(1))
             expect(targetEvaluations2.count).to(equal(2))
-            expect(context.get(experiment) as! ExperimentEvaluation).to(beIdenticalTo(evaluation2))
+            expect(context.get(experiment) as? ExperimentEvaluation).to(beIdenticalTo(evaluation2))
         }
 
         it("properties") {
             let context = Evaluators.context()
             let p1 = context.properties
-            expect(p1.isEmpty) == true
+            expect(p1).to(beEmpty())
 
             context.setProperty("a", 1)
             let p2 = context.properties
 
-            expect(p1.isEmpty) == true
+            expect(p1).to(beEmpty())
             expect(p2["a"] as? Int).to(equal(1))
         }
     }

--- a/Tests/HackleTests/Core/Evaluation/Evaluator/EvaluatorContextSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Evaluator/EvaluatorContextSpecs.swift
@@ -11,7 +11,7 @@ import Nimble
 @testable import Hackle
 
 class EvaluatorContextSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
 
         it("stack") {
             let context = Evaluators.context()

--- a/Tests/HackleTests/Core/Evaluation/Evaluator/EvaluatorContextSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Evaluator/EvaluatorContextSpecs.swift
@@ -55,7 +55,7 @@ class EvaluatorContextSpecs: QuickSpec {
             let targetEvaluations2 = context.targetEvaluations
             expect(targetEvaluations1.count).to(equal(1))
             expect(targetEvaluations2.count).to(equal(2))
-            expect(context.get(experiment) as AnyObject).to(beIdenticalTo(evaluation2 as AnyObject))
+            expect(context.get(experiment) as! ExperimentEvaluation).to(beIdenticalTo(evaluation2))
         }
 
         it("properties") {

--- a/Tests/HackleTests/Core/Evaluation/Evaluator/Experiment/DefaultExperimentFlowFactorySpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Evaluator/Experiment/DefaultExperimentFlowFactorySpecs.swift
@@ -4,7 +4,7 @@ import Nimble
 @testable import Hackle
 
 class DefaultExperimentFlowFactorySpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
         var evaluationContext: EvaluationContext!
         var sut: DefaultExperimentFlowFactory!
 

--- a/Tests/HackleTests/Core/Evaluation/Evaluator/Experiment/ExperimentEvaluationSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Evaluator/Experiment/ExperimentEvaluationSpecs.swift
@@ -35,7 +35,7 @@ class ExperimentEvaluationSpecs: QuickSpec {
 
             expect(evaluation.reason) == DecisionReason.TRAFFIC_ALLOCATED
             expect(evaluation.targetEvaluations.count) == 1
-            expect(evaluation.experiment as! ExperimentEntity).to(beIdenticalTo(experiment as! ExperimentEntity))
+            expect(evaluation.experiment as? ExperimentEntity).to(beIdenticalTo(experiment as? ExperimentEntity))
             expect(evaluation.variationId) == variation.id
             expect(evaluation.variationKey) == "B"
             expect(evaluation.config).to(beIdenticalTo(config))
@@ -63,7 +63,7 @@ class ExperimentEvaluationSpecs: QuickSpec {
 
             expect(evaluation.reason) == DecisionReason.TRAFFIC_ALLOCATED
             expect(evaluation.targetEvaluations.count) == 1
-            expect(evaluation.experiment as! ExperimentEntity).to(beIdenticalTo(experiment as! ExperimentEntity))
+            expect(evaluation.experiment as? ExperimentEntity).to(beIdenticalTo(experiment as? ExperimentEntity))
             expect(evaluation.variationId) == variation.id
             expect(evaluation.variationKey) == "B"
             expect(evaluation.config).to(beNil())
@@ -109,7 +109,7 @@ class ExperimentEvaluationSpecs: QuickSpec {
 
             expect(evaluation.reason) == DecisionReason.TRAFFIC_NOT_ALLOCATED
             expect(evaluation.targetEvaluations.count) == 0
-            expect(evaluation.experiment as! ExperimentEntity).to(beIdenticalTo(experiment as! ExperimentEntity))
+            expect(evaluation.experiment as? ExperimentEntity).to(beIdenticalTo(experiment as? ExperimentEntity))
             expect(evaluation.variationId) == 320
             expect(evaluation.variationKey) == "A"
             expect(evaluation.config).to(beNil())
@@ -133,7 +133,7 @@ class ExperimentEvaluationSpecs: QuickSpec {
 
             expect(evaluation.reason) == DecisionReason.TRAFFIC_NOT_ALLOCATED
             expect(evaluation.targetEvaluations.count) == 0
-            expect(evaluation.experiment as! ExperimentEntity).to(beIdenticalTo(experiment as! ExperimentEntity))
+            expect(evaluation.experiment as? ExperimentEntity).to(beIdenticalTo(experiment as? ExperimentEntity))
             expect(evaluation.variationId).to(beNil())
             expect(evaluation.variationKey) == "C"
             expect(evaluation.config).to(beNil())

--- a/Tests/HackleTests/Core/Evaluation/Evaluator/Experiment/ExperimentEvaluationSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Evaluator/Experiment/ExperimentEvaluationSpecs.swift
@@ -35,7 +35,7 @@ class ExperimentEvaluationSpecs: QuickSpec {
 
             expect(evaluation.reason) == DecisionReason.TRAFFIC_ALLOCATED
             expect(evaluation.targetEvaluations.count) == 1
-            expect(evaluation.experiment).to(beIdenticalTo(experiment))
+            expect(evaluation.experiment as AnyObject).to(beIdenticalTo(experiment as AnyObject))
             expect(evaluation.variationId) == variation.id
             expect(evaluation.variationKey) == "B"
             expect(evaluation.config).to(beIdenticalTo(config))
@@ -63,7 +63,7 @@ class ExperimentEvaluationSpecs: QuickSpec {
 
             expect(evaluation.reason) == DecisionReason.TRAFFIC_ALLOCATED
             expect(evaluation.targetEvaluations.count) == 1
-            expect(evaluation.experiment).to(beIdenticalTo(experiment))
+            expect(evaluation.experiment as AnyObject).to(beIdenticalTo(experiment as AnyObject))
             expect(evaluation.variationId) == variation.id
             expect(evaluation.variationKey) == "B"
             expect(evaluation.config).to(beNil())
@@ -109,7 +109,7 @@ class ExperimentEvaluationSpecs: QuickSpec {
 
             expect(evaluation.reason) == DecisionReason.TRAFFIC_NOT_ALLOCATED
             expect(evaluation.targetEvaluations.count) == 0
-            expect(evaluation.experiment).to(beIdenticalTo(experiment))
+            expect(evaluation.experiment as AnyObject).to(beIdenticalTo(experiment as AnyObject))
             expect(evaluation.variationId) == 320
             expect(evaluation.variationKey) == "A"
             expect(evaluation.config).to(beNil())
@@ -133,7 +133,7 @@ class ExperimentEvaluationSpecs: QuickSpec {
 
             expect(evaluation.reason) == DecisionReason.TRAFFIC_NOT_ALLOCATED
             expect(evaluation.targetEvaluations.count) == 0
-            expect(evaluation.experiment).to(beIdenticalTo(experiment))
+            expect(evaluation.experiment as AnyObject).to(beIdenticalTo(experiment as AnyObject))
             expect(evaluation.variationId).to(beNil())
             expect(evaluation.variationKey) == "C"
             expect(evaluation.config).to(beNil())

--- a/Tests/HackleTests/Core/Evaluation/Evaluator/Experiment/ExperimentEvaluationSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Evaluator/Experiment/ExperimentEvaluationSpecs.swift
@@ -11,7 +11,7 @@ import Nimble
 @testable import Hackle
 
 class ExperimentEvaluationSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
         it("create by Variation") {
             let experiment = experiment(id: 42, key: 50,
                 variations: [

--- a/Tests/HackleTests/Core/Evaluation/Evaluator/Experiment/ExperimentEvaluationSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Evaluator/Experiment/ExperimentEvaluationSpecs.swift
@@ -35,7 +35,7 @@ class ExperimentEvaluationSpecs: QuickSpec {
 
             expect(evaluation.reason) == DecisionReason.TRAFFIC_ALLOCATED
             expect(evaluation.targetEvaluations.count) == 1
-            expect(evaluation.experiment as AnyObject).to(beIdenticalTo(experiment as AnyObject))
+            expect(evaluation.experiment as! ExperimentEntity).to(beIdenticalTo(experiment as! ExperimentEntity))
             expect(evaluation.variationId) == variation.id
             expect(evaluation.variationKey) == "B"
             expect(evaluation.config).to(beIdenticalTo(config))
@@ -63,7 +63,7 @@ class ExperimentEvaluationSpecs: QuickSpec {
 
             expect(evaluation.reason) == DecisionReason.TRAFFIC_ALLOCATED
             expect(evaluation.targetEvaluations.count) == 1
-            expect(evaluation.experiment as AnyObject).to(beIdenticalTo(experiment as AnyObject))
+            expect(evaluation.experiment as! ExperimentEntity).to(beIdenticalTo(experiment as! ExperimentEntity))
             expect(evaluation.variationId) == variation.id
             expect(evaluation.variationKey) == "B"
             expect(evaluation.config).to(beNil())
@@ -109,7 +109,7 @@ class ExperimentEvaluationSpecs: QuickSpec {
 
             expect(evaluation.reason) == DecisionReason.TRAFFIC_NOT_ALLOCATED
             expect(evaluation.targetEvaluations.count) == 0
-            expect(evaluation.experiment as AnyObject).to(beIdenticalTo(experiment as AnyObject))
+            expect(evaluation.experiment as! ExperimentEntity).to(beIdenticalTo(experiment as! ExperimentEntity))
             expect(evaluation.variationId) == 320
             expect(evaluation.variationKey) == "A"
             expect(evaluation.config).to(beNil())
@@ -133,7 +133,7 @@ class ExperimentEvaluationSpecs: QuickSpec {
 
             expect(evaluation.reason) == DecisionReason.TRAFFIC_NOT_ALLOCATED
             expect(evaluation.targetEvaluations.count) == 0
-            expect(evaluation.experiment as AnyObject).to(beIdenticalTo(experiment as AnyObject))
+            expect(evaluation.experiment as! ExperimentEntity).to(beIdenticalTo(experiment as! ExperimentEntity))
             expect(evaluation.variationId).to(beNil())
             expect(evaluation.variationKey) == "C"
             expect(evaluation.config).to(beNil())

--- a/Tests/HackleTests/Core/Evaluation/Evaluator/Experiment/ExperimentEvaluatorSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Evaluator/Experiment/ExperimentEvaluatorSpecs.swift
@@ -13,7 +13,7 @@ import MockingKit
 
 class ExperimentEvaluatorSpecs: QuickSpec {
 
-    override func spec() {
+    override class func spec() {
 
         var flowFactory: MockExperimentFlowFactory!
         var sut: ExperimentEvaluator!

--- a/Tests/HackleTests/Core/Evaluation/Evaluator/Experiment/ExperimentFlowEvaluatorSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Evaluator/Experiment/ExperimentFlowEvaluatorSpecs.swift
@@ -5,7 +5,7 @@ import Nimble
 
 
 class ExperimentFlowEvaluatorSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
 
         var nextFlow: ExperimentFlow!
         var context: EvaluatorContext!

--- a/Tests/HackleTests/Core/Evaluation/Evaluator/InAppMessage/Eligibility/DefaultInAppMessageEligibilityFlowFactorySpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Evaluator/InAppMessage/Eligibility/DefaultInAppMessageEligibilityFlowFactorySpecs.swift
@@ -4,7 +4,7 @@ import Nimble
 @testable import Hackle
 
 class DefaultInAppMessageEligibilityFlowFactorySpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
 
         var evaluationContext: EvaluationContext!
         var sut: DefaultInAppMessageEligibilityFlowFactory!

--- a/Tests/HackleTests/Core/Evaluation/Evaluator/InAppMessage/Eligibility/InAppMessageEligibilityEvaluatorSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Evaluator/InAppMessage/Eligibility/InAppMessageEligibilityEvaluatorSpecs.swift
@@ -91,7 +91,7 @@ class InAppMessageEligibilityEvaluatorSpecs: QuickSpec {
                 verify(exactly: 1) {
                     eventRecorder.recordMock
                 }
-                expect(eventRecorder.recordMock.firstInvokation().arguments.1 as AnyObject).to(beIdenticalTo(evaluation as AnyObject))
+                expect(eventRecorder.recordMock.firstInvokation().arguments.1 as! InAppMessageEligibilityEvaluation).to(beIdenticalTo(evaluation))
             }
 
             it("when eligible then do not record layout evaluation") {
@@ -110,7 +110,7 @@ class InAppMessageEligibilityEvaluatorSpecs: QuickSpec {
                 verify(exactly: 1) {
                     eventRecorder.recordMock
                 }
-                expect(eventRecorder.recordMock.firstInvokation().arguments.1 as AnyObject).to(beIdenticalTo(evaluation as AnyObject))
+                expect(eventRecorder.recordMock.firstInvokation().arguments.1 as! InAppMessageEligibilityEvaluation).to(beIdenticalTo(evaluation))
             }
 
             it("when ineligible without layout then do not record layout") {
@@ -128,7 +128,7 @@ class InAppMessageEligibilityEvaluatorSpecs: QuickSpec {
                 verify(exactly: 1) {
                     eventRecorder.recordMock
                 }
-                expect(eventRecorder.recordMock.firstInvokation().arguments.1 as AnyObject).to(beIdenticalTo(evaluation as AnyObject))
+                expect(eventRecorder.recordMock.firstInvokation().arguments.1 as! InAppMessageEligibilityEvaluation).to(beIdenticalTo(evaluation))
             }
 
             it("when ineligible with layout then record layout evaluation") {
@@ -147,8 +147,8 @@ class InAppMessageEligibilityEvaluatorSpecs: QuickSpec {
                 verify(exactly: 2) {
                     eventRecorder.recordMock
                 }
-                expect(eventRecorder.recordMock.invokations()[0].arguments.1 as AnyObject).to(beIdenticalTo(evaluation as AnyObject))
-                expect(eventRecorder.recordMock.invokations()[1].arguments.1 as AnyObject).to(beIdenticalTo(layoutEvaluation as AnyObject))
+                expect(eventRecorder.recordMock.invokations()[0].arguments.1 as! InAppMessageEligibilityEvaluation).to(beIdenticalTo(evaluation))
+                expect(eventRecorder.recordMock.invokations()[1].arguments.1 as! InAppMessageLayoutEvaluation).to(beIdenticalTo(layoutEvaluation))
             }
         }
     }

--- a/Tests/HackleTests/Core/Evaluation/Evaluator/InAppMessage/Eligibility/InAppMessageEligibilityEvaluatorSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Evaluator/InAppMessage/Eligibility/InAppMessageEligibilityEvaluatorSpecs.swift
@@ -4,7 +4,7 @@ import Nimble
 @testable import Hackle
 
 class InAppMessageEligibilityEvaluatorSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
 
         it("supports") {
             let sut = InAppMessageEligibilityEvaluator(

--- a/Tests/HackleTests/Core/Evaluation/Evaluator/InAppMessage/Eligibility/InAppMessageEligibilityEvaluatorSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Evaluator/InAppMessage/Eligibility/InAppMessageEligibilityEvaluatorSpecs.swift
@@ -91,7 +91,7 @@ class InAppMessageEligibilityEvaluatorSpecs: QuickSpec {
                 verify(exactly: 1) {
                     eventRecorder.recordMock
                 }
-                expect(eventRecorder.recordMock.firstInvokation().arguments.1).to(beIdenticalTo(evaluation))
+                expect(eventRecorder.recordMock.firstInvokation().arguments.1 as AnyObject).to(beIdenticalTo(evaluation as AnyObject))
             }
 
             it("when eligible then do not record layout evaluation") {
@@ -110,7 +110,7 @@ class InAppMessageEligibilityEvaluatorSpecs: QuickSpec {
                 verify(exactly: 1) {
                     eventRecorder.recordMock
                 }
-                expect(eventRecorder.recordMock.firstInvokation().arguments.1).to(beIdenticalTo(evaluation))
+                expect(eventRecorder.recordMock.firstInvokation().arguments.1 as AnyObject).to(beIdenticalTo(evaluation as AnyObject))
             }
 
             it("when ineligible without layout then do not record layout") {
@@ -128,7 +128,7 @@ class InAppMessageEligibilityEvaluatorSpecs: QuickSpec {
                 verify(exactly: 1) {
                     eventRecorder.recordMock
                 }
-                expect(eventRecorder.recordMock.firstInvokation().arguments.1).to(beIdenticalTo(evaluation))
+                expect(eventRecorder.recordMock.firstInvokation().arguments.1 as AnyObject).to(beIdenticalTo(evaluation as AnyObject))
             }
 
             it("when ineligible with layout then record layout evaluation") {
@@ -147,8 +147,8 @@ class InAppMessageEligibilityEvaluatorSpecs: QuickSpec {
                 verify(exactly: 2) {
                     eventRecorder.recordMock
                 }
-                expect(eventRecorder.recordMock.invokations()[0].arguments.1).to(beIdenticalTo(evaluation))
-                expect(eventRecorder.recordMock.invokations()[1].arguments.1).to(beIdenticalTo(layoutEvaluation))
+                expect(eventRecorder.recordMock.invokations()[0].arguments.1 as AnyObject).to(beIdenticalTo(evaluation as AnyObject))
+                expect(eventRecorder.recordMock.invokations()[1].arguments.1 as AnyObject).to(beIdenticalTo(layoutEvaluation as AnyObject))
             }
         }
     }

--- a/Tests/HackleTests/Core/Evaluation/Evaluator/InAppMessage/Eligibility/InAppMessageEligibilityEvaluatorSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Evaluator/InAppMessage/Eligibility/InAppMessageEligibilityEvaluatorSpecs.swift
@@ -91,7 +91,7 @@ class InAppMessageEligibilityEvaluatorSpecs: QuickSpec {
                 verify(exactly: 1) {
                     eventRecorder.recordMock
                 }
-                expect(eventRecorder.recordMock.firstInvokation().arguments.1 as! InAppMessageEligibilityEvaluation).to(beIdenticalTo(evaluation))
+                expect(eventRecorder.recordMock.firstInvokation().arguments.1 as? InAppMessageEligibilityEvaluation).to(beIdenticalTo(evaluation))
             }
 
             it("when eligible then do not record layout evaluation") {
@@ -110,7 +110,7 @@ class InAppMessageEligibilityEvaluatorSpecs: QuickSpec {
                 verify(exactly: 1) {
                     eventRecorder.recordMock
                 }
-                expect(eventRecorder.recordMock.firstInvokation().arguments.1 as! InAppMessageEligibilityEvaluation).to(beIdenticalTo(evaluation))
+                expect(eventRecorder.recordMock.firstInvokation().arguments.1 as? InAppMessageEligibilityEvaluation).to(beIdenticalTo(evaluation))
             }
 
             it("when ineligible without layout then do not record layout") {
@@ -128,7 +128,7 @@ class InAppMessageEligibilityEvaluatorSpecs: QuickSpec {
                 verify(exactly: 1) {
                     eventRecorder.recordMock
                 }
-                expect(eventRecorder.recordMock.firstInvokation().arguments.1 as! InAppMessageEligibilityEvaluation).to(beIdenticalTo(evaluation))
+                expect(eventRecorder.recordMock.firstInvokation().arguments.1 as? InAppMessageEligibilityEvaluation).to(beIdenticalTo(evaluation))
             }
 
             it("when ineligible with layout then record layout evaluation") {
@@ -147,8 +147,8 @@ class InAppMessageEligibilityEvaluatorSpecs: QuickSpec {
                 verify(exactly: 2) {
                     eventRecorder.recordMock
                 }
-                expect(eventRecorder.recordMock.invokations()[0].arguments.1 as! InAppMessageEligibilityEvaluation).to(beIdenticalTo(evaluation))
-                expect(eventRecorder.recordMock.invokations()[1].arguments.1 as! InAppMessageLayoutEvaluation).to(beIdenticalTo(layoutEvaluation))
+                expect(eventRecorder.recordMock.invokations()[0].arguments.1 as? InAppMessageEligibilityEvaluation).to(beIdenticalTo(evaluation))
+                expect(eventRecorder.recordMock.invokations()[1].arguments.1 as? InAppMessageLayoutEvaluation).to(beIdenticalTo(layoutEvaluation))
             }
         }
     }

--- a/Tests/HackleTests/Core/Evaluation/Evaluator/InAppMessage/Eligibility/InAppMessageEligibilityFlowEvaluatorSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Evaluator/InAppMessage/Eligibility/InAppMessageEligibilityFlowEvaluatorSpecs.swift
@@ -4,7 +4,7 @@ import Nimble
 @testable import Hackle
 
 class InAppMessageEligibilityFlowEvaluatorSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
 
         var nextFlow: InAppMessageEligibilityFlow!
         var evaluation: InAppMessageEligibilityEvaluation!

--- a/Tests/HackleTests/Core/Evaluation/Evaluator/InAppMessage/Eligibility/InAppMessageEligibilityRequestSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Evaluator/InAppMessage/Eligibility/InAppMessageEligibilityRequestSpecs.swift
@@ -4,7 +4,7 @@ import Nimble
 @testable import Hackle
 
 class InAppMessageEligibilityRequestSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
 
         it("==") {
 

--- a/Tests/HackleTests/Core/Evaluation/Evaluator/InAppMessage/Eligibility/TimetableInAppMessageEligibilityFlowEvaluatorSpec.swift
+++ b/Tests/HackleTests/Core/Evaluation/Evaluator/InAppMessage/Eligibility/TimetableInAppMessageEligibilityFlowEvaluatorSpec.swift
@@ -11,7 +11,7 @@ import Nimble
 @testable import Hackle
 
 class TimetableInAppMessageEligibilityFlowEvaluatorSpec: QuickSpec {
-    override func spec() {
+    override class func spec() {
 
         var sut: TimetableInAppMessageEligibilityFlowEvaluator!
         var evaluatorContext: EvaluatorContext!

--- a/Tests/HackleTests/Core/Evaluation/Evaluator/InAppMessage/Layout/InAppMessageLayoutEvaluatorSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Evaluator/InAppMessage/Layout/InAppMessageLayoutEvaluatorSpecs.swift
@@ -70,9 +70,9 @@ class InAppMessageLayoutEvaluatorSpecs: QuickSpec {
                 expect(actual.message).to(be(message))
                 expect(actual.reason) == "IN_APP_MESSAGE_TARGET"
                 expect(actual.targetEvaluations[0] as AnyObject).to(beIdenticalTo(evaluation as AnyObject))
-                expect(actual.properties["experiment_id"] as? Int) == 5
-                expect(actual.properties["experiment_key"] as? Int) == 42
-                expect(actual.properties["variation_id"] as? Int) == 320
+                expect(actual.properties["experiment_id"] as? Int64) == 5
+                expect(actual.properties["experiment_key"] as? Int64) == 42
+                expect(actual.properties["variation_id"] as? Int64) == 320
                 expect(actual.properties["variation_key"] as? String) == "B"
                 expect(actual.properties["experiment_decision_reason"] as? String).to(equal("TRAFFIC_ALLOCATED"))
             }

--- a/Tests/HackleTests/Core/Evaluation/Evaluator/InAppMessage/Layout/InAppMessageLayoutEvaluatorSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Evaluator/InAppMessage/Layout/InAppMessageLayoutEvaluatorSpecs.swift
@@ -69,7 +69,7 @@ class InAppMessageLayoutEvaluatorSpecs: QuickSpec {
                 // then
                 expect(actual.message).to(be(message))
                 expect(actual.reason) == "IN_APP_MESSAGE_TARGET"
-                expect(actual.targetEvaluations[0] as AnyObject).to(beIdenticalTo(evaluation as AnyObject))
+                expect(actual.targetEvaluations[0] as! ExperimentEvaluation).to(beIdenticalTo(evaluation))
                 expect(actual.properties["experiment_id"] as? Int64) == 5
                 expect(actual.properties["experiment_key"] as? Int64) == 42
                 expect(actual.properties["variation_id"] as? Int64) == 320

--- a/Tests/HackleTests/Core/Evaluation/Evaluator/InAppMessage/Layout/InAppMessageLayoutEvaluatorSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Evaluator/InAppMessage/Layout/InAppMessageLayoutEvaluatorSpecs.swift
@@ -4,7 +4,7 @@ import Quick
 @testable import Hackle
 
 class InAppMessageLayoutEvaluatorSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
 
         var evaluator: MockEvaluator!
         var eventRecorder: MockEvaluationEventRecorder!

--- a/Tests/HackleTests/Core/Evaluation/Evaluator/InAppMessage/Layout/InAppMessageLayoutEvaluatorSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Evaluator/InAppMessage/Layout/InAppMessageLayoutEvaluatorSpecs.swift
@@ -69,11 +69,11 @@ class InAppMessageLayoutEvaluatorSpecs: QuickSpec {
                 // then
                 expect(actual.message).to(be(message))
                 expect(actual.reason) == "IN_APP_MESSAGE_TARGET"
-                expect(actual.targetEvaluations[0]).to(be(evaluation))
-                expect(actual.properties["experiment_id"]).to(be(5))
-                expect(actual.properties["experiment_key"]).to(be(42))
-                expect(actual.properties["variation_id"]).to(be(320))
-                expect(actual.properties["variation_key"]).to(be("B"))
+                expect(actual.targetEvaluations[0] as AnyObject).to(beIdenticalTo(evaluation as AnyObject))
+                expect(actual.properties["experiment_id"] as? Int) == 5
+                expect(actual.properties["experiment_key"] as? Int) == 42
+                expect(actual.properties["variation_id"] as? Int) == 320
+                expect(actual.properties["variation_key"] as? String) == "B"
                 expect(actual.properties["experiment_decision_reason"] as? String).to(equal("TRAFFIC_ALLOCATED"))
             }
 

--- a/Tests/HackleTests/Core/Evaluation/Evaluator/InAppMessage/Layout/InAppMessageLayoutEvaluatorSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Evaluator/InAppMessage/Layout/InAppMessageLayoutEvaluatorSpecs.swift
@@ -69,7 +69,7 @@ class InAppMessageLayoutEvaluatorSpecs: QuickSpec {
                 // then
                 expect(actual.message).to(be(message))
                 expect(actual.reason) == "IN_APP_MESSAGE_TARGET"
-                expect(actual.targetEvaluations[0] as! ExperimentEvaluation).to(beIdenticalTo(evaluation))
+                expect(actual.targetEvaluations[0] as? ExperimentEvaluation).to(beIdenticalTo(evaluation))
                 expect(actual.properties["experiment_id"] as? Int64) == 5
                 expect(actual.properties["experiment_key"] as? Int64) == 42
                 expect(actual.properties["variation_id"] as? Int64) == 320

--- a/Tests/HackleTests/Core/Evaluation/Evaluator/InAppMessage/Layout/InAppMessageLayoutRequestSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Evaluator/InAppMessage/Layout/InAppMessageLayoutRequestSpecs.swift
@@ -4,7 +4,7 @@ import Quick
 @testable import Hackle
 
 class InAppMessageLayoutRequestSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
         it("==") {
             let workspace = WorkspaceEntity.create()
             let user = HackleUser.builder().identifier(.id, "user").build()

--- a/Tests/HackleTests/Core/Evaluation/Evaluator/RemoteConfig/RemoteConfigEvaluatorSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Evaluator/RemoteConfig/RemoteConfigEvaluatorSpecs.swift
@@ -13,7 +13,7 @@ import MockingKit
 
 class RemoteConfigEvaluatorSpecs: QuickSpec {
 
-    override func spec() {
+    override class func spec() {
 
         var remoteConfigTargetRuleDeterminer: MockRemoteConfigTargetRuleDeterminer!
         var sut: RemoteConfigEvaluator!

--- a/Tests/HackleTests/Core/Evaluation/Flow/EvaluationFlowSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Flow/EvaluationFlowSpecs.swift
@@ -5,7 +5,7 @@ import Nimble
 
 
 class EvaluationFlowSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
 
         describe("evaluate") {
 

--- a/Tests/HackleTests/Core/Evaluation/Flow/EvaluationFlowTestExt.swift
+++ b/Tests/HackleTests/Core/Evaluation/Flow/EvaluationFlowTestExt.swift
@@ -27,7 +27,7 @@ extension EvaluationFlow {
             fail("Expected: \(expectedFlowEvaluator)\nActual: EvaluationFlow.end")
             return nil
         }
-        expect(evaluator as! T).to(beIdenticalTo(expectedFlowEvaluator))
+        expect(evaluator as? T).to(beIdenticalTo(expectedFlowEvaluator))
         return nextFlow
     }
 

--- a/Tests/HackleTests/Core/Evaluation/Flow/EvaluationFlowTestExt.swift
+++ b/Tests/HackleTests/Core/Evaluation/Flow/EvaluationFlowTestExt.swift
@@ -27,7 +27,7 @@ extension EvaluationFlow {
             fail("Expected: \(expectedFlowEvaluator)\nActual: EvaluationFlow.end")
             return nil
         }
-        expect(evaluator).to(beIdenticalTo(expectedFlowEvaluator))
+        expect(evaluator as AnyObject).to(beIdenticalTo(expectedFlowEvaluator as AnyObject))
         return nextFlow
     }
 

--- a/Tests/HackleTests/Core/Evaluation/Flow/EvaluationFlowTestExt.swift
+++ b/Tests/HackleTests/Core/Evaluation/Flow/EvaluationFlowTestExt.swift
@@ -22,12 +22,12 @@ extension EvaluationFlow {
         return nextFlow
     }
 
-    func isDecisionWith<T: FlowEvaluator>(_ expectedFlowEvaluator: T) -> EvaluationFlow? {
+    func isDecisionWith<T: FlowEvaluator & AnyObject>(_ expectedFlowEvaluator: T) -> EvaluationFlow? {
         guard let evaluator = evaluator, let nextFlow = nextFlow else {
             fail("Expected: \(expectedFlowEvaluator)\nActual: EvaluationFlow.end")
             return nil
         }
-        expect(evaluator as AnyObject).to(beIdenticalTo(expectedFlowEvaluator as AnyObject))
+        expect(evaluator as! T).to(beIdenticalTo(expectedFlowEvaluator))
         return nextFlow
     }
 

--- a/Tests/HackleTests/Core/Evaluation/Match/AbTestConditionMatcherSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Match/AbTestConditionMatcherSpecs.swift
@@ -158,7 +158,7 @@ class AbTestConditionMatcherSpecs: QuickSpec {
             let actual = try sut.matches(request: request, context: context, condition: condition)
 
             expect(actual) == true
-            expect(context.get(request.experiment)).to(beIdenticalTo(evaluation))
+            expect(context.get(request.experiment) as AnyObject).to(beIdenticalTo(evaluation as AnyObject))
         }
 
         it("ExperimentRequest 가 아니면 evaluation 그대로 사용") {
@@ -176,7 +176,7 @@ class AbTestConditionMatcherSpecs: QuickSpec {
             let actual = try sut.matches(request: request, context: context, condition: condition)
 
             expect(actual) == true
-            expect(context.get(experimentRequest.experiment)).to(beIdenticalTo(evaluation))
+            expect(context.get(experimentRequest.experiment) as AnyObject).to(beIdenticalTo(evaluation as AnyObject))
         }
     }
 }

--- a/Tests/HackleTests/Core/Evaluation/Match/AbTestConditionMatcherSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Match/AbTestConditionMatcherSpecs.swift
@@ -13,7 +13,7 @@ import MockingKit
 
 
 class AbTestConditionMatcherSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
         var evaluator: MockEvaluator!
         var valueOperatorMatcher: MockValueOperatorMatcher!
         var sut: AbTestConditionMatcher!

--- a/Tests/HackleTests/Core/Evaluation/Match/AbTestConditionMatcherSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Match/AbTestConditionMatcherSpecs.swift
@@ -158,7 +158,7 @@ class AbTestConditionMatcherSpecs: QuickSpec {
             let actual = try sut.matches(request: request, context: context, condition: condition)
 
             expect(actual) == true
-            expect(context.get(request.experiment) as! ExperimentEvaluation).to(beIdenticalTo(evaluation))
+            expect(context.get(request.experiment) as? ExperimentEvaluation).to(beIdenticalTo(evaluation))
         }
 
         it("ExperimentRequest 가 아니면 evaluation 그대로 사용") {
@@ -176,7 +176,7 @@ class AbTestConditionMatcherSpecs: QuickSpec {
             let actual = try sut.matches(request: request, context: context, condition: condition)
 
             expect(actual) == true
-            expect(context.get(experimentRequest.experiment) as! ExperimentEvaluation).to(beIdenticalTo(evaluation))
+            expect(context.get(experimentRequest.experiment) as? ExperimentEvaluation).to(beIdenticalTo(evaluation))
         }
     }
 }

--- a/Tests/HackleTests/Core/Evaluation/Match/AbTestConditionMatcherSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Match/AbTestConditionMatcherSpecs.swift
@@ -158,7 +158,7 @@ class AbTestConditionMatcherSpecs: QuickSpec {
             let actual = try sut.matches(request: request, context: context, condition: condition)
 
             expect(actual) == true
-            expect(context.get(request.experiment) as AnyObject).to(beIdenticalTo(evaluation as AnyObject))
+            expect(context.get(request.experiment) as! ExperimentEvaluation).to(beIdenticalTo(evaluation))
         }
 
         it("ExperimentRequest 가 아니면 evaluation 그대로 사용") {
@@ -176,7 +176,7 @@ class AbTestConditionMatcherSpecs: QuickSpec {
             let actual = try sut.matches(request: request, context: context, condition: condition)
 
             expect(actual) == true
-            expect(context.get(experimentRequest.experiment) as AnyObject).to(beIdenticalTo(evaluation as AnyObject))
+            expect(context.get(experimentRequest.experiment) as! ExperimentEvaluation).to(beIdenticalTo(evaluation))
         }
     }
 }

--- a/Tests/HackleTests/Core/Evaluation/Match/CohortConditionMatcherSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Match/CohortConditionMatcherSpecs.swift
@@ -4,7 +4,7 @@ import Quick
 @testable import Hackle
 
 class CohortConditionMatcherSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
 
         let valueOperatorMatcher = DefaultValueOperatorMatcher(
             valueMatcherFactory: ValueMatcherFactory(),

--- a/Tests/HackleTests/Core/Evaluation/Match/DefaultConditionMatcherFactorySpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Match/DefaultConditionMatcherFactorySpecs.swift
@@ -5,7 +5,7 @@ import MockingKit
 @testable import Hackle
 
 class DefaultConditionMatcherFactorySpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
         let sut = DefaultConditionMatcherFactory(evaluator: MockEvaluator(), clock: SystemClock.shared)
         it("getMatcher") {
             expect(sut.getMatcher(.userId)).to(beAnInstanceOf(UserConditionMatcher.self))

--- a/Tests/HackleTests/Core/Evaluation/Match/DefaultSegmentMatcher.swift
+++ b/Tests/HackleTests/Core/Evaluation/Match/DefaultSegmentMatcher.swift
@@ -6,7 +6,7 @@ import Nimble
 
 class DefaultSegmentMatcherSpecs: QuickSpec {
 
-    override func spec() {
+    override class func spec() {
 
         var userConditionMatcher: ConditionMatcherStub!
         var sut: DefaultSegmentMatcher!

--- a/Tests/HackleTests/Core/Evaluation/Match/DefaultTargetMatcherSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Match/DefaultTargetMatcherSpecs.swift
@@ -9,11 +9,11 @@ class DefaultTargetMatcherSpecs: QuickSpec {
         it("타겟의 모든 조건이 일치하면 true") {
             // given
             let target = Target(conditions: [
-                self.condition(),
-                self.condition(),
-                self.condition(),
-                self.condition(),
-                self.condition()
+                condition(),
+                condition(),
+                condition(),
+                condition(),
+                condition()
             ])
 
             let matcher = MockConditionMatcher(true)
@@ -37,12 +37,12 @@ class DefaultTargetMatcherSpecs: QuickSpec {
         it("타겟의 조건중 하나라도 일치하지 않으면 false") {
             // given
             let target = Target(conditions: [
-                self.condition(),
-                self.condition(),
-                self.condition(),
-                self.condition(),
-                self.condition(),
-                self.condition()
+                condition(),
+                condition(),
+                condition(),
+                condition(),
+                condition(),
+                condition()
             ])
 
             let trueMatcher = MockConditionMatcher(true)
@@ -82,7 +82,7 @@ class DefaultTargetMatcherSpecs: QuickSpec {
 
             it("when any target matches then return true") {
                 // given
-                let target = Target(conditions: [self.condition()])
+                let target = Target(conditions: [condition()])
                 let targets = [target, target, target, target, target]
 
                 let trueMatcher = MockConditionMatcher(true)
@@ -107,7 +107,7 @@ class DefaultTargetMatcherSpecs: QuickSpec {
 
             it("when every targets do not match then return false") {
                 // given
-                let target = Target(conditions: [self.condition()])
+                let target = Target(conditions: [condition()])
                 let targets = [target, target, target]
 
                 let falseMatcher = MockConditionMatcher(false)
@@ -128,7 +128,7 @@ class DefaultTargetMatcherSpecs: QuickSpec {
         }
     }
 
-    private func condition() -> Target.Condition {
+    private static func condition() -> Target.Condition {
         Target.Condition(key: Target.Key(type: .userProperty, name: "age"), match: Target.Match(type: .match, matchOperator: ._in, valueType: .number, values: [HackleValue(value: 1)]))
     }
 }

--- a/Tests/HackleTests/Core/Evaluation/Match/DefaultTargetMatcherSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Match/DefaultTargetMatcherSpecs.swift
@@ -5,7 +5,7 @@ import MockingKit
 @testable import Hackle
 
 class DefaultTargetMatcherSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
         it("타겟의 모든 조건이 일치하면 true") {
             // given
             let target = Target(conditions: [

--- a/Tests/HackleTests/Core/Evaluation/Match/DefaultUserValueResolverSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Match/DefaultUserValueResolverSpecs.swift
@@ -6,7 +6,7 @@ import MockingKit
 
 class DefaultUserValueResolverSpecs: QuickSpec {
 
-    override func spec() {
+    override class func spec() {
 
         var sut: DefaultUserValueResolver!
         let user = HackleUser.of(

--- a/Tests/HackleTests/Core/Evaluation/Match/DefaultValueOperatorMatcherSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Match/DefaultValueOperatorMatcherSpecs.swift
@@ -6,7 +6,7 @@ import MockingKit
 
 class DefaultValueOperatorMatcherSpecs: QuickSpec {
 
-    override func spec() {
+    override class func spec() {
 
         let sut = DefaultValueOperatorMatcher(valueMatcherFactory: ValueMatcherFactory(), operatorMatcherFactory: OperatorMatcherFactory())
 

--- a/Tests/HackleTests/Core/Evaluation/Match/EventConditionMatcherSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Match/EventConditionMatcherSpecs.swift
@@ -11,7 +11,7 @@ import Nimble
 @testable import Hackle
 
 class EventConditionMatcherSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
 
         var eventValueResolver: EventValueResolver!
         var valueOperatorMatcher: MockValueOperatorMatcher!
@@ -81,7 +81,7 @@ class EventConditionMatcherSpecs: QuickSpec {
 
 
 class DefaultEventValueResolverSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
         let sut = DefaultEventValueResolver()
 
         it("TRACK") {

--- a/Tests/HackleTests/Core/Evaluation/Match/ExperimentConditionMatcherSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Match/ExperimentConditionMatcherSpecs.swift
@@ -12,7 +12,7 @@ import MockingKit
 @testable import Hackle
 
 class ExperimentConditionMatcherSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
 
         var abTestMatcher: MockExperimentMatcher!
         var featureFlagMatcher: MockExperimentMatcher!

--- a/Tests/HackleTests/Core/Evaluation/Match/FeatureFlagConditionMatcherSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Match/FeatureFlagConditionMatcherSpecs.swift
@@ -13,7 +13,7 @@ import MockingKit
 
 
 class FeatureFlagConditionMatcherSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
         var evaluator: MockEvaluator!
         var valueOperatorMatcher: MockValueOperatorMatcher!
         var sut: FeatureFlagConditionMatcher!

--- a/Tests/HackleTests/Core/Evaluation/Match/OperatorMatcherSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Match/OperatorMatcherSpecs.swift
@@ -6,7 +6,7 @@ import MockingKit
 
 
 class OperatorMatcherSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
 
         describe("InMatcher") {
 

--- a/Tests/HackleTests/Core/Evaluation/Match/OperatorMatcherSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Match/OperatorMatcherSpecs.swift
@@ -13,31 +13,31 @@ class OperatorMatcherSpecs: QuickSpec {
             let sut = InMatcher()
 
             it("string") {
-                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValues: [HackleValue(value: "abc")]))
-                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValues: [HackleValue(value: "abc"), HackleValue(value: "def")]))
-                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValues: [HackleValue(value: "abc1")]))
+                assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValues: [HackleValue(value: "abc")]))
+                assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValues: [HackleValue(value: "abc"), HackleValue(value: "def")]))
+                assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValues: [HackleValue(value: "abc1")]))
             }
 
             it("number") {
-                self.assertTrue(sut.matches(valueMatcher: NumberMatcher(), userValue: 320, matchValues: [HackleValue(value: 320)]))
-                self.assertTrue(sut.matches(valueMatcher: NumberMatcher(), userValue: 320.0, matchValues: [HackleValue(value: 320), HackleValue(value: 321)]))
-                self.assertTrue(sut.matches(valueMatcher: NumberMatcher(), userValue: 320.0, matchValues: [HackleValue(value: 320)]))
-                self.assertTrue(sut.matches(valueMatcher: NumberMatcher(), userValue: 320.0, matchValues: [HackleValue(value: 320.0)]))
-                self.assertFalse(sut.matches(valueMatcher: NumberMatcher(), userValue: 320, matchValues: [HackleValue(value: 321)]))
+                assertTrue(sut.matches(valueMatcher: NumberMatcher(), userValue: 320, matchValues: [HackleValue(value: 320)]))
+                assertTrue(sut.matches(valueMatcher: NumberMatcher(), userValue: 320.0, matchValues: [HackleValue(value: 320), HackleValue(value: 321)]))
+                assertTrue(sut.matches(valueMatcher: NumberMatcher(), userValue: 320.0, matchValues: [HackleValue(value: 320)]))
+                assertTrue(sut.matches(valueMatcher: NumberMatcher(), userValue: 320.0, matchValues: [HackleValue(value: 320.0)]))
+                assertFalse(sut.matches(valueMatcher: NumberMatcher(), userValue: 320, matchValues: [HackleValue(value: 321)]))
             }
 
             it("boolean") {
-                self.assertTrue(sut.matches(valueMatcher: BoolMatcher(), userValue: true, matchValues: [HackleValue(value: true)]))
-                self.assertTrue(sut.matches(valueMatcher: BoolMatcher(), userValue: false, matchValues: [HackleValue(value: false)]))
-                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: true, matchValues: [HackleValue(value: false)]))
-                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: false, matchValues: [HackleValue(value: true)]))
+                assertTrue(sut.matches(valueMatcher: BoolMatcher(), userValue: true, matchValues: [HackleValue(value: true)]))
+                assertTrue(sut.matches(valueMatcher: BoolMatcher(), userValue: false, matchValues: [HackleValue(value: false)]))
+                assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: true, matchValues: [HackleValue(value: false)]))
+                assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: false, matchValues: [HackleValue(value: true)]))
             }
 
             it("version") {
-                self.assertTrue(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValues: [HackleValue(value: "1.0.0")]))
-                self.assertTrue(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValues: [HackleValue(value: "1.0.0")]))
-                self.assertTrue(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValues: [HackleValue(value: "1.0.0"), HackleValue(value: "1.0.1")]))
-                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValues: [HackleValue(value: "1.0.1")]))
+                assertTrue(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValues: [HackleValue(value: "1.0.0")]))
+                assertTrue(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValues: [HackleValue(value: "1.0.0")]))
+                assertTrue(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValues: [HackleValue(value: "1.0.0"), HackleValue(value: "1.0.1")]))
+                assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValues: [HackleValue(value: "1.0.1")]))
             }
         }
 
@@ -45,32 +45,32 @@ class OperatorMatcherSpecs: QuickSpec {
             let sut = ContainsMatcher()
 
             it("string") {
-                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValues: [HackleValue(value: "abc")]))
-                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValues: [HackleValue(value: "a")]))
-                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValues: [HackleValue(value: "b")]))
-                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValues: [HackleValue(value: "c")]))
-                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValues: [HackleValue(value: "ab")]))
-                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValues: [HackleValue(value: "ac")]))
-                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "a", matchValues: [HackleValue(value: "ab")]))
+                assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValues: [HackleValue(value: "abc")]))
+                assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValues: [HackleValue(value: "a")]))
+                assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValues: [HackleValue(value: "b")]))
+                assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValues: [HackleValue(value: "c")]))
+                assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValues: [HackleValue(value: "ab")]))
+                assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValues: [HackleValue(value: "ac")]))
+                assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "a", matchValues: [HackleValue(value: "ab")]))
             }
 
             it("number") {
-                self.assertFalse(sut.matches(valueMatcher: NumberMatcher(), userValue: 1, matchValues: [HackleValue(value: 1)]))
-                self.assertFalse(sut.matches(valueMatcher: NumberMatcher(), userValue: 11, matchValues: [HackleValue(value: 1)]))
-                self.assertFalse(sut.matches(valueMatcher: NumberMatcher(), userValue: 1, matchValues: [HackleValue(value: 11)]))
+                assertFalse(sut.matches(valueMatcher: NumberMatcher(), userValue: 1, matchValues: [HackleValue(value: 1)]))
+                assertFalse(sut.matches(valueMatcher: NumberMatcher(), userValue: 11, matchValues: [HackleValue(value: 1)]))
+                assertFalse(sut.matches(valueMatcher: NumberMatcher(), userValue: 1, matchValues: [HackleValue(value: 11)]))
             }
 
             it("boolean") {
-                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: true, matchValues: [HackleValue(value: true)]))
-                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: false, matchValues: [HackleValue(value: false)]))
-                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: true, matchValues: [HackleValue(value: false)]))
-                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: false, matchValues: [HackleValue(value: true)]))
+                assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: true, matchValues: [HackleValue(value: true)]))
+                assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: false, matchValues: [HackleValue(value: false)]))
+                assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: true, matchValues: [HackleValue(value: false)]))
+                assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: false, matchValues: [HackleValue(value: true)]))
             }
 
             it("version") {
-                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValues: [HackleValue(value: "1.0.0")]))
-                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValues: [HackleValue(value: "2.0.0")]))
-                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: "2.0.0", matchValues: [HackleValue(value: "1.0.0")]))
+                assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValues: [HackleValue(value: "1.0.0")]))
+                assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValues: [HackleValue(value: "2.0.0")]))
+                assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: "2.0.0", matchValues: [HackleValue(value: "1.0.0")]))
             }
         }
 
@@ -78,32 +78,32 @@ class OperatorMatcherSpecs: QuickSpec {
             let sut = StartsWithMatcher()
 
             it("string") {
-                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValues: [HackleValue(value: "abc")]))
-                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValues: [HackleValue(value: "a")]))
-                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValues: [HackleValue(value: "b")]))
-                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValues: [HackleValue(value: "c")]))
-                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValues: [HackleValue(value: "ab")]))
-                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValues: [HackleValue(value: "ac")]))
-                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "a", matchValues: [HackleValue(value: "ab")]))
+                assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValues: [HackleValue(value: "abc")]))
+                assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValues: [HackleValue(value: "a")]))
+                assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValues: [HackleValue(value: "b")]))
+                assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValues: [HackleValue(value: "c")]))
+                assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValues: [HackleValue(value: "ab")]))
+                assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValues: [HackleValue(value: "ac")]))
+                assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "a", matchValues: [HackleValue(value: "ab")]))
             }
 
             it("number") {
-                self.assertFalse(sut.matches(valueMatcher: NumberMatcher(), userValue: 1, matchValues: [HackleValue(value: 1)]))
-                self.assertFalse(sut.matches(valueMatcher: NumberMatcher(), userValue: 11, matchValues: [HackleValue(value: 1)]))
-                self.assertFalse(sut.matches(valueMatcher: NumberMatcher(), userValue: 1, matchValues: [HackleValue(value: 11)]))
+                assertFalse(sut.matches(valueMatcher: NumberMatcher(), userValue: 1, matchValues: [HackleValue(value: 1)]))
+                assertFalse(sut.matches(valueMatcher: NumberMatcher(), userValue: 11, matchValues: [HackleValue(value: 1)]))
+                assertFalse(sut.matches(valueMatcher: NumberMatcher(), userValue: 1, matchValues: [HackleValue(value: 11)]))
             }
 
             it("boolean") {
-                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: true, matchValues: [HackleValue(value: true)]))
-                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: false, matchValues: [HackleValue(value: false)]))
-                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: true, matchValues: [HackleValue(value: false)]))
-                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: false, matchValues: [HackleValue(value: true)]))
+                assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: true, matchValues: [HackleValue(value: true)]))
+                assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: false, matchValues: [HackleValue(value: false)]))
+                assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: true, matchValues: [HackleValue(value: false)]))
+                assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: false, matchValues: [HackleValue(value: true)]))
             }
 
             it("version") {
-                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValues: [HackleValue(value: "1.0.0")]))
-                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValues: [HackleValue(value: "2.0.0")]))
-                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: "2.0.0", matchValues: [HackleValue(value: "1.0.0")]))
+                assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValues: [HackleValue(value: "1.0.0")]))
+                assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValues: [HackleValue(value: "2.0.0")]))
+                assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: "2.0.0", matchValues: [HackleValue(value: "1.0.0")]))
             }
         }
 
@@ -111,32 +111,32 @@ class OperatorMatcherSpecs: QuickSpec {
             let sut = EndsWithMatcher()
 
             it("string") {
-                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValues: [HackleValue(value: "abc")]))
-                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValues: [HackleValue(value: "a")]))
-                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValues: [HackleValue(value: "b")]))
-                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValues: [HackleValue(value: "c")]))
-                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValues: [HackleValue(value: "ab")]))
-                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValues: [HackleValue(value: "ac")]))
-                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "a", matchValues: [HackleValue(value: "ab")]))
+                assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValues: [HackleValue(value: "abc")]))
+                assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValues: [HackleValue(value: "a")]))
+                assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValues: [HackleValue(value: "b")]))
+                assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValues: [HackleValue(value: "c")]))
+                assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValues: [HackleValue(value: "ab")]))
+                assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValues: [HackleValue(value: "ac")]))
+                assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "a", matchValues: [HackleValue(value: "ab")]))
             }
 
             it("number") {
-                self.assertFalse(sut.matches(valueMatcher: NumberMatcher(), userValue: 1, matchValues: [HackleValue(value: 1)]))
-                self.assertFalse(sut.matches(valueMatcher: NumberMatcher(), userValue: 11, matchValues: [HackleValue(value: 1)]))
-                self.assertFalse(sut.matches(valueMatcher: NumberMatcher(), userValue: 1, matchValues: [HackleValue(value: 11)]))
+                assertFalse(sut.matches(valueMatcher: NumberMatcher(), userValue: 1, matchValues: [HackleValue(value: 1)]))
+                assertFalse(sut.matches(valueMatcher: NumberMatcher(), userValue: 11, matchValues: [HackleValue(value: 1)]))
+                assertFalse(sut.matches(valueMatcher: NumberMatcher(), userValue: 1, matchValues: [HackleValue(value: 11)]))
             }
 
             it("boolean") {
-                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: true, matchValues: [HackleValue(value: true)]))
-                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: false, matchValues: [HackleValue(value: false)]))
-                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: true, matchValues: [HackleValue(value: false)]))
-                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: false, matchValues: [HackleValue(value: true)]))
+                assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: true, matchValues: [HackleValue(value: true)]))
+                assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: false, matchValues: [HackleValue(value: false)]))
+                assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: true, matchValues: [HackleValue(value: false)]))
+                assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: false, matchValues: [HackleValue(value: true)]))
             }
 
             it("version") {
-                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValues: [HackleValue(value: "1.0.0")]))
-                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValues: [HackleValue(value: "2.0.0")]))
-                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: "2.0.0", matchValues: [HackleValue(value: "1.0.0")]))
+                assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValues: [HackleValue(value: "1.0.0")]))
+                assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValues: [HackleValue(value: "2.0.0")]))
+                assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: "2.0.0", matchValues: [HackleValue(value: "1.0.0")]))
             }
         }
 
@@ -144,42 +144,42 @@ class OperatorMatcherSpecs: QuickSpec {
             let sut = GreaterThanMatcher()
 
             it("string") {
-                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "41", matchValues: [HackleValue(value: "42")]))
-                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "42", matchValues: [HackleValue(value: "42")]))
-                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "43", matchValues: [HackleValue(value: "42")]))
+                assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "41", matchValues: [HackleValue(value: "42")]))
+                assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "42", matchValues: [HackleValue(value: "42")]))
+                assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "43", matchValues: [HackleValue(value: "42")]))
 
-                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "20230114", matchValues: [HackleValue(value: "20230115")]))
-                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "20230115", matchValues: [HackleValue(value: "20230115")]))
-                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "20230116", matchValues: [HackleValue(value: "20230115")]))
+                assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "20230114", matchValues: [HackleValue(value: "20230115")]))
+                assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "20230115", matchValues: [HackleValue(value: "20230115")]))
+                assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "20230116", matchValues: [HackleValue(value: "20230115")]))
 
-                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "2023-01-14", matchValues: [HackleValue(value: "2023-01-15")]))
-                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "2023-01-15", matchValues: [HackleValue(value: "2023-01-15")]))
-                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "2023-01-16", matchValues: [HackleValue(value: "2023-01-15")]))
+                assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "2023-01-14", matchValues: [HackleValue(value: "2023-01-15")]))
+                assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "2023-01-15", matchValues: [HackleValue(value: "2023-01-15")]))
+                assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "2023-01-16", matchValues: [HackleValue(value: "2023-01-15")]))
 
-                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "a", matchValues: [HackleValue(value: "a")]))
-                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "a", matchValues: [HackleValue(value: "A")]))
-                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "A", matchValues: [HackleValue(value: "a")]))
-                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "aa", matchValues: [HackleValue(value: "a")]))
-                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "a", matchValues: [HackleValue(value: "aa")]))
+                assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "a", matchValues: [HackleValue(value: "a")]))
+                assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "a", matchValues: [HackleValue(value: "A")]))
+                assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "A", matchValues: [HackleValue(value: "a")]))
+                assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "aa", matchValues: [HackleValue(value: "a")]))
+                assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "a", matchValues: [HackleValue(value: "aa")]))
             }
 
             it("number") {
-                self.assertFalse(sut.matches(valueMatcher: NumberMatcher(), userValue: 1, matchValues: [HackleValue(value: 1)]))
-                self.assertTrue(sut.matches(valueMatcher: NumberMatcher(), userValue: 1.1, matchValues: [HackleValue(value: 1)]))
-                self.assertFalse(sut.matches(valueMatcher: NumberMatcher(), userValue: 1, matchValues: [HackleValue(value: 1.1)]))
+                assertFalse(sut.matches(valueMatcher: NumberMatcher(), userValue: 1, matchValues: [HackleValue(value: 1)]))
+                assertTrue(sut.matches(valueMatcher: NumberMatcher(), userValue: 1.1, matchValues: [HackleValue(value: 1)]))
+                assertFalse(sut.matches(valueMatcher: NumberMatcher(), userValue: 1, matchValues: [HackleValue(value: 1.1)]))
             }
 
             it("boolean") {
-                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: true, matchValues: [HackleValue(value: true)]))
-                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: false, matchValues: [HackleValue(value: false)]))
-                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: true, matchValues: [HackleValue(value: false)]))
-                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: false, matchValues: [HackleValue(value: true)]))
+                assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: true, matchValues: [HackleValue(value: true)]))
+                assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: false, matchValues: [HackleValue(value: false)]))
+                assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: true, matchValues: [HackleValue(value: false)]))
+                assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: false, matchValues: [HackleValue(value: true)]))
             }
 
             it("version") {
-                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValues: [HackleValue(value: "1.0.0")]))
-                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValues: [HackleValue(value: "2.0.0")]))
-                self.assertTrue(sut.matches(valueMatcher: VersionMatcher(), userValue: "2.0.0", matchValues: [HackleValue(value: "1.0.0")]))
+                assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValues: [HackleValue(value: "1.0.0")]))
+                assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValues: [HackleValue(value: "2.0.0")]))
+                assertTrue(sut.matches(valueMatcher: VersionMatcher(), userValue: "2.0.0", matchValues: [HackleValue(value: "1.0.0")]))
             }
         }
         
@@ -187,42 +187,42 @@ class OperatorMatcherSpecs: QuickSpec {
             let sut = GreaterThanOrEqualToMatcher()
 
             it("string") {
-                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "41", matchValues: [HackleValue(value: "42")]))
-                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "42", matchValues: [HackleValue(value: "42")]))
-                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "43", matchValues: [HackleValue(value: "42")]))
+                assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "41", matchValues: [HackleValue(value: "42")]))
+                assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "42", matchValues: [HackleValue(value: "42")]))
+                assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "43", matchValues: [HackleValue(value: "42")]))
 
-                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "20230114", matchValues: [HackleValue(value: "20230115")]))
-                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "20230115", matchValues: [HackleValue(value: "20230115")]))
-                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "20230116", matchValues: [HackleValue(value: "20230115")]))
+                assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "20230114", matchValues: [HackleValue(value: "20230115")]))
+                assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "20230115", matchValues: [HackleValue(value: "20230115")]))
+                assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "20230116", matchValues: [HackleValue(value: "20230115")]))
 
-                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "2023-01-14", matchValues: [HackleValue(value: "2023-01-15")]))
-                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "2023-01-15", matchValues: [HackleValue(value: "2023-01-15")]))
-                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "2023-01-16", matchValues: [HackleValue(value: "2023-01-15")]))
+                assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "2023-01-14", matchValues: [HackleValue(value: "2023-01-15")]))
+                assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "2023-01-15", matchValues: [HackleValue(value: "2023-01-15")]))
+                assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "2023-01-16", matchValues: [HackleValue(value: "2023-01-15")]))
 
-                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "a", matchValues: [HackleValue(value: "a")]))
-                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "a", matchValues: [HackleValue(value: "A")]))
-                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "A", matchValues: [HackleValue(value: "a")]))
-                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "aa", matchValues: [HackleValue(value: "a")]))
-                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "a", matchValues: [HackleValue(value: "aa")]))
+                assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "a", matchValues: [HackleValue(value: "a")]))
+                assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "a", matchValues: [HackleValue(value: "A")]))
+                assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "A", matchValues: [HackleValue(value: "a")]))
+                assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "aa", matchValues: [HackleValue(value: "a")]))
+                assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "a", matchValues: [HackleValue(value: "aa")]))
             }
 
             it("number") {
-                self.assertTrue(sut.matches(valueMatcher: NumberMatcher(), userValue: 1, matchValues: [HackleValue(value: 1)]))
-                self.assertTrue(sut.matches(valueMatcher: NumberMatcher(), userValue: 1.1, matchValues: [HackleValue(value: 1)]))
-                self.assertFalse(sut.matches(valueMatcher: NumberMatcher(), userValue: 1, matchValues: [HackleValue(value: 1.1)]))
+                assertTrue(sut.matches(valueMatcher: NumberMatcher(), userValue: 1, matchValues: [HackleValue(value: 1)]))
+                assertTrue(sut.matches(valueMatcher: NumberMatcher(), userValue: 1.1, matchValues: [HackleValue(value: 1)]))
+                assertFalse(sut.matches(valueMatcher: NumberMatcher(), userValue: 1, matchValues: [HackleValue(value: 1.1)]))
             }
 
             it("boolean") {
-                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: true, matchValues: [HackleValue(value: true)]))
-                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: false, matchValues: [HackleValue(value: false)]))
-                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: true, matchValues: [HackleValue(value: false)]))
-                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: false, matchValues: [HackleValue(value: true)]))
+                assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: true, matchValues: [HackleValue(value: true)]))
+                assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: false, matchValues: [HackleValue(value: false)]))
+                assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: true, matchValues: [HackleValue(value: false)]))
+                assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: false, matchValues: [HackleValue(value: true)]))
             }
 
             it("version") {
-                self.assertTrue(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValues: [HackleValue(value: "1.0.0")]))
-                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValues: [HackleValue(value: "2.0.0")]))
-                self.assertTrue(sut.matches(valueMatcher: VersionMatcher(), userValue: "2.0.0", matchValues: [HackleValue(value: "1.0.0")]))
+                assertTrue(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValues: [HackleValue(value: "1.0.0")]))
+                assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValues: [HackleValue(value: "2.0.0")]))
+                assertTrue(sut.matches(valueMatcher: VersionMatcher(), userValue: "2.0.0", matchValues: [HackleValue(value: "1.0.0")]))
             }
         }
 
@@ -230,42 +230,42 @@ class OperatorMatcherSpecs: QuickSpec {
             let sut = LessThanMatcher()
 
             it("string") {
-                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "41", matchValues: [HackleValue(value: "42")]))
-                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "42", matchValues: [HackleValue(value: "42")]))
-                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "43", matchValues: [HackleValue(value: "42")]))
+                assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "41", matchValues: [HackleValue(value: "42")]))
+                assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "42", matchValues: [HackleValue(value: "42")]))
+                assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "43", matchValues: [HackleValue(value: "42")]))
 
-                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "20230114", matchValues: [HackleValue(value: "20230115")]))
-                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "20230115", matchValues: [HackleValue(value: "20230115")]))
-                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "20230116", matchValues: [HackleValue(value: "20230115")]))
+                assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "20230114", matchValues: [HackleValue(value: "20230115")]))
+                assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "20230115", matchValues: [HackleValue(value: "20230115")]))
+                assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "20230116", matchValues: [HackleValue(value: "20230115")]))
 
-                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "2023-01-14", matchValues: [HackleValue(value: "2023-01-15")]))
-                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "2023-01-15", matchValues: [HackleValue(value: "2023-01-15")]))
-                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "2023-01-16", matchValues: [HackleValue(value: "2023-01-15")]))
+                assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "2023-01-14", matchValues: [HackleValue(value: "2023-01-15")]))
+                assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "2023-01-15", matchValues: [HackleValue(value: "2023-01-15")]))
+                assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "2023-01-16", matchValues: [HackleValue(value: "2023-01-15")]))
 
-                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "a", matchValues: [HackleValue(value: "a")]))
-                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "a", matchValues: [HackleValue(value: "A")]))
-                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "A", matchValues: [HackleValue(value: "a")]))
-                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "aa", matchValues: [HackleValue(value: "a")]))
-                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "a", matchValues: [HackleValue(value: "aa")]))
+                assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "a", matchValues: [HackleValue(value: "a")]))
+                assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "a", matchValues: [HackleValue(value: "A")]))
+                assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "A", matchValues: [HackleValue(value: "a")]))
+                assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "aa", matchValues: [HackleValue(value: "a")]))
+                assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "a", matchValues: [HackleValue(value: "aa")]))
             }
 
             it("number") {
-                self.assertFalse(sut.matches(valueMatcher: NumberMatcher(), userValue: 1, matchValues: [HackleValue(value: 1)]))
-                self.assertFalse(sut.matches(valueMatcher: NumberMatcher(), userValue: 1.1, matchValues: [HackleValue(value: 1)]))
-                self.assertTrue(sut.matches(valueMatcher: NumberMatcher(), userValue: 1, matchValues: [HackleValue(value: 1.1)]))
+                assertFalse(sut.matches(valueMatcher: NumberMatcher(), userValue: 1, matchValues: [HackleValue(value: 1)]))
+                assertFalse(sut.matches(valueMatcher: NumberMatcher(), userValue: 1.1, matchValues: [HackleValue(value: 1)]))
+                assertTrue(sut.matches(valueMatcher: NumberMatcher(), userValue: 1, matchValues: [HackleValue(value: 1.1)]))
             }
 
             it("boolean") {
-                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: true, matchValues: [HackleValue(value: true)]))
-                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: false, matchValues: [HackleValue(value: false)]))
-                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: true, matchValues: [HackleValue(value: false)]))
-                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: false, matchValues: [HackleValue(value: true)]))
+                assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: true, matchValues: [HackleValue(value: true)]))
+                assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: false, matchValues: [HackleValue(value: false)]))
+                assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: true, matchValues: [HackleValue(value: false)]))
+                assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: false, matchValues: [HackleValue(value: true)]))
             }
 
             it("version") {
-                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValues: [HackleValue(value: "1.0.0")]))
-                self.assertTrue(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValues: [HackleValue(value: "2.0.0")]))
-                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: "2.0.0", matchValues: [HackleValue(value: "1.0.0")]))
+                assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValues: [HackleValue(value: "1.0.0")]))
+                assertTrue(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValues: [HackleValue(value: "2.0.0")]))
+                assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: "2.0.0", matchValues: [HackleValue(value: "1.0.0")]))
             }
         }
 
@@ -273,42 +273,42 @@ class OperatorMatcherSpecs: QuickSpec {
             let sut = LessThanOrEqualToMatcher()
 
             it("string") {
-                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "41", matchValues: [HackleValue(value: "42")]))
-                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "42", matchValues: [HackleValue(value: "42")]))
-                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "43", matchValues: [HackleValue(value: "42")]))
+                assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "41", matchValues: [HackleValue(value: "42")]))
+                assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "42", matchValues: [HackleValue(value: "42")]))
+                assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "43", matchValues: [HackleValue(value: "42")]))
 
-                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "20230114", matchValues: [HackleValue(value: "20230115")]))
-                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "20230115", matchValues: [HackleValue(value: "20230115")]))
-                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "20230116", matchValues: [HackleValue(value: "20230115")]))
+                assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "20230114", matchValues: [HackleValue(value: "20230115")]))
+                assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "20230115", matchValues: [HackleValue(value: "20230115")]))
+                assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "20230116", matchValues: [HackleValue(value: "20230115")]))
 
-                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "2023-01-14", matchValues: [HackleValue(value: "2023-01-15")]))
-                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "2023-01-15", matchValues: [HackleValue(value: "2023-01-15")]))
-                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "2023-01-16", matchValues: [HackleValue(value: "2023-01-15")]))
+                assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "2023-01-14", matchValues: [HackleValue(value: "2023-01-15")]))
+                assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "2023-01-15", matchValues: [HackleValue(value: "2023-01-15")]))
+                assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "2023-01-16", matchValues: [HackleValue(value: "2023-01-15")]))
 
-                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "a", matchValues: [HackleValue(value: "a")]))
-                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "a", matchValues: [HackleValue(value: "A")]))
-                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "A", matchValues: [HackleValue(value: "a")]))
-                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "aa", matchValues: [HackleValue(value: "a")]))
-                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "a", matchValues: [HackleValue(value: "aa")]))
+                assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "a", matchValues: [HackleValue(value: "a")]))
+                assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "a", matchValues: [HackleValue(value: "A")]))
+                assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "A", matchValues: [HackleValue(value: "a")]))
+                assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: "aa", matchValues: [HackleValue(value: "a")]))
+                assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "a", matchValues: [HackleValue(value: "aa")]))
             }
 
             it("number") {
-                self.assertTrue(sut.matches(valueMatcher: NumberMatcher(), userValue: 1, matchValues: [HackleValue(value: 1)]))
-                self.assertFalse(sut.matches(valueMatcher: NumberMatcher(), userValue: 1.1, matchValues: [HackleValue(value: 1)]))
-                self.assertTrue(sut.matches(valueMatcher: NumberMatcher(), userValue: 1, matchValues: [HackleValue(value: 1.1)]))
+                assertTrue(sut.matches(valueMatcher: NumberMatcher(), userValue: 1, matchValues: [HackleValue(value: 1)]))
+                assertFalse(sut.matches(valueMatcher: NumberMatcher(), userValue: 1.1, matchValues: [HackleValue(value: 1)]))
+                assertTrue(sut.matches(valueMatcher: NumberMatcher(), userValue: 1, matchValues: [HackleValue(value: 1.1)]))
             }
 
             it("boolean") {
-                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: true, matchValues: [HackleValue(value: true)]))
-                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: false, matchValues: [HackleValue(value: false)]))
-                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: true, matchValues: [HackleValue(value: false)]))
-                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: false, matchValues: [HackleValue(value: true)]))
+                assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: true, matchValues: [HackleValue(value: true)]))
+                assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: false, matchValues: [HackleValue(value: false)]))
+                assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: true, matchValues: [HackleValue(value: false)]))
+                assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: false, matchValues: [HackleValue(value: true)]))
             }
 
             it("version") {
-                self.assertTrue(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValues: [HackleValue(value: "1.0.0")]))
-                self.assertTrue(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValues: [HackleValue(value: "2.0.0")]))
-                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: "2.0.0", matchValues: [HackleValue(value: "1.0.0")]))
+                assertTrue(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValues: [HackleValue(value: "1.0.0")]))
+                assertTrue(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValues: [HackleValue(value: "2.0.0")]))
+                assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: "2.0.0", matchValues: [HackleValue(value: "1.0.0")]))
             }
         }
         
@@ -316,47 +316,47 @@ class OperatorMatcherSpecs: QuickSpec {
             let sut = ExistsMatcher()
             
             it("if null fail") {
-                self.assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: nil, matchValues: []))
-                self.assertFalse(sut.matches(valueMatcher: NumberMatcher(), userValue: nil, matchValues: []))
-                self.assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: nil, matchValues: []))
-                self.assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: nil, matchValues: []))
+                assertFalse(sut.matches(valueMatcher: StringMatcher(), userValue: nil, matchValues: []))
+                assertFalse(sut.matches(valueMatcher: NumberMatcher(), userValue: nil, matchValues: []))
+                assertFalse(sut.matches(valueMatcher: BoolMatcher(), userValue: nil, matchValues: []))
+                assertFalse(sut.matches(valueMatcher: VersionMatcher(), userValue: nil, matchValues: []))
             }
             
             it("if not null success") {
-                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValues: []))
-                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: 1, matchValues: []))
-                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: true, matchValues: []))
-                self.assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "1.0.0", matchValues: []))
+                assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "abc", matchValues: []))
+                assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: 1, matchValues: []))
+                assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: true, matchValues: []))
+                assertTrue(sut.matches(valueMatcher: StringMatcher(), userValue: "1.0.0", matchValues: []))
                 
-                self.assertTrue(sut.matches(valueMatcher: NumberMatcher(), userValue: "abc", matchValues: []))
-                self.assertTrue(sut.matches(valueMatcher: NumberMatcher(), userValue: 1, matchValues: []))
-                self.assertTrue(sut.matches(valueMatcher: NumberMatcher(), userValue: true, matchValues: []))
-                self.assertTrue(sut.matches(valueMatcher: NumberMatcher(), userValue: "1.0.0", matchValues: []))
+                assertTrue(sut.matches(valueMatcher: NumberMatcher(), userValue: "abc", matchValues: []))
+                assertTrue(sut.matches(valueMatcher: NumberMatcher(), userValue: 1, matchValues: []))
+                assertTrue(sut.matches(valueMatcher: NumberMatcher(), userValue: true, matchValues: []))
+                assertTrue(sut.matches(valueMatcher: NumberMatcher(), userValue: "1.0.0", matchValues: []))
                 
-                self.assertTrue(sut.matches(valueMatcher: BoolMatcher(), userValue: "abc", matchValues: []))
-                self.assertTrue(sut.matches(valueMatcher: BoolMatcher(), userValue: 1, matchValues: []))
-                self.assertTrue(sut.matches(valueMatcher: BoolMatcher(), userValue: true, matchValues: []))
-                self.assertTrue(sut.matches(valueMatcher: BoolMatcher(), userValue: "1.0.0", matchValues: []))
+                assertTrue(sut.matches(valueMatcher: BoolMatcher(), userValue: "abc", matchValues: []))
+                assertTrue(sut.matches(valueMatcher: BoolMatcher(), userValue: 1, matchValues: []))
+                assertTrue(sut.matches(valueMatcher: BoolMatcher(), userValue: true, matchValues: []))
+                assertTrue(sut.matches(valueMatcher: BoolMatcher(), userValue: "1.0.0", matchValues: []))
                 
-                self.assertTrue(sut.matches(valueMatcher: VersionMatcher(), userValue: "abc", matchValues: []))
-                self.assertTrue(sut.matches(valueMatcher: VersionMatcher(), userValue: 1, matchValues: []))
-                self.assertTrue(sut.matches(valueMatcher: VersionMatcher(), userValue: true, matchValues: []))
-                self.assertTrue(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValues: []))
+                assertTrue(sut.matches(valueMatcher: VersionMatcher(), userValue: "abc", matchValues: []))
+                assertTrue(sut.matches(valueMatcher: VersionMatcher(), userValue: 1, matchValues: []))
+                assertTrue(sut.matches(valueMatcher: VersionMatcher(), userValue: true, matchValues: []))
+                assertTrue(sut.matches(valueMatcher: VersionMatcher(), userValue: "1.0.0", matchValues: []))
             }
             
             
         }
     }
 
-    private func assertTrue(_ actual: Bool) {
+    private static func assertTrue(_ actual: Bool) {
         expect(actual).to(beTrue())
     }
 
-    private func assertFalse(_ actual: Bool) {
+    private static func assertFalse(_ actual: Bool) {
         expect(actual).to(beFalse())
     }
 
-    private func v(_ version: String) -> Version {
+    private static func v(_ version: String) -> Version {
         Version.tryParse(value: version)!
     }
 }

--- a/Tests/HackleTests/Core/Evaluation/Match/SegmentConditionMatcherSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Match/SegmentConditionMatcherSpecs.swift
@@ -5,7 +5,7 @@ import Nimble
 
 
 class SegmentConditionMatcherSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
 
         var segmentMatcher: MockSegmentMatcher!
         var sut: SegmentConditionMatcher!

--- a/Tests/HackleTests/Core/Evaluation/Match/TargetEventConditionMatchSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Match/TargetEventConditionMatchSpecs.swift
@@ -17,7 +17,7 @@ class TargetEventConditionMatchSpecs: QuickSpec {
         operatorMatcherFactory: OperatorMatcherFactory()
     )
 
-    override func spec() {
+    override class func spec() {
         beforeEach {
             self.clock.setKstTime(9)
         }

--- a/Tests/HackleTests/Core/Evaluation/Match/TargetEventConditionMatchSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Match/TargetEventConditionMatchSpecs.swift
@@ -11,17 +11,17 @@ import Quick
 import Foundation
 
 class TargetEventConditionMatchSpecs: QuickSpec {
-    private let clock = TestClock()
-    let valueOperatorMatcher = DefaultValueOperatorMatcher(
-        valueMatcherFactory: ValueMatcherFactory(),
-        operatorMatcherFactory: OperatorMatcherFactory()
-    )
-
     override class func spec() {
+        let clock = TestClock()
+        let valueOperatorMatcher = DefaultValueOperatorMatcher(
+            valueMatcherFactory: ValueMatcherFactory(),
+            operatorMatcherFactory: OperatorMatcherFactory()
+        )
+
         beforeEach {
-            self.clock.setKstTime(9)
+            clock.setKstTime(9)
         }
-        
+
         let sut = TargetEventConditionMatcher(
             numberOfEventsInDaysMatcher: NumberOfEventsInDaysMatcher(valueOperatorMatcher: valueOperatorMatcher, clock: clock),
             numberOfEventsWithPropertyInDaysMatcher: NumberOfEventsWithPropertyInDaysMatcher(valueOperatorMatcher: valueOperatorMatcher, clock: clock)
@@ -43,7 +43,7 @@ class TargetEventConditionMatchSpecs: QuickSpec {
             
             verify(
                 targetEvents: targetEvents,
-                key: try self.getKeyString(eventKey: "purchase", days: 7, filter: Target.Condition(
+                key: try getKeyString(eventKey: "purchase", days: 7, filter: Target.Condition(
                     key: Target.Key(type: .hackleProperty, name: "purchase"),
                     match: Target.Match(type: .match, matchOperator: ._in, valueType: .string, values: [HackleValue(value: "1")])
                 )),
@@ -57,7 +57,7 @@ class TargetEventConditionMatchSpecs: QuickSpec {
         it("when target event is empty in 30 days, fail") {
             verify(
                 targetEvents: [],
-                key: try self.getKeyString(eventKey: "purchase", days: 30),
+                key: try getKeyString(eventKey: "purchase", days: 30),
                 operator: .gte,
                 valueType: .number,
                 targetValue: 1,
@@ -67,11 +67,11 @@ class TargetEventConditionMatchSpecs: QuickSpec {
         
         it("when eventkey is not match, fail") {
             let targetEvents = [
-                TargetEvent(eventKey: "purchase", stats: self.makeSingleTargetEventStat(daysAgo: 1), property: nil)
+                TargetEvent(eventKey: "purchase", stats: makeSingleTargetEventStat(clock: clock, daysAgo: 1), property: nil)
             ]
             verify(
                 targetEvents: targetEvents,
-                key: try self.getKeyString(eventKey: "view", days: 30),
+                key: try getKeyString(eventKey: "view", days: 30),
                 operator: .gte,
                 valueType: .number,
                 targetValue: 1,
@@ -81,11 +81,11 @@ class TargetEventConditionMatchSpecs: QuickSpec {
         
         it("when purchase event occur 1 every 30 days and match condition is purchase event in 30 days and target value is 1, success") {
             let targetEvents = [
-                TargetEvent(eventKey: "purchase", stats: self.makeTargetEventStat(daysAgo: 30), property: nil)
+                TargetEvent(eventKey: "purchase", stats: makeTargetEventStat(clock: clock, daysAgo: 30), property: nil)
             ]
             verify(
                 targetEvents: targetEvents,
-                key: try self.getKeyString(eventKey: "purchase", days: 30),
+                key: try getKeyString(eventKey: "purchase", days: 30),
                 operator: .gte,
                 valueType: .number,
                 targetValue: 1,
@@ -95,11 +95,11 @@ class TargetEventConditionMatchSpecs: QuickSpec {
         
         it("when login event occur 3 today and match condition is login event in 1 day and target value is 3, success") {
             let targetEvents = [
-                TargetEvent(eventKey: "login", stats: self.makeSingleTargetEventStat(daysAgo: 0, count: 3), property: nil)
+                TargetEvent(eventKey: "login", stats: makeSingleTargetEventStat(clock: clock, daysAgo: 0, count: 3), property: nil)
             ]
             verify(
                 targetEvents: targetEvents,
-                key: try self.getKeyString(eventKey: "login", days: 1),
+                key: try getKeyString(eventKey: "login", days: 1),
                 operator: .gte,
                 valueType: .number,
                 targetValue: 3,
@@ -108,14 +108,14 @@ class TargetEventConditionMatchSpecs: QuickSpec {
         }
         
         it("when login event occur 3 yesterday and match condition is login event in 1 day and target value is 3 at today 8:00, success") {
-            self.clock.setKstTime(8)
+            clock.setKstTime(8)
             let targetEvents = [
-                TargetEvent(eventKey: "login", stats: self.makeSingleTargetEventStat(daysAgo: 0, count: 3), property: nil),
-                TargetEvent(eventKey: "prucase", stats: self.makeTargetEventStat(daysAgo: 0, count: 3), property: nil)
+                TargetEvent(eventKey: "login", stats: makeSingleTargetEventStat(clock: clock, daysAgo: 0, count: 3), property: nil),
+                TargetEvent(eventKey: "prucase", stats: makeTargetEventStat(clock: clock, daysAgo: 0, count: 3), property: nil)
             ]
             verify(
                 targetEvents: targetEvents,
-                key: try self.getKeyString(eventKey: "login", days: 1),
+                key: try getKeyString(eventKey: "login", days: 1),
                 operator: ._in,
                 valueType: .number,
                 targetValue: 3,
@@ -124,14 +124,14 @@ class TargetEventConditionMatchSpecs: QuickSpec {
         }
         
         it("when login event occur 3 yesterday and match condition is login event in 1 day and target value is 3 at today 14:00, fail") {
-            self.clock.setKstTime(14)
+            clock.setKstTime(14)
             let targetEvents = [
-                TargetEvent(eventKey: "login", stats: self.makeSingleTargetEventStat(daysAgo: 1, count: 3), property: nil),
-                TargetEvent(eventKey: "prucase", stats: self.makeSingleTargetEventStat(daysAgo: 1, count: 3), property: nil)
+                TargetEvent(eventKey: "login", stats: makeSingleTargetEventStat(clock: clock, daysAgo: 1, count: 3), property: nil),
+                TargetEvent(eventKey: "prucase", stats: makeSingleTargetEventStat(clock: clock, daysAgo: 1, count: 3), property: nil)
             ]
             verify(
                 targetEvents: targetEvents,
-                key: try self.getKeyString(eventKey: "login", days: 1),
+                key: try getKeyString(eventKey: "login", days: 1),
                 operator: ._in,
                 valueType: .number,
                 targetValue: 3,
@@ -141,11 +141,11 @@ class TargetEventConditionMatchSpecs: QuickSpec {
         
         it("when purchase event occur 3 every 30 days and match condition is purchase 100, fail") {
             let targetEvents = [
-                TargetEvent(eventKey: "purchase", stats: self.makeTargetEventStat(daysAgo: 30, count: 3), property: nil)
+                TargetEvent(eventKey: "purchase", stats: makeTargetEventStat(clock: clock, daysAgo: 30, count: 3), property: nil)
             ]
             verify(
                 targetEvents: targetEvents,
-                key: try self.getKeyString(eventKey: "purchase", days: 30),
+                key: try getKeyString(eventKey: "purchase", days: 30),
                 operator: ._in,
                 valueType: .number,
                 targetValue: 100,
@@ -155,11 +155,11 @@ class TargetEventConditionMatchSpecs: QuickSpec {
         
         it("when purchase event with milk property occur 1 at 5 days ago and match condition is purchase event with milk property in 7 days and target value is 1, success") {
             let targetEvents = [
-                TargetEvent(eventKey: "purchase", stats: self.makeSingleTargetEventStat(daysAgo: 5), property: TargetEvent.Property(key: "product", type: .eventProperty, value: HackleValue(value: "milk")))
+                TargetEvent(eventKey: "purchase", stats: makeSingleTargetEventStat(clock: clock, daysAgo: 5), property: TargetEvent.Property(key: "product", type: .eventProperty, value: HackleValue(value: "milk")))
             ]
             verify(
                 targetEvents: targetEvents,
-                key: try self.getKeyString(eventKey: "purchase", days: 7, filter: Target.Condition(
+                key: try getKeyString(eventKey: "purchase", days: 7, filter: Target.Condition(
                     key: Target.Key(type: .eventProperty, name: "product"),
                     match: Target.Match(type: .match, matchOperator: ._in, valueType: .string, values: [HackleValue(value: "milk")])
                 )),
@@ -172,11 +172,11 @@ class TargetEventConditionMatchSpecs: QuickSpec {
         
         it("when purchase event with milk property occur 1 at 5 days ago and match condition is purchase event with milk property in 7 days and target value is grater then 1, fail") {
             let targetEvents = [
-                TargetEvent(eventKey: "purchase", stats: self.makeSingleTargetEventStat(daysAgo: 5), property: TargetEvent.Property(key: "product", type: .eventProperty, value: HackleValue(value: "milk")))
+                TargetEvent(eventKey: "purchase", stats: makeSingleTargetEventStat(clock: clock, daysAgo: 5), property: TargetEvent.Property(key: "product", type: .eventProperty, value: HackleValue(value: "milk")))
             ]
             verify(
                 targetEvents: targetEvents,
-                key: try self.getKeyString(eventKey: "purchase", days: 7, filter: Target.Condition(
+                key: try getKeyString(eventKey: "purchase", days: 7, filter: Target.Condition(
                     key: Target.Key(type: .eventProperty, name: "product"),
                     match: Target.Match(type: .match, matchOperator: ._in, valueType: .string, values: [HackleValue(value: "milk")])
                 )),
@@ -189,14 +189,14 @@ class TargetEventConditionMatchSpecs: QuickSpec {
         
         it("when purchase events with milk(1/day) and cookie(2/day) occur within 5 days, and filter contains milk/cookie then success") {
             let targetEvents = [
-                TargetEvent(eventKey: "purchase", stats: self.makeTargetEventStat(daysAgo: 1, count: 1), property: TargetEvent.Property(key: "productName", type: .eventProperty, value: HackleValue(value: "milk"))),
-                TargetEvent(eventKey: "purchase", stats: self.makeTargetEventStat(daysAgo: 2, count: 2), property: TargetEvent.Property(key: "productName", type: .eventProperty, value: HackleValue(value: "cookie"))),
-                TargetEvent(eventKey: "login", stats: self.makeTargetEventStat(daysAgo: 3, count: 3), property: nil),
-                TargetEvent(eventKey: "purchase", stats: self.makeTargetEventStat(daysAgo: 3, count: 3), property: nil)
+                TargetEvent(eventKey: "purchase", stats: makeTargetEventStat(clock: clock, daysAgo: 1, count: 1), property: TargetEvent.Property(key: "productName", type: .eventProperty, value: HackleValue(value: "milk"))),
+                TargetEvent(eventKey: "purchase", stats: makeTargetEventStat(clock: clock, daysAgo: 2, count: 2), property: TargetEvent.Property(key: "productName", type: .eventProperty, value: HackleValue(value: "cookie"))),
+                TargetEvent(eventKey: "login", stats: makeTargetEventStat(clock: clock, daysAgo: 3, count: 3), property: nil),
+                TargetEvent(eventKey: "purchase", stats: makeTargetEventStat(clock: clock, daysAgo: 3, count: 3), property: nil)
             ]
             verify(
                 targetEvents: targetEvents,
-                key: try self.getKeyString(eventKey: "purchase", days: 5, filter: Target.Condition(
+                key: try getKeyString(eventKey: "purchase", days: 5, filter: Target.Condition(
                     key: Target.Key(type: .eventProperty, name: "productName"),
                     match: Target.Match(type: .match, matchOperator: .contains, valueType: .string, values: [HackleValue(value: "cookie"), HackleValue(value: "milk")])
                 )),
@@ -209,12 +209,12 @@ class TargetEventConditionMatchSpecs: QuickSpec {
 
         it("when purchase events with milk(7 days ago) and cookie(2 days) occur within 8 days, and filter contains milk/cookie then success") {
             let targetEvents = [
-                TargetEvent(eventKey: "purchase", stats: self.makeSingleTargetEventStat(daysAgo: 7, count: 1), property: TargetEvent.Property(key: "productName", type: .eventProperty, value: HackleValue(value: "milk"))),
-                TargetEvent(eventKey: "purchase", stats: self.makeTargetEventStat(daysAgo: 2, count: 2), property: TargetEvent.Property(key: "productName", type: .eventProperty, value: HackleValue(value: "cookie")))
+                TargetEvent(eventKey: "purchase", stats: makeSingleTargetEventStat(clock: clock, daysAgo: 7, count: 1), property: TargetEvent.Property(key: "productName", type: .eventProperty, value: HackleValue(value: "milk"))),
+                TargetEvent(eventKey: "purchase", stats: makeTargetEventStat(clock: clock, daysAgo: 2, count: 2), property: TargetEvent.Property(key: "productName", type: .eventProperty, value: HackleValue(value: "cookie")))
             ]
             verify(
                 targetEvents: targetEvents,
-                key: try self.getKeyString(eventKey: "purchase", days: 8, filter: Target.Condition(
+                key: try getKeyString(eventKey: "purchase", days: 8, filter: Target.Condition(
                     key: Target.Key(type: .eventProperty, name: "productName"),
                     match: Target.Match(type: .match, matchOperator: .contains, valueType: .string, values: [HackleValue(value: "cookie"), HackleValue(value: "milk")])
                 )),
@@ -227,11 +227,11 @@ class TargetEventConditionMatchSpecs: QuickSpec {
 
         it("when events have properties but filter is empty then fail") {
             let targetEvents = [
-                TargetEvent(eventKey: "purchase", stats: self.makeTargetEventStat(daysAgo: 30, count: 1), property: TargetEvent.Property(key: "productName", type: .eventProperty, value: HackleValue(value: "milk")))
+                TargetEvent(eventKey: "purchase", stats: makeTargetEventStat(clock: clock, daysAgo: 30, count: 1), property: TargetEvent.Property(key: "productName", type: .eventProperty, value: HackleValue(value: "milk")))
             ]
             verify(
                 targetEvents: targetEvents,
-                key: try self.getKeyString(eventKey: "purchase", days: 3),
+                key: try getKeyString(eventKey: "purchase", days: 3),
                 operator: .gte,
                 valueType: .number,
                 targetValue: 1,
@@ -243,7 +243,7 @@ class TargetEventConditionMatchSpecs: QuickSpec {
             let targetEvents: [TargetEvent] = []
             verify(
                 targetEvents: targetEvents,
-                key: try self.getKeyString(eventKey: "purchase", days: 1),
+                key: try getKeyString(eventKey: "purchase", days: 1),
                 operator: .gte,
                 valueType: .number,
                 targetValue: 0,
@@ -252,7 +252,7 @@ class TargetEventConditionMatchSpecs: QuickSpec {
             
             verify(
                 targetEvents: targetEvents,
-                key: try self.getKeyString(eventKey: "purchase", days: 1, filter: Target.Condition(
+                key: try getKeyString(eventKey: "purchase", days: 1, filter: Target.Condition(
                     key: Target.Key(type: .eventProperty, name: "productName"),
                     match: Target.Match(type: .match, matchOperator: ._in, valueType: .string, values: [HackleValue(value: "milk")])
                 )),
@@ -265,12 +265,12 @@ class TargetEventConditionMatchSpecs: QuickSpec {
 
         it("when partial matching events occurred and meet condition then success") {
             let targetEvents = [
-                TargetEvent(eventKey: "purchase", stats: self.makeSingleTargetEventStat(daysAgo: 1, count: 3), property: TargetEvent.Property(key: "productName", type: .eventProperty, value: HackleValue(value: "cookie"))),
-                TargetEvent(eventKey: "purchase", stats: self.makeSingleTargetEventStat(daysAgo: 0, count: 1), property: nil)
+                TargetEvent(eventKey: "purchase", stats: makeSingleTargetEventStat(clock: clock, daysAgo: 1, count: 3), property: TargetEvent.Property(key: "productName", type: .eventProperty, value: HackleValue(value: "cookie"))),
+                TargetEvent(eventKey: "purchase", stats: makeSingleTargetEventStat(clock: clock, daysAgo: 0, count: 1), property: nil)
             ]
             verify(
                 targetEvents: targetEvents,
-                key: try self.getKeyString(eventKey: "purchase", days: 7, filter: Target.Condition(
+                key: try getKeyString(eventKey: "purchase", days: 7, filter: Target.Condition(
                     key: Target.Key(type: .eventProperty, name: "productName"),
                     match: Target.Match(type: .match, matchOperator: ._in, valueType: .string, values: [HackleValue(value: "milk"), HackleValue(value: "cookie")])
                 )),
@@ -285,7 +285,7 @@ class TargetEventConditionMatchSpecs: QuickSpec {
             let targetEvents = [
                 TargetEvent(
                     eventKey: "purchase",
-                    stats: self.makeSingleTargetEventStat(daysAgo: 1, count: 3),
+                    stats: makeSingleTargetEventStat(clock: clock, daysAgo: 1, count: 3),
                     property: TargetEvent.Property(
                         key: "productName",
                         type: .eventProperty,
@@ -294,14 +294,14 @@ class TargetEventConditionMatchSpecs: QuickSpec {
                 ),
                 TargetEvent(
                     eventKey: "purchase",
-                    stats: self.makeSingleTargetEventStat(daysAgo: 0, count: 1),
+                    stats: makeSingleTargetEventStat(clock: clock, daysAgo: 0, count: 1),
                     property: nil
                 )
             ]
             
             verify(
                 targetEvents: targetEvents,
-                key: try self.getKeyString(
+                key: try getKeyString(
                     eventKey: "login",
                     days: 1
                 ),
@@ -313,7 +313,7 @@ class TargetEventConditionMatchSpecs: QuickSpec {
             
             verify(
                 targetEvents: targetEvents,
-                key: try self.getKeyString(
+                key: try getKeyString(
                     eventKey: "purchase",
                     days: 1,
                     filter: Target.Condition(
@@ -337,7 +337,7 @@ class TargetEventConditionMatchSpecs: QuickSpec {
             let targetEvents = [
                 TargetEvent(
                     eventKey: "purchase",
-                    stats: self.makeSingleTargetEventStat(daysAgo: 1, count: 3),
+                    stats: makeSingleTargetEventStat(clock: clock, daysAgo: 1, count: 3),
                     property: TargetEvent.Property(
                         key: "productName",
                         type: .eventProperty,
@@ -346,7 +346,7 @@ class TargetEventConditionMatchSpecs: QuickSpec {
                 ),
                 TargetEvent(
                     eventKey: "purchase",
-                    stats: self.makeSingleTargetEventStat(daysAgo: 0, count: 1),
+                    stats: makeSingleTargetEventStat(clock: clock, daysAgo: 0, count: 1),
                     property: TargetEvent.Property(
                         key: "productName",
                         type: .eventProperty,
@@ -355,14 +355,14 @@ class TargetEventConditionMatchSpecs: QuickSpec {
                 ),
                 TargetEvent(
                     eventKey: "purchase",
-                    stats: self.makeSingleTargetEventStat(daysAgo: 0, count: 1),
+                    stats: makeSingleTargetEventStat(clock: clock, daysAgo: 0, count: 1),
                     property: nil
                 )
             ]
             
             verify(
                 targetEvents: targetEvents,
-                key: try self.getKeyString(
+                key: try getKeyString(
                     eventKey: "purchase",
                     days: 7,
                     filter: Target.Condition(
@@ -416,7 +416,7 @@ class TargetEventConditionMatchSpecs: QuickSpec {
     ///   - eventKey: event key
     ///   - days: period
     /// - Returns: json string
-    private func getKeyString(eventKey: String, days: Int) throws -> String {
+    private static func getKeyString(eventKey: String, days: Int) throws -> String {
         let model = Target.NumberOfEventsInDays(eventKey: eventKey, days: days)
         guard let data = try? JSONEncoder().encode(model),
               let jsonString = String(data: data, encoding: .utf8) else {
@@ -424,14 +424,14 @@ class TargetEventConditionMatchSpecs: QuickSpec {
         }
         return jsonString
     }
-    
+
     /// NumberOfEventsWithPropertyInDays Json String
     /// - Parameters:
     ///  - eventKey: event key
     ///  - days: period
     ///  - filter: property filter
     ///  - Returns: json string
-    private func getKeyString(eventKey: String, days: Int, filter: Target.Condition) throws -> String {
+    private static func getKeyString(eventKey: String, days: Int, filter: Target.Condition) throws -> String {
         let model = Target.NumberOfEventsWithPropertyInDays(eventKey: eventKey, days: days, propertyFilter: filter)
         guard let data = try? JSONEncoder().encode(model),
               let jsonString = String(data: data, encoding: .utf8) else {
@@ -439,37 +439,40 @@ class TargetEventConditionMatchSpecs: QuickSpec {
         }
         return jsonString
     }
-    
+
     /// Create TargetEvent.Stat array
     /// - Parameters:
+    ///  - clock: clock
     ///  - days: period
     ///  - numOfEventsInDay: number of events in a day
     ///  - Returns: TargetEvent.Stat array
-    private func makeTargetEventStat(daysAgo: Int, count: Int = 1) -> [TargetEvent.Stat] {
+    private static func makeTargetEventStat(clock: TestClock, daysAgo: Int, count: Int = 1) -> [TargetEvent.Stat] {
         let stats = (0..<daysAgo).map { day in
-            TargetEvent.Stat(date: getTimeStamp(daysAgo: day), count: count)
+            TargetEvent.Stat(date: getTimeStamp(clock: clock, daysAgo: day), count: count)
         }
-        
+
         return stats
     }
-    
+
     /// Create TargetEvent.Stat for single day
     /// - Parameters:
+    /// - clock: clock
     /// - day: target ago day
     /// - numOfEventsInDay: number of events in a day
     /// - Returns: TargetEvent.Stat array
-    private func makeSingleTargetEventStat(daysAgo: Int, count: Int = 1) -> [TargetEvent.Stat] {
+    private static func makeSingleTargetEventStat(clock: TestClock, daysAgo: Int, count: Int = 1) -> [TargetEvent.Stat] {
         return [
-            TargetEvent.Stat(date: getTimeStamp(daysAgo: daysAgo), count: count)
+            TargetEvent.Stat(date: getTimeStamp(clock: clock, daysAgo: daysAgo), count: count)
         ]
     }
-    
+
     /// Get TimeStamp
     /// - Parameters:
+    /// - clock: clock
     /// - daysAgo: target ago day
     /// - Returns: timestamp
-    private func getTimeStamp(daysAgo: Int) -> Int64 {
-        let currentMills = self.clock.currentMillis()
+    private static func getTimeStamp(clock: TestClock, daysAgo: Int) -> Int64 {
+        let currentMills = clock.currentMillis()
         let daysAgoMillis = (try? daysAgo.getDaysToMilliseconds()) ?? 0
         let timeStamp = currentMills - (currentMills % (24 * 60 * 60 * 1000)) - daysAgoMillis
         return timeStamp

--- a/Tests/HackleTests/Core/Evaluation/Match/UserConditionMatcherSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Match/UserConditionMatcherSpecs.swift
@@ -5,7 +5,7 @@ import MockingKit
 @testable import Hackle
 
 class UserConditionMatcherSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
 
         var userValueResolver: MockUserValueResolver!
         var valueOperatorMatcher: MockValueOperatorMatcher!

--- a/Tests/HackleTests/Core/Evaluation/Match/ValueMatcherFactorySpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Match/ValueMatcherFactorySpecs.swift
@@ -7,7 +7,7 @@ import MockingKit
 class ValueMatcherFactorySpecs: QuickSpec {
 
 
-    override func spec() {
+    override class func spec() {
 
         let sut = ValueMatcherFactory()
 

--- a/Tests/HackleTests/Core/Evaluation/Match/ValueMatcherSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Match/ValueMatcherSpecs.swift
@@ -5,7 +5,7 @@ import MockingKit
 @testable import Hackle
 
 class ValueMatcherSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
 
         describe("StringMatcher") {
             let sut = StringMatcher()

--- a/Tests/HackleTests/Core/Evaluation/Match/ValueMatcherSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Match/ValueMatcherSpecs.swift
@@ -12,67 +12,67 @@ class ValueMatcherSpecs: QuickSpec {
             
 
             it("string type match") {
-                self.verifyIn(sut: sut, userValue: "42", matchValue: HackleValue(value: "42"), expected: true)
-                self.verifyIn(sut: sut, userValue: "42.42", matchValue: HackleValue(value: "42.42"), expected: true)
-                self.verifyContains(sut: sut, userValue: "42", matchValue: HackleValue(value: "4"), expected: true)
-                self.verifyStartsWith(sut: sut, userValue: "42", matchValue: HackleValue(value: "4"), expected: true)
-                self.verifyEndsWith(sut: sut, userValue: "42", matchValue: HackleValue(value: "2"), expected: true)
-                self.verifyGreaterThan(sut: sut, userValue: "42", matchValue: HackleValue(value: "41"), expected: true)
-                self.verifyGreaterThanOrEqual(sut: sut, userValue: "42", matchValue: HackleValue(value: "42"), expected: true)
-                self.verifyGreaterThanOrEqual(sut: sut, userValue: "43", matchValue: HackleValue(value: "42"), expected: true)
-                self.verifyLessThan(sut: sut, userValue: "42", matchValue: HackleValue(value: "43"), expected: true)
-                self.verifyLessThanOrEqual(sut: sut, userValue: "42", matchValue: HackleValue(value: "42"), expected: true)
-                self.verifyLessThanOrEqual(sut: sut, userValue: "41", matchValue: HackleValue(value: "42"), expected: true)
+                verifyIn(sut: sut, userValue: "42", matchValue: HackleValue(value: "42"), expected: true)
+                verifyIn(sut: sut, userValue: "42.42", matchValue: HackleValue(value: "42.42"), expected: true)
+                verifyContains(sut: sut, userValue: "42", matchValue: HackleValue(value: "4"), expected: true)
+                verifyStartsWith(sut: sut, userValue: "42", matchValue: HackleValue(value: "4"), expected: true)
+                verifyEndsWith(sut: sut, userValue: "42", matchValue: HackleValue(value: "2"), expected: true)
+                verifyGreaterThan(sut: sut, userValue: "42", matchValue: HackleValue(value: "41"), expected: true)
+                verifyGreaterThanOrEqual(sut: sut, userValue: "42", matchValue: HackleValue(value: "42"), expected: true)
+                verifyGreaterThanOrEqual(sut: sut, userValue: "43", matchValue: HackleValue(value: "42"), expected: true)
+                verifyLessThan(sut: sut, userValue: "42", matchValue: HackleValue(value: "43"), expected: true)
+                verifyLessThanOrEqual(sut: sut, userValue: "42", matchValue: HackleValue(value: "42"), expected: true)
+                verifyLessThanOrEqual(sut: sut, userValue: "41", matchValue: HackleValue(value: "42"), expected: true)
             }
             
             it("matchValue가 자료형이 아니면 항상 false") {
-                self.verifyIn(sut: sut, userValue: "42", matchValue: HackleValue(value: tmp()), expected: false)
-                self.verifyContains(sut: sut, userValue: "42", matchValue: HackleValue(value: tmp()), expected: false)
-                self.verifyStartsWith(sut: sut, userValue: "42", matchValue: HackleValue(value: tmp()), expected: false)
-                self.verifyEndsWith(sut: sut, userValue: "42", matchValue: HackleValue(value: tmp()), expected: false)
-                self.verifyGreaterThan(sut: sut, userValue: "42", matchValue: HackleValue(value: tmp()), expected: false)
-                self.verifyGreaterThanOrEqual(sut: sut, userValue: "42", matchValue: HackleValue(value: tmp()), expected: false)
-                self.verifyLessThan(sut: sut, userValue: "42", matchValue: HackleValue(value: tmp()), expected: false)
-                self.verifyLessThanOrEqual(sut: sut, userValue: "42", matchValue: HackleValue(value: tmp()), expected: false)
+                verifyIn(sut: sut, userValue: "42", matchValue: HackleValue(value: tmp()), expected: false)
+                verifyContains(sut: sut, userValue: "42", matchValue: HackleValue(value: tmp()), expected: false)
+                verifyStartsWith(sut: sut, userValue: "42", matchValue: HackleValue(value: tmp()), expected: false)
+                verifyEndsWith(sut: sut, userValue: "42", matchValue: HackleValue(value: tmp()), expected: false)
+                verifyGreaterThan(sut: sut, userValue: "42", matchValue: HackleValue(value: tmp()), expected: false)
+                verifyGreaterThanOrEqual(sut: sut, userValue: "42", matchValue: HackleValue(value: tmp()), expected: false)
+                verifyLessThan(sut: sut, userValue: "42", matchValue: HackleValue(value: tmp()), expected: false)
+                verifyLessThanOrEqual(sut: sut, userValue: "42", matchValue: HackleValue(value: tmp()), expected: false)
             }
             
             it("userValue가 자료형이 아니면 항상 false") {
-                self.verifyIn(sut: sut, userValue: tmp(), matchValue: HackleValue(value: "42"), expected: false)
-                self.verifyContains(sut: sut, userValue: tmp(), matchValue: HackleValue(value: "42"), expected: false)
-                self.verifyStartsWith(sut: sut, userValue: tmp(), matchValue: HackleValue(value: "42"), expected: false)
-                self.verifyEndsWith(sut: sut, userValue: tmp(), matchValue: HackleValue(value: "42"), expected: false)
-                self.verifyGreaterThan(sut: sut, userValue: tmp(), matchValue: HackleValue(value: "42"), expected: false)
-                self.verifyGreaterThanOrEqual(sut: sut, userValue: tmp(), matchValue: HackleValue(value: "42"), expected: false)
-                self.verifyLessThan(sut: sut, userValue: tmp(), matchValue: HackleValue(value: "42"), expected: false)
-                self.verifyLessThanOrEqual(sut: sut, userValue: tmp(), matchValue: HackleValue(value: "42"), expected: false)
+                verifyIn(sut: sut, userValue: tmp(), matchValue: HackleValue(value: "42"), expected: false)
+                verifyContains(sut: sut, userValue: tmp(), matchValue: HackleValue(value: "42"), expected: false)
+                verifyStartsWith(sut: sut, userValue: tmp(), matchValue: HackleValue(value: "42"), expected: false)
+                verifyEndsWith(sut: sut, userValue: tmp(), matchValue: HackleValue(value: "42"), expected: false)
+                verifyGreaterThan(sut: sut, userValue: tmp(), matchValue: HackleValue(value: "42"), expected: false)
+                verifyGreaterThanOrEqual(sut: sut, userValue: tmp(), matchValue: HackleValue(value: "42"), expected: false)
+                verifyLessThan(sut: sut, userValue: tmp(), matchValue: HackleValue(value: "42"), expected: false)
+                verifyLessThanOrEqual(sut: sut, userValue: tmp(), matchValue: HackleValue(value: "42"), expected: false)
             }
 
             it("number 타입이면 캐스팅 후 match") {
-                self.verifyIn(sut: sut, userValue: "42", matchValue: HackleValue(value: 42), expected: true)
-                self.verifyIn(sut: sut, userValue: 42, matchValue: HackleValue(value: "42"), expected: true)
-                self.verifyIn(sut: sut, userValue: 42, matchValue: HackleValue(value: 42), expected: true)
+                verifyIn(sut: sut, userValue: "42", matchValue: HackleValue(value: 42), expected: true)
+                verifyIn(sut: sut, userValue: 42, matchValue: HackleValue(value: "42"), expected: true)
+                verifyIn(sut: sut, userValue: 42, matchValue: HackleValue(value: 42), expected: true)
                 
-                self.verifyIn(sut: sut, userValue: "42.42", matchValue: HackleValue(value: 42.42), expected: true)
-                self.verifyIn(sut: sut, userValue: 42.42, matchValue: HackleValue(value: "42.42"), expected: true)
-                self.verifyIn(sut: sut, userValue: 42.42, matchValue: HackleValue(value: 42.42), expected: true)
+                verifyIn(sut: sut, userValue: "42.42", matchValue: HackleValue(value: 42.42), expected: true)
+                verifyIn(sut: sut, userValue: 42.42, matchValue: HackleValue(value: "42.42"), expected: true)
+                verifyIn(sut: sut, userValue: 42.42, matchValue: HackleValue(value: 42.42), expected: true)
             }
 
             it("bool 타입이면 캐스팅 후 match") {
-                self.verifyIn(sut: sut, userValue: "true", matchValue: HackleValue(value: true), expected: true)
-                self.verifyIn(sut: sut, userValue: true, matchValue: HackleValue(value: "true"), expected: true)
-                self.verifyIn(sut: sut, userValue: true, matchValue: HackleValue(value: true), expected: true)
-                self.verifyIn(sut: sut, userValue: "false", matchValue: HackleValue(value: false), expected: true)
-                self.verifyIn(sut: sut, userValue: false, matchValue: HackleValue(value: "false"), expected: true)
-                self.verifyIn(sut: sut, userValue: false, matchValue: HackleValue(value: false), expected: true)
+                verifyIn(sut: sut, userValue: "true", matchValue: HackleValue(value: true), expected: true)
+                verifyIn(sut: sut, userValue: true, matchValue: HackleValue(value: "true"), expected: true)
+                verifyIn(sut: sut, userValue: true, matchValue: HackleValue(value: true), expected: true)
+                verifyIn(sut: sut, userValue: "false", matchValue: HackleValue(value: false), expected: true)
+                verifyIn(sut: sut, userValue: false, matchValue: HackleValue(value: "false"), expected: true)
+                verifyIn(sut: sut, userValue: false, matchValue: HackleValue(value: false), expected: true)
             }
 
             it("지원하지 않는 type") {
-                self.verifyIn(sut: sut, userValue: true, matchValue: HackleValue(value: "1"), expected: false)
-                self.verifyIn(sut: sut, userValue: "1", matchValue: HackleValue(value: true), expected: false)
-                self.verifyIn(sut: sut, userValue: false, matchValue: HackleValue(value: "0"), expected: false)
-                self.verifyIn(sut: sut, userValue: "0", matchValue: HackleValue(value: false), expected: false)
-                self.verifyIn(sut: sut, userValue: true, matchValue: HackleValue(value: "TRUE"), expected: false)
-                self.verifyIn(sut: sut, userValue: false, matchValue: HackleValue(value: "FALSE"), expected: false)
+                verifyIn(sut: sut, userValue: true, matchValue: HackleValue(value: "1"), expected: false)
+                verifyIn(sut: sut, userValue: "1", matchValue: HackleValue(value: true), expected: false)
+                verifyIn(sut: sut, userValue: false, matchValue: HackleValue(value: "0"), expected: false)
+                verifyIn(sut: sut, userValue: "0", matchValue: HackleValue(value: false), expected: false)
+                verifyIn(sut: sut, userValue: true, matchValue: HackleValue(value: "TRUE"), expected: false)
+                verifyIn(sut: sut, userValue: false, matchValue: HackleValue(value: "FALSE"), expected: false)
             }
         }
 
@@ -80,167 +80,167 @@ class ValueMatcherSpecs: QuickSpec {
             let sut = NumberMatcher()
 
             it("number type") {
-                self.verifyIn(sut: sut, userValue: 42, matchValue: HackleValue(value: 42), expected: true)
-                self.verifyIn(sut: sut, userValue: 42.1, matchValue: HackleValue(value: 42.1), expected: true)
-                self.verifyIn(sut: sut, userValue: 42.0, matchValue: HackleValue(value: 42), expected: true)
-                self.verifyIn(sut: sut, userValue: 42, matchValue: HackleValue(value: 42.0), expected: true)
-                self.verifyIn(sut: sut, userValue: 0, matchValue: HackleValue(value: 0.0), expected: true)
-                self.verifyIn(sut: sut, userValue: Int64(42), matchValue: HackleValue(value: 42), expected: true)
-                self.verifyIn(sut: sut, userValue: Int64(42), matchValue: HackleValue(value: 42.0), expected: true)
-                self.verifyIn(sut: sut, userValue: 42, matchValue: HackleValue(value: Int64(42)), expected: true)
-                self.verifyIn(sut: sut, userValue: 42.0, matchValue: HackleValue(value: Int64(42)), expected: true)
-                self.verifyIn(sut: sut, userValue: Double(42.0), matchValue: HackleValue(value: 42), expected: true)
-                self.verifyIn(sut: sut, userValue: Double(42.1), matchValue: HackleValue(value: 42.1), expected: true)
-                self.verifyIn(sut: sut, userValue: 42.0, matchValue: HackleValue(value: Double(42.0)), expected: true)
-                self.verifyIn(sut: sut, userValue: 42.1, matchValue: HackleValue(value: Double(42.1)), expected: true)
+                verifyIn(sut: sut, userValue: 42, matchValue: HackleValue(value: 42), expected: true)
+                verifyIn(sut: sut, userValue: 42.1, matchValue: HackleValue(value: 42.1), expected: true)
+                verifyIn(sut: sut, userValue: 42.0, matchValue: HackleValue(value: 42), expected: true)
+                verifyIn(sut: sut, userValue: 42, matchValue: HackleValue(value: 42.0), expected: true)
+                verifyIn(sut: sut, userValue: 0, matchValue: HackleValue(value: 0.0), expected: true)
+                verifyIn(sut: sut, userValue: Int64(42), matchValue: HackleValue(value: 42), expected: true)
+                verifyIn(sut: sut, userValue: Int64(42), matchValue: HackleValue(value: 42.0), expected: true)
+                verifyIn(sut: sut, userValue: 42, matchValue: HackleValue(value: Int64(42)), expected: true)
+                verifyIn(sut: sut, userValue: 42.0, matchValue: HackleValue(value: Int64(42)), expected: true)
+                verifyIn(sut: sut, userValue: Double(42.0), matchValue: HackleValue(value: 42), expected: true)
+                verifyIn(sut: sut, userValue: Double(42.1), matchValue: HackleValue(value: 42.1), expected: true)
+                verifyIn(sut: sut, userValue: 42.0, matchValue: HackleValue(value: Double(42.0)), expected: true)
+                verifyIn(sut: sut, userValue: 42.1, matchValue: HackleValue(value: Double(42.1)), expected: true)
 
-                self.verifyGreaterThan(sut: sut, userValue: 43, matchValue: HackleValue(value: 42), expected: true)
-                self.verifyGreaterThan(sut: sut, userValue: 43.1, matchValue: HackleValue(value: 42.1), expected: true)
-                self.verifyGreaterThan(sut: sut, userValue: 43.0, matchValue: HackleValue(value: 42), expected: true)
-                self.verifyGreaterThan(sut: sut, userValue: 43, matchValue: HackleValue(value: 42.0), expected: true)
-                self.verifyGreaterThan(sut: sut, userValue: 1, matchValue: HackleValue(value: 0.0), expected: true)
-                self.verifyGreaterThan(sut: sut, userValue: Int64(43), matchValue: HackleValue(value: 42), expected: true)
-                self.verifyGreaterThan(sut: sut, userValue: Int64(43), matchValue: HackleValue(value: 42.0), expected: true)
-                self.verifyGreaterThan(sut: sut, userValue: 43, matchValue: HackleValue(value: Int64(42)), expected: true)
-                self.verifyGreaterThan(sut: sut, userValue: 43.0, matchValue: HackleValue(value: Int64(42)), expected: true)
-                self.verifyGreaterThan(sut: sut, userValue: Double(43.0), matchValue: HackleValue(value: 42), expected: true)
-                self.verifyGreaterThan(sut: sut, userValue: Double(43.1), matchValue: HackleValue(value: 42.1), expected: true)
-                self.verifyGreaterThan(sut: sut, userValue: 43.0, matchValue: HackleValue(value: Double(42.0)), expected: true)
-                self.verifyGreaterThan(sut: sut, userValue: 43.1, matchValue: HackleValue(value: Double(42.1)), expected: true)
+                verifyGreaterThan(sut: sut, userValue: 43, matchValue: HackleValue(value: 42), expected: true)
+                verifyGreaterThan(sut: sut, userValue: 43.1, matchValue: HackleValue(value: 42.1), expected: true)
+                verifyGreaterThan(sut: sut, userValue: 43.0, matchValue: HackleValue(value: 42), expected: true)
+                verifyGreaterThan(sut: sut, userValue: 43, matchValue: HackleValue(value: 42.0), expected: true)
+                verifyGreaterThan(sut: sut, userValue: 1, matchValue: HackleValue(value: 0.0), expected: true)
+                verifyGreaterThan(sut: sut, userValue: Int64(43), matchValue: HackleValue(value: 42), expected: true)
+                verifyGreaterThan(sut: sut, userValue: Int64(43), matchValue: HackleValue(value: 42.0), expected: true)
+                verifyGreaterThan(sut: sut, userValue: 43, matchValue: HackleValue(value: Int64(42)), expected: true)
+                verifyGreaterThan(sut: sut, userValue: 43.0, matchValue: HackleValue(value: Int64(42)), expected: true)
+                verifyGreaterThan(sut: sut, userValue: Double(43.0), matchValue: HackleValue(value: 42), expected: true)
+                verifyGreaterThan(sut: sut, userValue: Double(43.1), matchValue: HackleValue(value: 42.1), expected: true)
+                verifyGreaterThan(sut: sut, userValue: 43.0, matchValue: HackleValue(value: Double(42.0)), expected: true)
+                verifyGreaterThan(sut: sut, userValue: 43.1, matchValue: HackleValue(value: Double(42.1)), expected: true)
                 
-                self.verifyGreaterThanOrEqual(sut: sut, userValue: 42, matchValue: HackleValue(value: 42), expected: true)
-                self.verifyGreaterThanOrEqual(sut: sut, userValue: 42.1, matchValue: HackleValue(value: 42.1), expected: true)
-                self.verifyGreaterThanOrEqual(sut: sut, userValue: 42.0, matchValue: HackleValue(value: 42), expected: true)
-                self.verifyGreaterThanOrEqual(sut: sut, userValue: 42, matchValue: HackleValue(value: 42.0), expected: true)
-                self.verifyGreaterThanOrEqual(sut: sut, userValue: 0, matchValue: HackleValue(value: 0.0), expected: true)
-                self.verifyGreaterThanOrEqual(sut: sut, userValue: Int64(42), matchValue: HackleValue(value: 42), expected: true)
-                self.verifyGreaterThanOrEqual(sut: sut, userValue: Int64(42), matchValue: HackleValue(value: 42.0), expected: true)
-                self.verifyGreaterThanOrEqual(sut: sut, userValue: 42, matchValue: HackleValue(value: Int64(42)), expected: true)
-                self.verifyGreaterThanOrEqual(sut: sut, userValue: 42.0, matchValue: HackleValue(value: Int64(42)), expected: true)
-                self.verifyGreaterThanOrEqual(sut: sut, userValue: Double(42.0), matchValue: HackleValue(value: 42), expected: true)
-                self.verifyGreaterThanOrEqual(sut: sut, userValue: Double(42.1), matchValue: HackleValue(value: 42.1), expected: true)
-                self.verifyGreaterThanOrEqual(sut: sut, userValue: 42.0, matchValue: HackleValue(value: Double(42.0)), expected: true)
-                self.verifyGreaterThanOrEqual(sut: sut, userValue: 42.1, matchValue: HackleValue(value: Double(42.1)), expected: true)
+                verifyGreaterThanOrEqual(sut: sut, userValue: 42, matchValue: HackleValue(value: 42), expected: true)
+                verifyGreaterThanOrEqual(sut: sut, userValue: 42.1, matchValue: HackleValue(value: 42.1), expected: true)
+                verifyGreaterThanOrEqual(sut: sut, userValue: 42.0, matchValue: HackleValue(value: 42), expected: true)
+                verifyGreaterThanOrEqual(sut: sut, userValue: 42, matchValue: HackleValue(value: 42.0), expected: true)
+                verifyGreaterThanOrEqual(sut: sut, userValue: 0, matchValue: HackleValue(value: 0.0), expected: true)
+                verifyGreaterThanOrEqual(sut: sut, userValue: Int64(42), matchValue: HackleValue(value: 42), expected: true)
+                verifyGreaterThanOrEqual(sut: sut, userValue: Int64(42), matchValue: HackleValue(value: 42.0), expected: true)
+                verifyGreaterThanOrEqual(sut: sut, userValue: 42, matchValue: HackleValue(value: Int64(42)), expected: true)
+                verifyGreaterThanOrEqual(sut: sut, userValue: 42.0, matchValue: HackleValue(value: Int64(42)), expected: true)
+                verifyGreaterThanOrEqual(sut: sut, userValue: Double(42.0), matchValue: HackleValue(value: 42), expected: true)
+                verifyGreaterThanOrEqual(sut: sut, userValue: Double(42.1), matchValue: HackleValue(value: 42.1), expected: true)
+                verifyGreaterThanOrEqual(sut: sut, userValue: 42.0, matchValue: HackleValue(value: Double(42.0)), expected: true)
+                verifyGreaterThanOrEqual(sut: sut, userValue: 42.1, matchValue: HackleValue(value: Double(42.1)), expected: true)
                 
-                self.verifyGreaterThanOrEqual(sut: sut, userValue: 43, matchValue: HackleValue(value: 42), expected: true)
-                self.verifyGreaterThanOrEqual(sut: sut, userValue: 43.1, matchValue: HackleValue(value: 42.1), expected: true)
-                self.verifyGreaterThanOrEqual(sut: sut, userValue: 43.0, matchValue: HackleValue(value: 42), expected: true)
-                self.verifyGreaterThanOrEqual(sut: sut, userValue: 43, matchValue: HackleValue(value: 42.0), expected: true)
-                self.verifyGreaterThanOrEqual(sut: sut, userValue: 1, matchValue: HackleValue(value: 0.0), expected: true)
-                self.verifyGreaterThanOrEqual(sut: sut, userValue: Int64(43), matchValue: HackleValue(value: 42), expected: true)
-                self.verifyGreaterThanOrEqual(sut: sut, userValue: Int64(43), matchValue: HackleValue(value: 42.0), expected: true)
-                self.verifyGreaterThanOrEqual(sut: sut, userValue: 43, matchValue: HackleValue(value: Int64(42)), expected: true)
-                self.verifyGreaterThanOrEqual(sut: sut, userValue: 43.0, matchValue: HackleValue(value: Int64(42)), expected: true)
-                self.verifyGreaterThanOrEqual(sut: sut, userValue: Double(43.0), matchValue: HackleValue(value: 42), expected: true)
-                self.verifyGreaterThanOrEqual(sut: sut, userValue: Double(43.1), matchValue: HackleValue(value: 42.1), expected: true)
-                self.verifyGreaterThanOrEqual(sut: sut, userValue: 43.0, matchValue: HackleValue(value: Double(42.0)), expected: true)
-                self.verifyGreaterThanOrEqual(sut: sut, userValue: 43.1, matchValue: HackleValue(value: Double(42.1)), expected: true)
+                verifyGreaterThanOrEqual(sut: sut, userValue: 43, matchValue: HackleValue(value: 42), expected: true)
+                verifyGreaterThanOrEqual(sut: sut, userValue: 43.1, matchValue: HackleValue(value: 42.1), expected: true)
+                verifyGreaterThanOrEqual(sut: sut, userValue: 43.0, matchValue: HackleValue(value: 42), expected: true)
+                verifyGreaterThanOrEqual(sut: sut, userValue: 43, matchValue: HackleValue(value: 42.0), expected: true)
+                verifyGreaterThanOrEqual(sut: sut, userValue: 1, matchValue: HackleValue(value: 0.0), expected: true)
+                verifyGreaterThanOrEqual(sut: sut, userValue: Int64(43), matchValue: HackleValue(value: 42), expected: true)
+                verifyGreaterThanOrEqual(sut: sut, userValue: Int64(43), matchValue: HackleValue(value: 42.0), expected: true)
+                verifyGreaterThanOrEqual(sut: sut, userValue: 43, matchValue: HackleValue(value: Int64(42)), expected: true)
+                verifyGreaterThanOrEqual(sut: sut, userValue: 43.0, matchValue: HackleValue(value: Int64(42)), expected: true)
+                verifyGreaterThanOrEqual(sut: sut, userValue: Double(43.0), matchValue: HackleValue(value: 42), expected: true)
+                verifyGreaterThanOrEqual(sut: sut, userValue: Double(43.1), matchValue: HackleValue(value: 42.1), expected: true)
+                verifyGreaterThanOrEqual(sut: sut, userValue: 43.0, matchValue: HackleValue(value: Double(42.0)), expected: true)
+                verifyGreaterThanOrEqual(sut: sut, userValue: 43.1, matchValue: HackleValue(value: Double(42.1)), expected: true)
                 
-                self.verifyLessThan(sut: sut, userValue: 41, matchValue: HackleValue(value: 42), expected: true)
-                self.verifyLessThan(sut: sut, userValue: 41.1, matchValue: HackleValue(value: 42.1), expected: true)
-                self.verifyLessThan(sut: sut, userValue: 41.0, matchValue: HackleValue(value: 42), expected: true)
-                self.verifyLessThan(sut: sut, userValue: 41, matchValue: HackleValue(value: 42.0), expected: true)
-                self.verifyLessThan(sut: sut, userValue: -1, matchValue: HackleValue(value: 0.0), expected: true)
-                self.verifyLessThan(sut: sut, userValue: Int64(41), matchValue: HackleValue(value: 42), expected: true)
-                self.verifyLessThan(sut: sut, userValue: Int64(41), matchValue: HackleValue(value: 42.0), expected: true)
-                self.verifyLessThan(sut: sut, userValue: 41, matchValue: HackleValue(value: Int64(42)), expected: true)
-                self.verifyLessThan(sut: sut, userValue: 41.0, matchValue: HackleValue(value: Int64(42)), expected: true)
-                self.verifyLessThan(sut: sut, userValue: Double(41.0), matchValue: HackleValue(value: 42), expected: true)
-                self.verifyLessThan(sut: sut, userValue: Double(41.1), matchValue: HackleValue(value: 42.1), expected: true)
-                self.verifyLessThan(sut: sut, userValue: 41.0, matchValue: HackleValue(value: Double(42.0)), expected: true)
-                self.verifyLessThan(sut: sut, userValue: 41.1, matchValue: HackleValue(value: Double(42.1)), expected: true)
+                verifyLessThan(sut: sut, userValue: 41, matchValue: HackleValue(value: 42), expected: true)
+                verifyLessThan(sut: sut, userValue: 41.1, matchValue: HackleValue(value: 42.1), expected: true)
+                verifyLessThan(sut: sut, userValue: 41.0, matchValue: HackleValue(value: 42), expected: true)
+                verifyLessThan(sut: sut, userValue: 41, matchValue: HackleValue(value: 42.0), expected: true)
+                verifyLessThan(sut: sut, userValue: -1, matchValue: HackleValue(value: 0.0), expected: true)
+                verifyLessThan(sut: sut, userValue: Int64(41), matchValue: HackleValue(value: 42), expected: true)
+                verifyLessThan(sut: sut, userValue: Int64(41), matchValue: HackleValue(value: 42.0), expected: true)
+                verifyLessThan(sut: sut, userValue: 41, matchValue: HackleValue(value: Int64(42)), expected: true)
+                verifyLessThan(sut: sut, userValue: 41.0, matchValue: HackleValue(value: Int64(42)), expected: true)
+                verifyLessThan(sut: sut, userValue: Double(41.0), matchValue: HackleValue(value: 42), expected: true)
+                verifyLessThan(sut: sut, userValue: Double(41.1), matchValue: HackleValue(value: 42.1), expected: true)
+                verifyLessThan(sut: sut, userValue: 41.0, matchValue: HackleValue(value: Double(42.0)), expected: true)
+                verifyLessThan(sut: sut, userValue: 41.1, matchValue: HackleValue(value: Double(42.1)), expected: true)
                 
-                self.verifyLessThanOrEqual(sut: sut, userValue: 41, matchValue: HackleValue(value: 42), expected: true)
-                self.verifyLessThanOrEqual(sut: sut, userValue: 41.1, matchValue: HackleValue(value: 42.1), expected: true)
-                self.verifyLessThanOrEqual(sut: sut, userValue: 41.0, matchValue: HackleValue(value: 42), expected: true)
-                self.verifyLessThanOrEqual(sut: sut, userValue: 41, matchValue: HackleValue(value: 42.0), expected: true)
-                self.verifyLessThanOrEqual(sut: sut, userValue: -1, matchValue: HackleValue(value: 0.0), expected: true)
-                self.verifyLessThanOrEqual(sut: sut, userValue: Int64(41), matchValue: HackleValue(value: 42), expected: true)
-                self.verifyLessThanOrEqual(sut: sut, userValue: Int64(41), matchValue: HackleValue(value: 42.0), expected: true)
-                self.verifyLessThanOrEqual(sut: sut, userValue: 41, matchValue: HackleValue(value: Int64(42)), expected: true)
-                self.verifyLessThanOrEqual(sut: sut, userValue: 41.0, matchValue: HackleValue(value: Int64(42)), expected: true)
-                self.verifyLessThanOrEqual(sut: sut, userValue: Double(41.0), matchValue: HackleValue(value: 42), expected: true)
-                self.verifyLessThanOrEqual(sut: sut, userValue: Double(41.1), matchValue: HackleValue(value: 42.1), expected: true)
-                self.verifyLessThanOrEqual(sut: sut, userValue: 41.0, matchValue: HackleValue(value: Double(42.0)), expected: true)
-                self.verifyLessThanOrEqual(sut: sut, userValue: 41.1, matchValue: HackleValue(value: Double(42.1)), expected: true)
+                verifyLessThanOrEqual(sut: sut, userValue: 41, matchValue: HackleValue(value: 42), expected: true)
+                verifyLessThanOrEqual(sut: sut, userValue: 41.1, matchValue: HackleValue(value: 42.1), expected: true)
+                verifyLessThanOrEqual(sut: sut, userValue: 41.0, matchValue: HackleValue(value: 42), expected: true)
+                verifyLessThanOrEqual(sut: sut, userValue: 41, matchValue: HackleValue(value: 42.0), expected: true)
+                verifyLessThanOrEqual(sut: sut, userValue: -1, matchValue: HackleValue(value: 0.0), expected: true)
+                verifyLessThanOrEqual(sut: sut, userValue: Int64(41), matchValue: HackleValue(value: 42), expected: true)
+                verifyLessThanOrEqual(sut: sut, userValue: Int64(41), matchValue: HackleValue(value: 42.0), expected: true)
+                verifyLessThanOrEqual(sut: sut, userValue: 41, matchValue: HackleValue(value: Int64(42)), expected: true)
+                verifyLessThanOrEqual(sut: sut, userValue: 41.0, matchValue: HackleValue(value: Int64(42)), expected: true)
+                verifyLessThanOrEqual(sut: sut, userValue: Double(41.0), matchValue: HackleValue(value: 42), expected: true)
+                verifyLessThanOrEqual(sut: sut, userValue: Double(41.1), matchValue: HackleValue(value: 42.1), expected: true)
+                verifyLessThanOrEqual(sut: sut, userValue: 41.0, matchValue: HackleValue(value: Double(42.0)), expected: true)
+                verifyLessThanOrEqual(sut: sut, userValue: 41.1, matchValue: HackleValue(value: Double(42.1)), expected: true)
                 
-                self.verifyLessThanOrEqual(sut: sut, userValue: 42, matchValue: HackleValue(value: 42), expected: true)
-                self.verifyLessThanOrEqual(sut: sut, userValue: 42.1, matchValue: HackleValue(value: 42.1), expected: true)
-                self.verifyLessThanOrEqual(sut: sut, userValue: 42.0, matchValue: HackleValue(value: 42), expected: true)
-                self.verifyLessThanOrEqual(sut: sut, userValue: 42, matchValue: HackleValue(value: 42.0), expected: true)
-                self.verifyLessThanOrEqual(sut: sut, userValue: 0, matchValue: HackleValue(value: 0.0), expected: true)
-                self.verifyLessThanOrEqual(sut: sut, userValue: Int64(42), matchValue: HackleValue(value: 42), expected: true)
-                self.verifyLessThanOrEqual(sut: sut, userValue: Int64(42), matchValue: HackleValue(value: 42.0), expected: true)
-                self.verifyLessThanOrEqual(sut: sut, userValue: 42, matchValue: HackleValue(value: Int64(42)), expected: true)
-                self.verifyLessThanOrEqual(sut: sut, userValue: 42.0, matchValue: HackleValue(value: Int64(42)), expected: true)
-                self.verifyLessThanOrEqual(sut: sut, userValue: Double(42.0), matchValue: HackleValue(value: 42), expected: true)
-                self.verifyLessThanOrEqual(sut: sut, userValue: Double(42.1), matchValue: HackleValue(value: 42.1), expected: true)
-                self.verifyLessThanOrEqual(sut: sut, userValue: 42.0, matchValue: HackleValue(value: Double(42.0)), expected: true)
-                self.verifyLessThanOrEqual(sut: sut, userValue: 42.1, matchValue: HackleValue(value: Double(42.1)), expected: true)
+                verifyLessThanOrEqual(sut: sut, userValue: 42, matchValue: HackleValue(value: 42), expected: true)
+                verifyLessThanOrEqual(sut: sut, userValue: 42.1, matchValue: HackleValue(value: 42.1), expected: true)
+                verifyLessThanOrEqual(sut: sut, userValue: 42.0, matchValue: HackleValue(value: 42), expected: true)
+                verifyLessThanOrEqual(sut: sut, userValue: 42, matchValue: HackleValue(value: 42.0), expected: true)
+                verifyLessThanOrEqual(sut: sut, userValue: 0, matchValue: HackleValue(value: 0.0), expected: true)
+                verifyLessThanOrEqual(sut: sut, userValue: Int64(42), matchValue: HackleValue(value: 42), expected: true)
+                verifyLessThanOrEqual(sut: sut, userValue: Int64(42), matchValue: HackleValue(value: 42.0), expected: true)
+                verifyLessThanOrEqual(sut: sut, userValue: 42, matchValue: HackleValue(value: Int64(42)), expected: true)
+                verifyLessThanOrEqual(sut: sut, userValue: 42.0, matchValue: HackleValue(value: Int64(42)), expected: true)
+                verifyLessThanOrEqual(sut: sut, userValue: Double(42.0), matchValue: HackleValue(value: 42), expected: true)
+                verifyLessThanOrEqual(sut: sut, userValue: Double(42.1), matchValue: HackleValue(value: 42.1), expected: true)
+                verifyLessThanOrEqual(sut: sut, userValue: 42.0, matchValue: HackleValue(value: Double(42.0)), expected: true)
+                verifyLessThanOrEqual(sut: sut, userValue: 42.1, matchValue: HackleValue(value: Double(42.1)), expected: true)
             }
             
             it("숫자형 범위 체크") {
-                self.verifyIn(sut: sut, userValue: Int32.max, matchValue: HackleValue(value: Int32.max), expected: true)
-                self.verifyIn(sut: sut, userValue: Int32.min, matchValue: HackleValue(value: Int32.min), expected: true)
-                self.verifyIn(sut: sut, userValue: 2^53, matchValue: HackleValue(value: 2^53), expected: true)
-                self.verifyIn(sut: sut, userValue: -2^53, matchValue: HackleValue(value: -2^53), expected: true)
-                self.verifyIn(sut: sut, userValue: Double(Int32.max), matchValue: HackleValue(value: Int32.max), expected: true)
-                self.verifyIn(sut: sut, userValue: Double(Int32.min), matchValue: HackleValue(value: Int32.min), expected: true)
-                self.verifyIn(sut: sut, userValue: Double(2^53), matchValue: HackleValue(value: 2^53), expected: true)
-                self.verifyIn(sut: sut, userValue: Double(-2^53), matchValue: HackleValue(value: -2^53), expected: true)
-                self.verifyIn(sut: sut, userValue: Double.zero, matchValue: HackleValue(value: Int32.zero), expected: true)
-                self.verifyIn(sut: sut, userValue: Double.zero, matchValue: HackleValue(value: Int64.zero), expected: true)
-                self.verifyIn(sut: sut, userValue: Int32.zero, matchValue: HackleValue(value: Double.zero), expected: true)
-                self.verifyIn(sut: sut, userValue: Int64.zero, matchValue: HackleValue(value: Double.zero), expected: true)
+                verifyIn(sut: sut, userValue: Int32.max, matchValue: HackleValue(value: Int32.max), expected: true)
+                verifyIn(sut: sut, userValue: Int32.min, matchValue: HackleValue(value: Int32.min), expected: true)
+                verifyIn(sut: sut, userValue: 2^53, matchValue: HackleValue(value: 2^53), expected: true)
+                verifyIn(sut: sut, userValue: -2^53, matchValue: HackleValue(value: -2^53), expected: true)
+                verifyIn(sut: sut, userValue: Double(Int32.max), matchValue: HackleValue(value: Int32.max), expected: true)
+                verifyIn(sut: sut, userValue: Double(Int32.min), matchValue: HackleValue(value: Int32.min), expected: true)
+                verifyIn(sut: sut, userValue: Double(2^53), matchValue: HackleValue(value: 2^53), expected: true)
+                verifyIn(sut: sut, userValue: Double(-2^53), matchValue: HackleValue(value: -2^53), expected: true)
+                verifyIn(sut: sut, userValue: Double.zero, matchValue: HackleValue(value: Int32.zero), expected: true)
+                verifyIn(sut: sut, userValue: Double.zero, matchValue: HackleValue(value: Int64.zero), expected: true)
+                verifyIn(sut: sut, userValue: Int32.zero, matchValue: HackleValue(value: Double.zero), expected: true)
+                verifyIn(sut: sut, userValue: Int64.zero, matchValue: HackleValue(value: Double.zero), expected: true)
             }
             
             it("matchValue가 숫자가 아니면 아니면 항상 false") {
-                self.verifyIn(sut: sut, userValue: "1", matchValue: HackleValue(value: true), expected: false)
-                self.verifyContains(sut: sut, userValue: "42", matchValue: HackleValue(value: false), expected: false)
-                self.verifyStartsWith(sut: sut, userValue: "42", matchValue: HackleValue(value: tmp()), expected: false)
-                self.verifyEndsWith(sut: sut, userValue: "1", matchValue: HackleValue(value: false), expected: false)
-                self.verifyGreaterThan(sut: sut, userValue: "42", matchValue: HackleValue(value: "string"), expected: false)
-                self.verifyGreaterThanOrEqual(sut: sut, userValue: "42", matchValue: HackleValue(value: "1.1.1"), expected: false)
-                self.verifyLessThan(sut: sut, userValue: "42", matchValue: HackleValue(value: "string"), expected: false)
-                self.verifyLessThanOrEqual(sut: sut, userValue: "42", matchValue: HackleValue(value: tmp()), expected: false)
+                verifyIn(sut: sut, userValue: "1", matchValue: HackleValue(value: true), expected: false)
+                verifyContains(sut: sut, userValue: "42", matchValue: HackleValue(value: false), expected: false)
+                verifyStartsWith(sut: sut, userValue: "42", matchValue: HackleValue(value: tmp()), expected: false)
+                verifyEndsWith(sut: sut, userValue: "1", matchValue: HackleValue(value: false), expected: false)
+                verifyGreaterThan(sut: sut, userValue: "42", matchValue: HackleValue(value: "string"), expected: false)
+                verifyGreaterThanOrEqual(sut: sut, userValue: "42", matchValue: HackleValue(value: "1.1.1"), expected: false)
+                verifyLessThan(sut: sut, userValue: "42", matchValue: HackleValue(value: "string"), expected: false)
+                verifyLessThanOrEqual(sut: sut, userValue: "42", matchValue: HackleValue(value: tmp()), expected: false)
             }
             
             it("userValue가 숫자가 아니면 항상 false") {
-                self.verifyIn(sut: sut, userValue: true, matchValue: HackleValue(value: "1"), expected: false)
-                self.verifyContains(sut: sut, userValue: "false", matchValue: HackleValue(value: "42"), expected: false)
-                self.verifyStartsWith(sut: sut, userValue: "string", matchValue: HackleValue(value: "42"), expected: false)
-                self.verifyEndsWith(sut: sut, userValue: tmp(), matchValue: HackleValue(value: "42"), expected: false)
-                self.verifyGreaterThan(sut: sut, userValue: "1.1.1", matchValue: HackleValue(value: "42"), expected: false)
-                self.verifyGreaterThanOrEqual(sut: sut, userValue: false, matchValue: HackleValue(value: "42"), expected: false)
-                self.verifyLessThan(sut: sut, userValue: tmp(), matchValue: HackleValue(value: "42"), expected: false)
-                self.verifyLessThanOrEqual(sut: sut, userValue: true, matchValue: HackleValue(value: "42"), expected: false)
+                verifyIn(sut: sut, userValue: true, matchValue: HackleValue(value: "1"), expected: false)
+                verifyContains(sut: sut, userValue: "false", matchValue: HackleValue(value: "42"), expected: false)
+                verifyStartsWith(sut: sut, userValue: "string", matchValue: HackleValue(value: "42"), expected: false)
+                verifyEndsWith(sut: sut, userValue: tmp(), matchValue: HackleValue(value: "42"), expected: false)
+                verifyGreaterThan(sut: sut, userValue: "1.1.1", matchValue: HackleValue(value: "42"), expected: false)
+                verifyGreaterThanOrEqual(sut: sut, userValue: false, matchValue: HackleValue(value: "42"), expected: false)
+                verifyLessThan(sut: sut, userValue: tmp(), matchValue: HackleValue(value: "42"), expected: false)
+                verifyLessThanOrEqual(sut: sut, userValue: true, matchValue: HackleValue(value: "42"), expected: false)
             }
 
             it("string type 이면 캐스팅후 match") {
-                self.verifyIn(sut: sut, userValue: "42", matchValue: HackleValue(value: "42"), expected: true)
-                self.verifyIn(sut: sut, userValue: "42", matchValue: HackleValue(value: 42), expected: true)
-                self.verifyIn(sut: sut, userValue: 42, matchValue: HackleValue(value: "42"), expected: true)
+                verifyIn(sut: sut, userValue: "42", matchValue: HackleValue(value: "42"), expected: true)
+                verifyIn(sut: sut, userValue: "42", matchValue: HackleValue(value: 42), expected: true)
+                verifyIn(sut: sut, userValue: 42, matchValue: HackleValue(value: "42"), expected: true)
 
-                self.verifyIn(sut: sut, userValue: "42.42", matchValue: HackleValue(value: "42.42"), expected: true)
-                self.verifyIn(sut: sut, userValue: "42.42", matchValue: HackleValue(value: 42.42), expected: true)
-                self.verifyIn(sut: sut, userValue: 42.42, matchValue: HackleValue(value: "42.42"), expected: true)
+                verifyIn(sut: sut, userValue: "42.42", matchValue: HackleValue(value: "42.42"), expected: true)
+                verifyIn(sut: sut, userValue: "42.42", matchValue: HackleValue(value: 42.42), expected: true)
+                verifyIn(sut: sut, userValue: 42.42, matchValue: HackleValue(value: "42.42"), expected: true)
                 
-                self.verifyIn(sut: sut, userValue: "42.0", matchValue: HackleValue(value: "42.0"), expected: true)
-                self.verifyIn(sut: sut, userValue: "42.0", matchValue: HackleValue(value: 42.0), expected: true)
-                self.verifyIn(sut: sut, userValue: 42.0, matchValue: HackleValue(value: "42.0"), expected: true)
+                verifyIn(sut: sut, userValue: "42.0", matchValue: HackleValue(value: "42.0"), expected: true)
+                verifyIn(sut: sut, userValue: "42.0", matchValue: HackleValue(value: 42.0), expected: true)
+                verifyIn(sut: sut, userValue: 42.0, matchValue: HackleValue(value: "42.0"), expected: true)
             }
 
             it("지원하지 않는 type") {
-                self.verifyIn(sut: sut, userValue: true, matchValue: HackleValue(value: true), expected: false)
-                self.verifyIn(sut: sut, userValue: true, matchValue: HackleValue(value: 1), expected: false)
-                self.verifyIn(sut: sut, userValue: 1, matchValue: HackleValue(value: true), expected: false)
-                self.verifyIn(sut: sut, userValue: "42a", matchValue: HackleValue(value: 42), expected: false)
+                verifyIn(sut: sut, userValue: true, matchValue: HackleValue(value: true), expected: false)
+                verifyIn(sut: sut, userValue: true, matchValue: HackleValue(value: 1), expected: false)
+                verifyIn(sut: sut, userValue: 1, matchValue: HackleValue(value: true), expected: false)
+                verifyIn(sut: sut, userValue: "42a", matchValue: HackleValue(value: 42), expected: false)
             }
             
             it("지원하지 않는 연산자") {
-                self.verifyContains(sut: sut, userValue: 42, matchValue: HackleValue(value: 42), expected: false)
-                self.verifyStartsWith(sut: sut, userValue: 42, matchValue: HackleValue(value: 42), expected: false)
-                self.verifyEndsWith(sut: sut, userValue: 42, matchValue: HackleValue(value: 42), expected: false)
+                verifyContains(sut: sut, userValue: 42, matchValue: HackleValue(value: 42), expected: false)
+                verifyStartsWith(sut: sut, userValue: 42, matchValue: HackleValue(value: 42), expected: false)
+                verifyEndsWith(sut: sut, userValue: 42, matchValue: HackleValue(value: 42), expected: false)
             }
         }
 
@@ -248,66 +248,66 @@ class ValueMatcherSpecs: QuickSpec {
             let sut = BoolMatcher()
 
             it("bool type") {
-                self.verifyIn(sut: sut, userValue: true, matchValue: HackleValue(value: true), expected: true)
-                self.verifyIn(sut: sut, userValue: "true", matchValue: HackleValue(value: true), expected: true)
-                self.verifyIn(sut: sut, userValue: true, matchValue: HackleValue(value: "true"), expected: true)
-                self.verifyIn(sut: sut, userValue: "true", matchValue: HackleValue(value: "true"), expected: true)
-                self.verifyIn(sut: sut, userValue: false, matchValue: HackleValue(value: false), expected: true)
-                self.verifyIn(sut: sut, userValue: "false", matchValue: HackleValue(value: false), expected: true)
-                self.verifyIn(sut: sut, userValue: false, matchValue: HackleValue(value: "false"), expected: true)
-                self.verifyIn(sut: sut, userValue: "false", matchValue: HackleValue(value: "false"), expected: true)
+                verifyIn(sut: sut, userValue: true, matchValue: HackleValue(value: true), expected: true)
+                verifyIn(sut: sut, userValue: "true", matchValue: HackleValue(value: true), expected: true)
+                verifyIn(sut: sut, userValue: true, matchValue: HackleValue(value: "true"), expected: true)
+                verifyIn(sut: sut, userValue: "true", matchValue: HackleValue(value: "true"), expected: true)
+                verifyIn(sut: sut, userValue: false, matchValue: HackleValue(value: false), expected: true)
+                verifyIn(sut: sut, userValue: "false", matchValue: HackleValue(value: false), expected: true)
+                verifyIn(sut: sut, userValue: false, matchValue: HackleValue(value: "false"), expected: true)
+                verifyIn(sut: sut, userValue: "false", matchValue: HackleValue(value: "false"), expected: true)
                 
-                self.verifyIn(sut: sut, userValue: true, matchValue: HackleValue(value: false), expected: false)
-                self.verifyIn(sut: sut, userValue: "true", matchValue: HackleValue(value: false), expected: false)
-                self.verifyIn(sut: sut, userValue: false, matchValue: HackleValue(value: true), expected: false)
-                self.verifyIn(sut: sut, userValue: "false", matchValue: HackleValue(value: true), expected: false)
+                verifyIn(sut: sut, userValue: true, matchValue: HackleValue(value: false), expected: false)
+                verifyIn(sut: sut, userValue: "true", matchValue: HackleValue(value: false), expected: false)
+                verifyIn(sut: sut, userValue: false, matchValue: HackleValue(value: true), expected: false)
+                verifyIn(sut: sut, userValue: "false", matchValue: HackleValue(value: true), expected: false)
                 
-                self.verifyIn(sut: sut, userValue: true, matchValue: HackleValue(value: 1), expected: false)
-                self.verifyIn(sut: sut, userValue: true, matchValue: HackleValue(value: "1"), expected: false)
-                self.verifyIn(sut: sut, userValue: false, matchValue: HackleValue(value: 0), expected: false)
-                self.verifyIn(sut: sut, userValue: false, matchValue: HackleValue(value: "0"), expected: false)
-                self.verifyIn(sut: sut, userValue: 1, matchValue: HackleValue(value: true), expected: false)
-                self.verifyIn(sut: sut, userValue: "1", matchValue: HackleValue(value: true), expected: false)
-                self.verifyIn(sut: sut, userValue: 0, matchValue: HackleValue(value: false), expected: false)
-                self.verifyIn(sut: sut, userValue: "0", matchValue: HackleValue(value: false), expected: false)
+                verifyIn(sut: sut, userValue: true, matchValue: HackleValue(value: 1), expected: false)
+                verifyIn(sut: sut, userValue: true, matchValue: HackleValue(value: "1"), expected: false)
+                verifyIn(sut: sut, userValue: false, matchValue: HackleValue(value: 0), expected: false)
+                verifyIn(sut: sut, userValue: false, matchValue: HackleValue(value: "0"), expected: false)
+                verifyIn(sut: sut, userValue: 1, matchValue: HackleValue(value: true), expected: false)
+                verifyIn(sut: sut, userValue: "1", matchValue: HackleValue(value: true), expected: false)
+                verifyIn(sut: sut, userValue: 0, matchValue: HackleValue(value: false), expected: false)
+                verifyIn(sut: sut, userValue: "0", matchValue: HackleValue(value: false), expected: false)
                 
-                self.verifyIn(sut: sut, userValue: "0", matchValue: HackleValue(value: true), expected: false)
-                self.verifyIn(sut: sut, userValue: 0, matchValue: HackleValue(value: true), expected: false)
-                self.verifyIn(sut: sut, userValue: "1", matchValue: HackleValue(value: false), expected: false)
-                self.verifyIn(sut: sut, userValue: 1, matchValue: HackleValue(value: false), expected: false)
-                self.verifyIn(sut: sut, userValue: true, matchValue: HackleValue(value: "0"), expected: false)
-                self.verifyIn(sut: sut, userValue: true, matchValue: HackleValue(value: 0), expected: false)
-                self.verifyIn(sut: sut, userValue: false, matchValue: HackleValue(value: "1"), expected: false)
-                self.verifyIn(sut: sut, userValue: false, matchValue: HackleValue(value: 1), expected: false)
+                verifyIn(sut: sut, userValue: "0", matchValue: HackleValue(value: true), expected: false)
+                verifyIn(sut: sut, userValue: 0, matchValue: HackleValue(value: true), expected: false)
+                verifyIn(sut: sut, userValue: "1", matchValue: HackleValue(value: false), expected: false)
+                verifyIn(sut: sut, userValue: 1, matchValue: HackleValue(value: false), expected: false)
+                verifyIn(sut: sut, userValue: true, matchValue: HackleValue(value: "0"), expected: false)
+                verifyIn(sut: sut, userValue: true, matchValue: HackleValue(value: 0), expected: false)
+                verifyIn(sut: sut, userValue: false, matchValue: HackleValue(value: "1"), expected: false)
+                verifyIn(sut: sut, userValue: false, matchValue: HackleValue(value: 1), expected: false)
                 
-                self.verifyIn(sut: sut, userValue: true, matchValue: HackleValue(value: "TRUE"), expected: false)
-                self.verifyIn(sut: sut, userValue: false, matchValue: HackleValue(value: "FALSE"), expected: false)
-                self.verifyIn(sut: sut, userValue: "TRUE", matchValue: HackleValue(value: true), expected: false)
-                self.verifyIn(sut: sut, userValue: "FALSE", matchValue: HackleValue(value: false), expected: false)
+                verifyIn(sut: sut, userValue: true, matchValue: HackleValue(value: "TRUE"), expected: false)
+                verifyIn(sut: sut, userValue: false, matchValue: HackleValue(value: "FALSE"), expected: false)
+                verifyIn(sut: sut, userValue: "TRUE", matchValue: HackleValue(value: true), expected: false)
+                verifyIn(sut: sut, userValue: "FALSE", matchValue: HackleValue(value: false), expected: false)
             }
             
             it("matchValue가 Bool이 아니면 항상 false") {
-                self.verifyIn(sut: sut, userValue: "true", matchValue: HackleValue(value: tmp()), expected: false)
-                self.verifyIn(sut: sut, userValue: true, matchValue: HackleValue(value: "string"), expected: false)
-                self.verifyIn(sut: sut, userValue: "false", matchValue: HackleValue(value: "1.1.1"), expected: false)
-                self.verifyIn(sut: sut, userValue: false, matchValue: HackleValue(value: 234), expected: false)
+                verifyIn(sut: sut, userValue: "true", matchValue: HackleValue(value: tmp()), expected: false)
+                verifyIn(sut: sut, userValue: true, matchValue: HackleValue(value: "string"), expected: false)
+                verifyIn(sut: sut, userValue: "false", matchValue: HackleValue(value: "1.1.1"), expected: false)
+                verifyIn(sut: sut, userValue: false, matchValue: HackleValue(value: 234), expected: false)
             }
 
             it("userValue가 Bool타입이 아니면 false") {
-                self.verifyIn(sut: sut, userValue: "string", matchValue: HackleValue(value: true), expected: false)
-                self.verifyIn(sut: sut, userValue: 234, matchValue: HackleValue(value: true), expected: false)
-                self.verifyIn(sut: sut, userValue: tmp(), matchValue: HackleValue(value: true), expected: false)
-                self.verifyIn(sut: sut, userValue: "1.1.1", matchValue: HackleValue(value: true), expected: false)
+                verifyIn(sut: sut, userValue: "string", matchValue: HackleValue(value: true), expected: false)
+                verifyIn(sut: sut, userValue: 234, matchValue: HackleValue(value: true), expected: false)
+                verifyIn(sut: sut, userValue: tmp(), matchValue: HackleValue(value: true), expected: false)
+                verifyIn(sut: sut, userValue: "1.1.1", matchValue: HackleValue(value: true), expected: false)
             }
 
             it("지원하지 않는 연산자") {
-                self.verifyContains(sut: sut, userValue: true, matchValue: HackleValue(value: true), expected: false)
-                self.verifyStartsWith(sut: sut, userValue: true, matchValue: HackleValue(value: true), expected: false)
-                self.verifyEndsWith(sut: sut, userValue: true, matchValue: HackleValue(value: true), expected: false)
-                self.verifyGreaterThan(sut: sut, userValue: true, matchValue: HackleValue(value: true), expected: false)
-                self.verifyGreaterThanOrEqual(sut: sut, userValue: true, matchValue: HackleValue(value: true), expected: false)
-                self.verifyLessThan(sut: sut, userValue: true, matchValue: HackleValue(value: true), expected: false)
-                self.verifyLessThanOrEqual(sut: sut, userValue: true, matchValue: HackleValue(value: true), expected: false)
+                verifyContains(sut: sut, userValue: true, matchValue: HackleValue(value: true), expected: false)
+                verifyStartsWith(sut: sut, userValue: true, matchValue: HackleValue(value: true), expected: false)
+                verifyEndsWith(sut: sut, userValue: true, matchValue: HackleValue(value: true), expected: false)
+                verifyGreaterThan(sut: sut, userValue: true, matchValue: HackleValue(value: true), expected: false)
+                verifyGreaterThanOrEqual(sut: sut, userValue: true, matchValue: HackleValue(value: true), expected: false)
+                verifyLessThan(sut: sut, userValue: true, matchValue: HackleValue(value: true), expected: false)
+                verifyLessThanOrEqual(sut: sut, userValue: true, matchValue: HackleValue(value: true), expected: false)
             }
         }
 
@@ -315,84 +315,84 @@ class ValueMatcherSpecs: QuickSpec {
             let sut = VersionMatcher()
             
             it("version type") {
-                self.verifyIn(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: "1.0.0"), expected: true)
-                self.verifyIn(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: "2.0.0"), expected: false)
-                self.verifyGreaterThan(sut: sut, userValue: "1.0.1", matchValue: HackleValue(value: "1.0.0"), expected: true)
-                self.verifyGreaterThanOrEqual(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: "1.0.0"), expected: true)
-                self.verifyGreaterThanOrEqual(sut: sut, userValue: "1.0.1", matchValue: HackleValue(value: "1.0.0"), expected: true)
-                self.verifyLessThan(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: "1.0.1"), expected: true)
-                self.verifyLessThanOrEqual(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: "1.0.0"), expected: true)
-                self.verifyLessThanOrEqual(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: "1.0.1"), expected: true)
+                verifyIn(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: "1.0.0"), expected: true)
+                verifyIn(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: "2.0.0"), expected: false)
+                verifyGreaterThan(sut: sut, userValue: "1.0.1", matchValue: HackleValue(value: "1.0.0"), expected: true)
+                verifyGreaterThanOrEqual(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: "1.0.0"), expected: true)
+                verifyGreaterThanOrEqual(sut: sut, userValue: "1.0.1", matchValue: HackleValue(value: "1.0.0"), expected: true)
+                verifyLessThan(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: "1.0.1"), expected: true)
+                verifyLessThanOrEqual(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: "1.0.0"), expected: true)
+                verifyLessThanOrEqual(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: "1.0.1"), expected: true)
             }
 
             it("matchValue가 Version 타입이 아니면 항상 false") {
-                self.verifyIn(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: Int.max), expected: false)
-                self.verifyIn(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: 1.0), expected: false)
-                self.verifyIn(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: "1.0.asd"), expected: false)
-                self.verifyIn(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: "string"), expected: false)
-                self.verifyIn(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: true), expected: false)
+                verifyIn(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: Int.max), expected: false)
+                verifyIn(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: 1.0), expected: false)
+                verifyIn(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: "1.0.asd"), expected: false)
+                verifyIn(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: "string"), expected: false)
+                verifyIn(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: true), expected: false)
                 
-                self.verifyGreaterThan(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: Int.max), expected: false)
-                self.verifyGreaterThan(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: 1.0), expected: false)
-                self.verifyGreaterThan(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: "1.0.asd"), expected: false)
-                self.verifyGreaterThan(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: "string"), expected: false)
-                self.verifyGreaterThan(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: true), expected: false)
+                verifyGreaterThan(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: Int.max), expected: false)
+                verifyGreaterThan(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: 1.0), expected: false)
+                verifyGreaterThan(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: "1.0.asd"), expected: false)
+                verifyGreaterThan(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: "string"), expected: false)
+                verifyGreaterThan(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: true), expected: false)
                 
-                self.verifyGreaterThanOrEqual(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: Int.max), expected: false)
-                self.verifyGreaterThanOrEqual(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: 1.0), expected: false)
-                self.verifyGreaterThanOrEqual(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: "1.0.asd"), expected: false)
-                self.verifyGreaterThanOrEqual(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: "string"), expected: false)
-                self.verifyGreaterThanOrEqual(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: true), expected: false)
+                verifyGreaterThanOrEqual(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: Int.max), expected: false)
+                verifyGreaterThanOrEqual(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: 1.0), expected: false)
+                verifyGreaterThanOrEqual(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: "1.0.asd"), expected: false)
+                verifyGreaterThanOrEqual(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: "string"), expected: false)
+                verifyGreaterThanOrEqual(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: true), expected: false)
                 
-                self.verifyLessThan(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: Int.max), expected: false)
-                self.verifyLessThan(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: 1.0), expected: false)
-                self.verifyLessThan(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: "1.0"), expected: false)
-                self.verifyLessThan(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: "string"), expected: false)
-                self.verifyLessThan(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: true), expected: false)
+                verifyLessThan(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: Int.max), expected: false)
+                verifyLessThan(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: 1.0), expected: false)
+                verifyLessThan(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: "1.0"), expected: false)
+                verifyLessThan(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: "string"), expected: false)
+                verifyLessThan(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: true), expected: false)
                 
-                self.verifyLessThanOrEqual(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: Int.max), expected: false)
-                self.verifyLessThanOrEqual(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: 1.0), expected: false)
-                self.verifyLessThanOrEqual(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: "1.0.asd"), expected: false)
-                self.verifyLessThanOrEqual(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: "string"), expected: false)
-                self.verifyLessThanOrEqual(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: true), expected: false)
+                verifyLessThanOrEqual(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: Int.max), expected: false)
+                verifyLessThanOrEqual(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: 1.0), expected: false)
+                verifyLessThanOrEqual(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: "1.0.asd"), expected: false)
+                verifyLessThanOrEqual(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: "string"), expected: false)
+                verifyLessThanOrEqual(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: true), expected: false)
             }
 
             it("userValue가 Version 타입이 아니면 false") {
-                self.verifyIn(sut: sut, userValue: Int.max, matchValue: HackleValue(value: "1.0.0"), expected: false)
-                self.verifyIn(sut: sut, userValue: 1.0, matchValue: HackleValue(value: "1.0.0"), expected: false)
-                self.verifyIn(sut: sut, userValue: "1.0.x", matchValue: HackleValue(value: "1.0.0"), expected: false)
-                self.verifyIn(sut: sut, userValue: "string", matchValue: HackleValue(value: "1.0.0"), expected: false)
-                self.verifyIn(sut: sut, userValue: true, matchValue: HackleValue(value: "1.0.0"), expected: false)
+                verifyIn(sut: sut, userValue: Int.max, matchValue: HackleValue(value: "1.0.0"), expected: false)
+                verifyIn(sut: sut, userValue: 1.0, matchValue: HackleValue(value: "1.0.0"), expected: false)
+                verifyIn(sut: sut, userValue: "1.0.x", matchValue: HackleValue(value: "1.0.0"), expected: false)
+                verifyIn(sut: sut, userValue: "string", matchValue: HackleValue(value: "1.0.0"), expected: false)
+                verifyIn(sut: sut, userValue: true, matchValue: HackleValue(value: "1.0.0"), expected: false)
                 
-                self.verifyGreaterThan(sut: sut, userValue: Int.max, matchValue: HackleValue(value: "1.0.0"), expected: false)
-                self.verifyGreaterThan(sut: sut, userValue: 1.0, matchValue: HackleValue(value: "1.0.0"), expected: false)
-                self.verifyGreaterThan(sut: sut, userValue: "1.0", matchValue: HackleValue(value: "1.0.0"), expected: false)
-                self.verifyGreaterThan(sut: sut, userValue: "string", matchValue: HackleValue(value: "1.0.0"), expected: false)
-                self.verifyGreaterThan(sut: sut, userValue: true, matchValue: HackleValue(value: "1.0.0"), expected: false)
+                verifyGreaterThan(sut: sut, userValue: Int.max, matchValue: HackleValue(value: "1.0.0"), expected: false)
+                verifyGreaterThan(sut: sut, userValue: 1.0, matchValue: HackleValue(value: "1.0.0"), expected: false)
+                verifyGreaterThan(sut: sut, userValue: "1.0", matchValue: HackleValue(value: "1.0.0"), expected: false)
+                verifyGreaterThan(sut: sut, userValue: "string", matchValue: HackleValue(value: "1.0.0"), expected: false)
+                verifyGreaterThan(sut: sut, userValue: true, matchValue: HackleValue(value: "1.0.0"), expected: false)
                 
-                self.verifyGreaterThanOrEqual(sut: sut, userValue: Int.max, matchValue: HackleValue(value: "1.0.0"), expected: false)
-                self.verifyGreaterThanOrEqual(sut: sut, userValue: 1.0, matchValue: HackleValue(value: "1.0.0"), expected: false)
-                self.verifyGreaterThanOrEqual(sut: sut, userValue: "1.0.x", matchValue: HackleValue(value: "1.0.0"), expected: false)
-                self.verifyGreaterThanOrEqual(sut: sut, userValue: "string", matchValue: HackleValue(value: "1.0.0"), expected: false)
-                self.verifyGreaterThanOrEqual(sut: sut, userValue: true, matchValue: HackleValue(value: "1.0.0"), expected: false)
+                verifyGreaterThanOrEqual(sut: sut, userValue: Int.max, matchValue: HackleValue(value: "1.0.0"), expected: false)
+                verifyGreaterThanOrEqual(sut: sut, userValue: 1.0, matchValue: HackleValue(value: "1.0.0"), expected: false)
+                verifyGreaterThanOrEqual(sut: sut, userValue: "1.0.x", matchValue: HackleValue(value: "1.0.0"), expected: false)
+                verifyGreaterThanOrEqual(sut: sut, userValue: "string", matchValue: HackleValue(value: "1.0.0"), expected: false)
+                verifyGreaterThanOrEqual(sut: sut, userValue: true, matchValue: HackleValue(value: "1.0.0"), expected: false)
                 
-                self.verifyLessThan(sut: sut, userValue: Int.max, matchValue: HackleValue(value: "1.0.0"), expected: false)
-                self.verifyLessThan(sut: sut, userValue: 1.0, matchValue: HackleValue(value: "1.0.0"), expected: false)
-                self.verifyLessThan(sut: sut, userValue: "1.0", matchValue: HackleValue(value: "1.0.0"), expected: false)
-                self.verifyLessThan(sut: sut, userValue: "string", matchValue: HackleValue(value: "1.0.0"), expected: false)
-                self.verifyLessThan(sut: sut, userValue: true, matchValue: HackleValue(value: "1.0.0"), expected: false)
+                verifyLessThan(sut: sut, userValue: Int.max, matchValue: HackleValue(value: "1.0.0"), expected: false)
+                verifyLessThan(sut: sut, userValue: 1.0, matchValue: HackleValue(value: "1.0.0"), expected: false)
+                verifyLessThan(sut: sut, userValue: "1.0", matchValue: HackleValue(value: "1.0.0"), expected: false)
+                verifyLessThan(sut: sut, userValue: "string", matchValue: HackleValue(value: "1.0.0"), expected: false)
+                verifyLessThan(sut: sut, userValue: true, matchValue: HackleValue(value: "1.0.0"), expected: false)
                 
-                self.verifyLessThanOrEqual(sut: sut, userValue: Int.max, matchValue: HackleValue(value: "1.0.0"), expected: false)
-                self.verifyLessThanOrEqual(sut: sut, userValue: 1.0, matchValue: HackleValue(value: "1.0.0"), expected: false)
-                self.verifyLessThanOrEqual(sut: sut, userValue: "1.0.x", matchValue: HackleValue(value: "1.0.0"), expected: false)
-                self.verifyLessThanOrEqual(sut: sut, userValue: "string", matchValue: HackleValue(value: "1.0.0"), expected: false)
-                self.verifyLessThanOrEqual(sut: sut, userValue: true, matchValue: HackleValue(value: "1.0.0"), expected: false)
+                verifyLessThanOrEqual(sut: sut, userValue: Int.max, matchValue: HackleValue(value: "1.0.0"), expected: false)
+                verifyLessThanOrEqual(sut: sut, userValue: 1.0, matchValue: HackleValue(value: "1.0.0"), expected: false)
+                verifyLessThanOrEqual(sut: sut, userValue: "1.0.x", matchValue: HackleValue(value: "1.0.0"), expected: false)
+                verifyLessThanOrEqual(sut: sut, userValue: "string", matchValue: HackleValue(value: "1.0.0"), expected: false)
+                verifyLessThanOrEqual(sut: sut, userValue: true, matchValue: HackleValue(value: "1.0.0"), expected: false)
             }
 
             it("지원하지 않는 연산자") {
-                self.verifyContains(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: "1.0.0"), expected: false)
-                self.verifyStartsWith(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: "1.0.0"), expected: false)
-                self.verifyEndsWith(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: "1.0.0"), expected: false)
+                verifyContains(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: "1.0.0"), expected: false)
+                verifyStartsWith(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: "1.0.0"), expected: false)
+                verifyEndsWith(sut: sut, userValue: "1.0.0", matchValue: HackleValue(value: "1.0.0"), expected: false)
             }
         }
     }
@@ -405,7 +405,7 @@ class ValueMatcherSpecs: QuickSpec {
         }
     }
     
-    private func v(_ value: Any) -> Any {
+    private static func v(_ value: Any) -> Any {
         if value is tmp {
             return value
         }
@@ -416,7 +416,7 @@ class ValueMatcherSpecs: QuickSpec {
         return dict["tmp"]!
     }
 
-    private func verifyIn(sut: ValueMatcher, userValue: Any, matchValue: HackleValue, expected: Bool) {
+    private static func verifyIn(sut: ValueMatcher, userValue: Any, matchValue: HackleValue, expected: Bool) {
         let userValueList = [userValue, v(userValue), HackleValue(value: userValue)]
         let hackleValueWrapedMatchValue = HackleValue(value: matchValue)
         
@@ -429,7 +429,7 @@ class ValueMatcherSpecs: QuickSpec {
         }
     }
     
-    private func verifyContains(sut: ValueMatcher, userValue: Any, matchValue: HackleValue, expected: Bool) {
+    private static func verifyContains(sut: ValueMatcher, userValue: Any, matchValue: HackleValue, expected: Bool) {
         let userValueList = [userValue, v(userValue), HackleValue(value: userValue)]
         let hackleValueWrapedMatchValue = HackleValue(value: matchValue)
         
@@ -442,7 +442,7 @@ class ValueMatcherSpecs: QuickSpec {
         }
     }
     
-    private func verifyStartsWith(sut: ValueMatcher, userValue: Any, matchValue: HackleValue, expected: Bool) {
+    private static func verifyStartsWith(sut: ValueMatcher, userValue: Any, matchValue: HackleValue, expected: Bool) {
         let userValueList = [userValue, v(userValue), HackleValue(value: userValue)]
         let hackleValueWrapedMatchValue = HackleValue(value: matchValue)
         
@@ -455,7 +455,7 @@ class ValueMatcherSpecs: QuickSpec {
         }
     }
     
-    private func verifyEndsWith(sut: ValueMatcher, userValue: Any, matchValue: HackleValue, expected: Bool) {
+    private static func verifyEndsWith(sut: ValueMatcher, userValue: Any, matchValue: HackleValue, expected: Bool) {
         let userValueList = [userValue, v(userValue), HackleValue(value: userValue)]
         let hackleValueWrapedMatchValue = HackleValue(value: matchValue)
         
@@ -469,7 +469,7 @@ class ValueMatcherSpecs: QuickSpec {
         
     }
     
-    private func verifyGreaterThan(sut: ValueMatcher, userValue: Any, matchValue: HackleValue, expected: Bool) {
+    private static func verifyGreaterThan(sut: ValueMatcher, userValue: Any, matchValue: HackleValue, expected: Bool) {
         let userValueList = [userValue, v(userValue), HackleValue(value: userValue)]
         let hackleValueWrapedMatchValue = HackleValue(value: matchValue)
         
@@ -482,7 +482,7 @@ class ValueMatcherSpecs: QuickSpec {
         }
     }
     
-    private func verifyGreaterThanOrEqual(sut: ValueMatcher, userValue: Any, matchValue: HackleValue, expected: Bool) {
+    private static func verifyGreaterThanOrEqual(sut: ValueMatcher, userValue: Any, matchValue: HackleValue, expected: Bool) {
         let userValueList = [userValue, v(userValue), HackleValue(value: userValue)]
         let hackleValueWrapedMatchValue = HackleValue(value: matchValue)
         
@@ -495,7 +495,7 @@ class ValueMatcherSpecs: QuickSpec {
         }
     }
     
-    private func verifyLessThan(sut: ValueMatcher, userValue: Any, matchValue: HackleValue, expected: Bool) {
+    private static func verifyLessThan(sut: ValueMatcher, userValue: Any, matchValue: HackleValue, expected: Bool) {
         let userValueList = [userValue, v(userValue), HackleValue(value: userValue)]
         let hackleValueWrapedMatchValue = HackleValue(value: matchValue)
         
@@ -508,7 +508,7 @@ class ValueMatcherSpecs: QuickSpec {
         }
     }
     
-    private func verifyLessThanOrEqual(sut: ValueMatcher, userValue: Any, matchValue: HackleValue, expected: Bool) {
+    private static func verifyLessThanOrEqual(sut: ValueMatcher, userValue: Any, matchValue: HackleValue, expected: Bool) {
         let userValueList = [userValue, v(userValue), HackleValue(value: userValue)]
         let hackleValueWrapedMatchValue = HackleValue(value: matchValue)
         

--- a/Tests/HackleTests/Core/Evaluation/Match/VersionSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Match/VersionSpecs.swift
@@ -6,7 +6,7 @@ import MockingKit
 
 
 class VersionSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
 
         describe("parse") {
 

--- a/Tests/HackleTests/Core/Evaluation/Match/VersionSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Match/VersionSpecs.swift
@@ -28,31 +28,31 @@ class VersionSpecs: QuickSpec {
             }
 
             it("semantic core version") {
-                self.verify("1.0.0", 1, 0, 0)
-                self.verify("14.165.14", 14, 165, 14)
+                verify("1.0.0", 1, 0, 0)
+                verify("14.165.14", 14, 165, 14)
             }
 
             it("semantic version with prerelease") {
-                self.verify("1.0.0-beta1", 1, 0, 0, prerelease: ["beta1"])
-                self.verify("1.0.0-beta.1", 1, 0, 0, prerelease: ["beta", "1"])
-                self.verify("1.0.0-x.y.z", 1, 0, 0, prerelease: ["x", "y", "z"])
+                verify("1.0.0-beta1", 1, 0, 0, prerelease: ["beta1"])
+                verify("1.0.0-beta.1", 1, 0, 0, prerelease: ["beta", "1"])
+                verify("1.0.0-x.y.z", 1, 0, 0, prerelease: ["x", "y", "z"])
             }
 
             it("semantic version with build") {
-                self.verify("1.0.0+beta1", 1, 0, 0, build: ["beta1"])
-                self.verify("1.0.0+beta.1", 1, 0, 0, build: ["beta1", "1"])
-                self.verify("1.0.0+x.y.z", 1, 0, 0, build: ["x", "y", "z"])
+                verify("1.0.0+beta1", 1, 0, 0, build: ["beta1"])
+                verify("1.0.0+beta.1", 1, 0, 0, build: ["beta1", "1"])
+                verify("1.0.0+x.y.z", 1, 0, 0, build: ["x", "y", "z"])
             }
 
             it("semantic version with prerelease and build") {
-                self.verify("1.0.0-beta.1+build.2", 1, 0, 0, prerelease: ["beta", "1"], build: ["build", "2"])
+                verify("1.0.0-beta.1+build.2", 1, 0, 0, prerelease: ["beta", "1"], build: ["build", "2"])
             }
 
             it("minor, patch 가 없는 경우 0 으로 채워준다") {
-                self.verify("15", 15, 0, 0)
-                self.verify("15.143", 15, 143, 0)
-                self.verify("15-x.y.z", 15, 0, 0, prerelease: ["x", "y", "z"])
-                self.verify("15-x.y.z+a.b.c", 15, 0, 0, prerelease: ["x", "y", "z"], build: ["a", "b", "c"])
+                verify("15", 15, 0, 0)
+                verify("15.143", 15, 143, 0)
+                verify("15-x.y.z", 15, 0, 0, prerelease: ["x", "y", "z"])
+                verify("15-x.y.z+a.b.c", 15, 0, 0, prerelease: ["x", "y", "z"], build: ["a", "b", "c"])
             }
         }
 
@@ -118,7 +118,7 @@ class VersionSpecs: QuickSpec {
         }
     }
 
-    private func verify(_ version: String, _ major: Int, _ minor: Int, _ patch: Int, prerelease: [String] = [], build: [String] = []) {
+    private static func verify(_ version: String, _ major: Int, _ minor: Int, _ patch: Int, prerelease: [String] = [], build: [String] = []) {
         expect(Version.tryParse(value: version))
             .to(equal(Version(
                 coreVersion: CoreVersion(major: major, minor: minor, patch: patch),

--- a/Tests/HackleTests/Core/Evaluation/Target/DefaultExperimentTargetDeterminerSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Target/DefaultExperimentTargetDeterminerSpecs.swift
@@ -5,7 +5,7 @@ import MockingKit
 @testable import Hackle
 
 class DefaultExperimentTargetDeterminerSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
 
 
         it("Audience가 비어 있으면 true") {

--- a/Tests/HackleTests/Core/Evaluation/Target/DefaultExperimentTargetDeterminerSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Target/DefaultExperimentTargetDeterminerSpecs.swift
@@ -26,7 +26,7 @@ class DefaultExperimentTargetDeterminerSpecs: QuickSpec {
             let matcher = TargetMatcherStub.of(false, false, false, true, false)
             let sut = DefaultExperimentTargetDeterminer(targetMatcher: matcher)
 
-            let experiment = experiment(targetAudiences: self.audiences())
+            let experiment = experiment(targetAudiences: audiences())
             let request = experimentRequest(experiment: experiment)
 
             // when
@@ -42,7 +42,7 @@ class DefaultExperimentTargetDeterminerSpecs: QuickSpec {
             let matcher = TargetMatcherStub.of(false, false, false, false, false)
             let sut = DefaultExperimentTargetDeterminer(targetMatcher: matcher)
 
-            let experiment = experiment(targetAudiences: self.audiences())
+            let experiment = experiment(targetAudiences: audiences())
             let request = experimentRequest(experiment: experiment)
 
             // when
@@ -54,7 +54,7 @@ class DefaultExperimentTargetDeterminerSpecs: QuickSpec {
         }
     }
 
-    private func audiences() -> [Target] {
+    private static func audiences() -> [Target] {
         [
             Target(conditions: [condition()]),
             Target(conditions: [condition()]),
@@ -64,7 +64,7 @@ class DefaultExperimentTargetDeterminerSpecs: QuickSpec {
         ]
     }
 
-    private func condition() -> Target.Condition {
+    private static func condition() -> Target.Condition {
         Target.Condition(key: Target.Key(type: .userProperty, name: "age"), match: Target.Match(type: .match, matchOperator: ._in, valueType: .number, values: [HackleValue(value: 1)]))
     }
 }

--- a/Tests/HackleTests/Core/Evaluation/Target/DefaultExperimentTargetRuleDeterminerSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Target/DefaultExperimentTargetRuleDeterminerSpecs.swift
@@ -5,7 +5,7 @@ import MockingKit
 @testable import Hackle
 
 class DefaultTargetRuleDeterminerSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
 
         it("첫 번째로 일치하는 타겟룰을 리턴한다") {
             // given

--- a/Tests/HackleTests/Core/Evaluation/Target/DefaultExperimentTargetRuleDeterminerSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Target/DefaultExperimentTargetRuleDeterminerSpecs.swift
@@ -27,7 +27,7 @@ class DefaultTargetRuleDeterminerSpecs: QuickSpec {
             let actual = try sut.determineTargetRuleOrNil(request: request, context: Evaluators.context())
 
             // then
-            expect(actual as AnyObject).to(beIdenticalTo(matchedTargetRule as AnyObject))
+            expect(actual as! MockTargetRule).to(beIdenticalTo(matchedTargetRule))
             expect(matcher.callCount).to(equal(4))
         }
 

--- a/Tests/HackleTests/Core/Evaluation/Target/DefaultExperimentTargetRuleDeterminerSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Target/DefaultExperimentTargetRuleDeterminerSpecs.swift
@@ -27,7 +27,7 @@ class DefaultTargetRuleDeterminerSpecs: QuickSpec {
             let actual = try sut.determineTargetRuleOrNil(request: request, context: Evaluators.context())
 
             // then
-            expect(actual as! MockTargetRule).to(beIdenticalTo(matchedTargetRule))
+            expect(actual as? MockTargetRule).to(beIdenticalTo(matchedTargetRule))
             expect(matcher.callCount).to(equal(4))
         }
 

--- a/Tests/HackleTests/Core/Evaluation/Target/DefaultExperimentTargetRuleDeterminerSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Target/DefaultExperimentTargetRuleDeterminerSpecs.swift
@@ -27,7 +27,7 @@ class DefaultTargetRuleDeterminerSpecs: QuickSpec {
             let actual = try sut.determineTargetRuleOrNil(request: request, context: Evaluators.context())
 
             // then
-            expect(actual).to(beIdenticalTo(matchedTargetRule))
+            expect(actual as AnyObject).to(beIdenticalTo(matchedTargetRule as AnyObject))
             expect(matcher.callCount).to(equal(4))
         }
 

--- a/Tests/HackleTests/Core/Evaluation/Target/DefaultOverrideResolverSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Target/DefaultOverrideResolverSpecs.swift
@@ -29,7 +29,7 @@ class DefaultOverrideResolverSpecs: QuickSpec {
 
             let actual = try sut.resolveOrNil(request: request, context: context)
 
-            expect(actual as! MockVariation).to(beIdenticalTo(variation))
+            expect(actual as? MockVariation).to(beIdenticalTo(variation))
         }
 
         it("identifierType에 해당하는 식별자가 없으면 segmentOverride를 평가한다") {
@@ -56,7 +56,7 @@ class DefaultOverrideResolverSpecs: QuickSpec {
             let actual = try sut.resolveOrNil(request: request, context: context)
 
             // then
-            expect(actual as! MockVariation).to(beIdenticalTo(variationBySegmentOverride))
+            expect(actual as? MockVariation).to(beIdenticalTo(variationBySegmentOverride))
         }
 
         it("identifierType에 해당하는 식별자가 override되어 있지않으면 segmentOverride를 평가한다") {
@@ -83,7 +83,7 @@ class DefaultOverrideResolverSpecs: QuickSpec {
             let actual = try sut.resolveOrNil(request: request, context: context)
 
             // then
-            expect(actual as! MockVariation).to(beIdenticalTo(variationBySegmentOverride))
+            expect(actual as? MockVariation).to(beIdenticalTo(variationBySegmentOverride))
         }
 
         it("identifierType에 해당하는 식별자로 override되어있는 variation을 리턴한다") {
@@ -110,7 +110,7 @@ class DefaultOverrideResolverSpecs: QuickSpec {
             let actual = try sut.resolveOrNil(request: request, context: context)
 
             // then
-            expect(actual as! MockVariation).to(beIdenticalTo(variationByUserOverride))
+            expect(actual as? MockVariation).to(beIdenticalTo(variationByUserOverride))
         }
 
         it("userOverride도 되어있지않고 segmentOverride도 되어있지 않으면 nil 리턴") {
@@ -165,7 +165,7 @@ class DefaultOverrideResolverSpecs: QuickSpec {
             let actual = try sut.resolveOrNil(request: request, context: context)
 
             // then
-            expect(actual as! MockVariation).to(beIdenticalTo(variationBySegmentOverride))
+            expect(actual as? MockVariation).to(beIdenticalTo(variationBySegmentOverride))
         }
 
         it("userOverride 는 첫번째로 매칭된 rule 로 평가한다") {
@@ -191,7 +191,7 @@ class DefaultOverrideResolverSpecs: QuickSpec {
             let actual = try sut.resolveOrNil(request: request, context: context)
 
             // then
-            expect(actual as! MockVariation).to(beIdenticalTo(variation))
+            expect(actual as? MockVariation).to(beIdenticalTo(variation))
             expect(targetMatcher.callCount) == 4
         }
 

--- a/Tests/HackleTests/Core/Evaluation/Target/DefaultOverrideResolverSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Target/DefaultOverrideResolverSpecs.swift
@@ -5,7 +5,7 @@ import MockingKit
 @testable import Hackle
 
 class DefaultOverrideResolverSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
 
         var manualOverrideStorage: ManualOverrideStorageStub!
         var targetMatcher: TargetMatcherStub!

--- a/Tests/HackleTests/Core/Evaluation/Target/DefaultOverrideResolverSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Target/DefaultOverrideResolverSpecs.swift
@@ -29,7 +29,7 @@ class DefaultOverrideResolverSpecs: QuickSpec {
 
             let actual = try sut.resolveOrNil(request: request, context: context)
 
-            expect(actual).to(beIdenticalTo(variation))
+            expect(actual as AnyObject).to(beIdenticalTo(variation as AnyObject))
         }
 
         it("identifierType에 해당하는 식별자가 없으면 segmentOverride를 평가한다") {
@@ -56,7 +56,7 @@ class DefaultOverrideResolverSpecs: QuickSpec {
             let actual = try sut.resolveOrNil(request: request, context: context)
 
             // then
-            expect(actual).to(beIdenticalTo(variationBySegmentOverride))
+            expect(actual as AnyObject).to(beIdenticalTo(variationBySegmentOverride as AnyObject))
         }
 
         it("identifierType에 해당하는 식별자가 override되어 있지않으면 segmentOverride를 평가한다") {
@@ -83,7 +83,7 @@ class DefaultOverrideResolverSpecs: QuickSpec {
             let actual = try sut.resolveOrNil(request: request, context: context)
 
             // then
-            expect(actual).to(beIdenticalTo(variationBySegmentOverride))
+            expect(actual as AnyObject).to(beIdenticalTo(variationBySegmentOverride as AnyObject))
         }
 
         it("identifierType에 해당하는 식별자로 override되어있는 variation을 리턴한다") {
@@ -110,7 +110,7 @@ class DefaultOverrideResolverSpecs: QuickSpec {
             let actual = try sut.resolveOrNil(request: request, context: context)
 
             // then
-            expect(actual).to(beIdenticalTo(variationByUserOverride))
+            expect(actual as AnyObject).to(beIdenticalTo(variationByUserOverride as AnyObject))
         }
 
         it("userOverride도 되어있지않고 segmentOverride도 되어있지 않으면 nil 리턴") {
@@ -165,7 +165,7 @@ class DefaultOverrideResolverSpecs: QuickSpec {
             let actual = try sut.resolveOrNil(request: request, context: context)
 
             // then
-            expect(actual).to(beIdenticalTo(variationBySegmentOverride))
+            expect(actual as AnyObject).to(beIdenticalTo(variationBySegmentOverride as AnyObject))
         }
 
         it("userOverride 는 첫번째로 매칭된 rule 로 평가한다") {
@@ -191,7 +191,7 @@ class DefaultOverrideResolverSpecs: QuickSpec {
             let actual = try sut.resolveOrNil(request: request, context: context)
 
             // then
-            expect(actual).to(beIdenticalTo(variation))
+            expect(actual as AnyObject).to(beIdenticalTo(variation as AnyObject))
             expect(targetMatcher.callCount) == 4
         }
 

--- a/Tests/HackleTests/Core/Evaluation/Target/DefaultOverrideResolverSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Target/DefaultOverrideResolverSpecs.swift
@@ -29,7 +29,7 @@ class DefaultOverrideResolverSpecs: QuickSpec {
 
             let actual = try sut.resolveOrNil(request: request, context: context)
 
-            expect(actual as AnyObject).to(beIdenticalTo(variation as AnyObject))
+            expect(actual as! MockVariation).to(beIdenticalTo(variation))
         }
 
         it("identifierType에 해당하는 식별자가 없으면 segmentOverride를 평가한다") {
@@ -56,7 +56,7 @@ class DefaultOverrideResolverSpecs: QuickSpec {
             let actual = try sut.resolveOrNil(request: request, context: context)
 
             // then
-            expect(actual as AnyObject).to(beIdenticalTo(variationBySegmentOverride as AnyObject))
+            expect(actual as! MockVariation).to(beIdenticalTo(variationBySegmentOverride))
         }
 
         it("identifierType에 해당하는 식별자가 override되어 있지않으면 segmentOverride를 평가한다") {
@@ -83,7 +83,7 @@ class DefaultOverrideResolverSpecs: QuickSpec {
             let actual = try sut.resolveOrNil(request: request, context: context)
 
             // then
-            expect(actual as AnyObject).to(beIdenticalTo(variationBySegmentOverride as AnyObject))
+            expect(actual as! MockVariation).to(beIdenticalTo(variationBySegmentOverride))
         }
 
         it("identifierType에 해당하는 식별자로 override되어있는 variation을 리턴한다") {
@@ -110,7 +110,7 @@ class DefaultOverrideResolverSpecs: QuickSpec {
             let actual = try sut.resolveOrNil(request: request, context: context)
 
             // then
-            expect(actual as AnyObject).to(beIdenticalTo(variationByUserOverride as AnyObject))
+            expect(actual as! MockVariation).to(beIdenticalTo(variationByUserOverride))
         }
 
         it("userOverride도 되어있지않고 segmentOverride도 되어있지 않으면 nil 리턴") {
@@ -165,7 +165,7 @@ class DefaultOverrideResolverSpecs: QuickSpec {
             let actual = try sut.resolveOrNil(request: request, context: context)
 
             // then
-            expect(actual as AnyObject).to(beIdenticalTo(variationBySegmentOverride as AnyObject))
+            expect(actual as! MockVariation).to(beIdenticalTo(variationBySegmentOverride))
         }
 
         it("userOverride 는 첫번째로 매칭된 rule 로 평가한다") {
@@ -191,7 +191,7 @@ class DefaultOverrideResolverSpecs: QuickSpec {
             let actual = try sut.resolveOrNil(request: request, context: context)
 
             // then
-            expect(actual as AnyObject).to(beIdenticalTo(variation as AnyObject))
+            expect(actual as! MockVariation).to(beIdenticalTo(variation))
             expect(targetMatcher.callCount) == 4
         }
 

--- a/Tests/HackleTests/Core/Evaluation/Target/DefaultRemoteConfigTargetRuleDeterminerSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Target/DefaultRemoteConfigTargetRuleDeterminerSpecs.swift
@@ -5,7 +5,7 @@ import MockingKit
 @testable import Hackle
 
 class DefaultRemoteConfigTargetRuleDeterminerSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
 
         var matcher: RemoteConfigTargetRuleMatcherStub!
         var sut: DefaultRemoteConfigTargetRuleDeterminer!

--- a/Tests/HackleTests/Core/Evaluation/Target/DefaultRemoteConfigTargetRuleMatcherSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Target/DefaultRemoteConfigTargetRuleMatcherSpecs.swift
@@ -6,7 +6,7 @@ import MockingKit
 
 
 class DefaultRemoteConfigTargetRuleMatcherSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
 
         var targetMatcher: MockTargetMatcher!
         var bucketer: MockBucketer!

--- a/Tests/HackleTests/Core/Evaluation/Target/DelegatingManualOverrideStorageSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Target/DelegatingManualOverrideStorageSpecs.swift
@@ -26,7 +26,7 @@ class DelegatingManualOverrideStorageSpecs: QuickSpec {
 
             let actual = sut.get(experiment: MockExperiment(), user: HackleUser.builder().build())
 
-            expect(actual).to(beIdenticalTo(variation))
+            expect(actual as AnyObject).to(beIdenticalTo(variation as AnyObject))
             expect(storage.count) == 4
         }
 

--- a/Tests/HackleTests/Core/Evaluation/Target/DelegatingManualOverrideStorageSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Target/DelegatingManualOverrideStorageSpecs.swift
@@ -26,7 +26,7 @@ class DelegatingManualOverrideStorageSpecs: QuickSpec {
 
             let actual = sut.get(experiment: MockExperiment(), user: HackleUser.builder().build())
 
-            expect(actual as! MockVariation).to(beIdenticalTo(variation))
+            expect(actual as? MockVariation).to(beIdenticalTo(variation))
             expect(storage.count) == 4
         }
 

--- a/Tests/HackleTests/Core/Evaluation/Target/DelegatingManualOverrideStorageSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Target/DelegatingManualOverrideStorageSpecs.swift
@@ -5,7 +5,7 @@ import MockingKit
 @testable import Hackle
 
 class DelegatingManualOverrideStorageSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
 
         it("empty storage") {
             let sut = DelegatingManualOverrideStorage(storages: [])

--- a/Tests/HackleTests/Core/Evaluation/Target/DelegatingManualOverrideStorageSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Target/DelegatingManualOverrideStorageSpecs.swift
@@ -26,7 +26,7 @@ class DelegatingManualOverrideStorageSpecs: QuickSpec {
 
             let actual = sut.get(experiment: MockExperiment(), user: HackleUser.builder().build())
 
-            expect(actual as AnyObject).to(beIdenticalTo(variation as AnyObject))
+            expect(actual as! MockVariation).to(beIdenticalTo(variation))
             expect(storage.count) == 4
         }
 

--- a/Tests/HackleTests/Core/Evaluation/Target/InAppMessageMatcherSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Target/InAppMessageMatcherSpecs.swift
@@ -12,7 +12,7 @@ import Nimble
 
 
 class InAppMessageUserOverrideMatcherSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
 
         var sut: InAppMessageUserOverrideMatcher!
 
@@ -71,7 +71,7 @@ class InAppMessageUserOverrideMatcherSpecs: QuickSpec {
 }
 
 class InAppMessageTargetMatcherSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
 
         it("when targets is empty when returns true") {
             // given
@@ -135,7 +135,7 @@ class InAppMessageTargetMatcherSpecs: QuickSpec {
 
 
 class InAppMessageHiddenMatcherSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
         var storage: InAppMessageHiddenStorage!
         var sut: InAppMessageHiddenMatcher!
 
@@ -174,7 +174,7 @@ class InAppMessageHiddenMatcherSpecs: QuickSpec {
 
 
 class InAppMessageFrequencyCapMatcherSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
         var storage: InAppMessageImpressionStorage!
         var sut: InAppMessageFrequencyCapMatcher!
         var user: HackleUser!

--- a/Tests/HackleTests/Core/Evaluation/Target/InAppMessageMatcherSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Target/InAppMessageMatcherSpecs.swift
@@ -91,7 +91,7 @@ class InAppMessageTargetMatcherSpecs: QuickSpec {
             let sut = InAppMessageTargetMatcher(targetMatcher: targetMatcher)
             let request = InAppMessage.eligibilityRequest(
                 inAppMessage: InAppMessage.create(
-                    targetContext: InAppMessage.targetContext(targets: self.targets()))
+                    targetContext: InAppMessage.targetContext(targets: targets()))
             )
             // when
             let actual = try sut.matches(request: request, context: Evaluators.context())
@@ -107,7 +107,7 @@ class InAppMessageTargetMatcherSpecs: QuickSpec {
             let sut = InAppMessageTargetMatcher(targetMatcher: targetMatcher)
             let request = InAppMessage.eligibilityRequest(
                 inAppMessage: InAppMessage.create(
-                    targetContext: InAppMessage.targetContext(targets: self.targets()))
+                    targetContext: InAppMessage.targetContext(targets: targets()))
             )
             // when
             let actual = try sut.matches(request: request, context: Evaluators.context())
@@ -118,7 +118,7 @@ class InAppMessageTargetMatcherSpecs: QuickSpec {
         }
     }
 
-    private func targets() -> [Target] {
+    private static func targets() -> [Target] {
         [
             Target(conditions: [condition()]),
             Target(conditions: [condition()]),
@@ -128,7 +128,7 @@ class InAppMessageTargetMatcherSpecs: QuickSpec {
         ]
     }
 
-    private func condition() -> Target.Condition {
+    private static func condition() -> Target.Condition {
         Target.Condition(key: Target.Key(type: .userProperty, name: "age"), match: Target.Match(type: .match, matchOperator: ._in, valueType: .number, values: [HackleValue(value: 1)]))
     }
 }

--- a/Tests/HackleTests/Core/Event/Dedup/DedupUserEventFilterSpecs.swift
+++ b/Tests/HackleTests/Core/Event/Dedup/DedupUserEventFilterSpecs.swift
@@ -4,7 +4,7 @@ import Nimble
 @testable import Hackle
 
 class DedupUserEventFilterSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
 
         var eventDedupDeterminer: MockUserEventDedupDeterminer!
         var sut: DedupUserEventFilter!

--- a/Tests/HackleTests/Core/Event/Dedup/DelegatingUserEventDedupDeterminerSpecs.swift
+++ b/Tests/HackleTests/Core/Event/Dedup/DelegatingUserEventDedupDeterminerSpecs.swift
@@ -4,7 +4,7 @@ import Nimble
 @testable import Hackle
 
 class DelegatingUserEventDedupDeterminerSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
         it("determiner") {
             // given
             let sut = DelegatingUserEventDedupDeterminer(determiners: [

--- a/Tests/HackleTests/Core/Event/Dedup/ExposureEventDedupDeterminerSpec.swift
+++ b/Tests/HackleTests/Core/Event/Dedup/ExposureEventDedupDeterminerSpec.swift
@@ -11,7 +11,7 @@ import Nimble
 @testable import Hackle
 
 class ExposureEventDedupDeterminerSpec: QuickSpec {
-    override func spec() {
+    override class func spec() {
         var repository: UserDefaultsKeyValueRepository!
         var exposureEventDedupDeterminerSut: ExposureEventDedupDeterminer!
         

--- a/Tests/HackleTests/Core/Event/Dedup/RemoteConfigEventDedupDeterminerSpecs.swift
+++ b/Tests/HackleTests/Core/Event/Dedup/RemoteConfigEventDedupDeterminerSpecs.swift
@@ -5,7 +5,7 @@ import Nimble
 
 
 class RemoteConfigEventDedupDeterminerSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
         it("cacheKey") {
             let repository = UserDefaultsKeyValueRepository.of(suiteName: "unittest_rc_repo_abcd1234")
             let sut = RemoteConfigEventDedupDeterminer(repository: repository, dedupInterval: -1)

--- a/Tests/HackleTests/Core/Event/DefaultUserEventBackoffControllerSpec.swift
+++ b/Tests/HackleTests/Core/Event/DefaultUserEventBackoffControllerSpec.swift
@@ -11,7 +11,7 @@ import Nimble
 import Foundation
 
 class DefaultUserEventBackoffControllerSpec: QuickSpec {
-    override func spec() {
+    override class func spec() {
         var sut: DefaultUserEventBackoffController!
         var userEventRetryInterval: TimeInterval!
         var clock: FixedClock!

--- a/Tests/HackleTests/Core/Event/DefaultUserEventDispatcherSepc.swift
+++ b/Tests/HackleTests/Core/Event/DefaultUserEventDispatcherSepc.swift
@@ -8,7 +8,7 @@ import Nimble
 @testable import Hackle
 
 class DefaultUserEventDispatcherSpec: QuickSpec {
-    override func spec() {
+    override class func spec() {
 
         var eventQueue: DispatchQueue!
         var eventRepository: MockSQLiteEventRepository!

--- a/Tests/HackleTests/Core/Event/DefaultUserEventFactorySpecs.swift
+++ b/Tests/HackleTests/Core/Event/DefaultUserEventFactorySpecs.swift
@@ -69,7 +69,7 @@ class DefaultUserEventFactorySpecs: QuickSpec {
             let exposure1 = events[1] as! UserEvents.Exposure
             expect(exposure1.timestamp) == Date(timeIntervalSince1970: 42)
             expect(exposure1.user).to(beIdenticalTo(request.user))
-            expect(exposure1.experiment as! ExperimentEntity).to(beIdenticalTo(evaluation1.experiment as! ExperimentEntity))
+            expect(exposure1.experiment as? ExperimentEntity).to(beIdenticalTo(evaluation1.experiment as? ExperimentEntity))
             expect(exposure1.variationId) == 42
             expect(exposure1.variationKey) == "B"
             expect(exposure1.decisionReason) == DecisionReason.TRAFFIC_ALLOCATED
@@ -84,7 +84,7 @@ class DefaultUserEventFactorySpecs: QuickSpec {
             let exposure2 = events[2] as! UserEvents.Exposure
             expect(exposure2.timestamp) == Date(timeIntervalSince1970: 42)
             expect(exposure2.user).to(beIdenticalTo(request.user))
-            expect(exposure2.experiment as! ExperimentEntity).to(beIdenticalTo(evaluation2.experiment as! ExperimentEntity))
+            expect(exposure2.experiment as? ExperimentEntity).to(beIdenticalTo(evaluation2.experiment as? ExperimentEntity))
             expect(exposure2.variationId) == 320
             expect(exposure2.variationKey) == "A"
             expect(exposure2.decisionReason) == DecisionReason.DEFAULT_RULE
@@ -118,7 +118,7 @@ class DefaultUserEventFactorySpecs: QuickSpec {
             let exposure1 = events[0] as! UserEvents.Exposure
             expect(exposure1.timestamp) == Date(timeIntervalSince1970: 42)
             expect(exposure1.user).to(beIdenticalTo(request.user))
-            expect(exposure1.experiment as! ExperimentEntity).to(beIdenticalTo(evaluation1.experiment as! ExperimentEntity))
+            expect(exposure1.experiment as? ExperimentEntity).to(beIdenticalTo(evaluation1.experiment as? ExperimentEntity))
             expect(exposure1.variationId) == 42
             expect(exposure1.variationKey) == "B"
             expect(exposure1.decisionReason) == DecisionReason.TRAFFIC_ALLOCATED

--- a/Tests/HackleTests/Core/Event/DefaultUserEventFactorySpecs.swift
+++ b/Tests/HackleTests/Core/Event/DefaultUserEventFactorySpecs.swift
@@ -69,7 +69,7 @@ class DefaultUserEventFactorySpecs: QuickSpec {
             let exposure1 = events[1] as! UserEvents.Exposure
             expect(exposure1.timestamp) == Date(timeIntervalSince1970: 42)
             expect(exposure1.user).to(beIdenticalTo(request.user))
-            expect(exposure1.experiment).to(beIdenticalTo(evaluation1.experiment))
+            expect(exposure1.experiment as AnyObject).to(beIdenticalTo(evaluation1.experiment as AnyObject))
             expect(exposure1.variationId) == 42
             expect(exposure1.variationKey) == "B"
             expect(exposure1.decisionReason) == DecisionReason.TRAFFIC_ALLOCATED
@@ -84,7 +84,7 @@ class DefaultUserEventFactorySpecs: QuickSpec {
             let exposure2 = events[2] as! UserEvents.Exposure
             expect(exposure2.timestamp) == Date(timeIntervalSince1970: 42)
             expect(exposure2.user).to(beIdenticalTo(request.user))
-            expect(exposure2.experiment).to(beIdenticalTo(evaluation2.experiment))
+            expect(exposure2.experiment as AnyObject).to(beIdenticalTo(evaluation2.experiment as AnyObject))
             expect(exposure2.variationId) == 320
             expect(exposure2.variationKey) == "A"
             expect(exposure2.decisionReason) == DecisionReason.DEFAULT_RULE
@@ -118,7 +118,7 @@ class DefaultUserEventFactorySpecs: QuickSpec {
             let exposure1 = events[0] as! UserEvents.Exposure
             expect(exposure1.timestamp) == Date(timeIntervalSince1970: 42)
             expect(exposure1.user).to(beIdenticalTo(request.user))
-            expect(exposure1.experiment).to(beIdenticalTo(evaluation1.experiment))
+            expect(exposure1.experiment as AnyObject).to(beIdenticalTo(evaluation1.experiment as AnyObject))
             expect(exposure1.variationId) == 42
             expect(exposure1.variationKey) == "B"
             expect(exposure1.decisionReason) == DecisionReason.TRAFFIC_ALLOCATED

--- a/Tests/HackleTests/Core/Event/DefaultUserEventFactorySpecs.swift
+++ b/Tests/HackleTests/Core/Event/DefaultUserEventFactorySpecs.swift
@@ -12,7 +12,7 @@ import MockingKit
 @testable import Hackle
 
 class DefaultUserEventFactorySpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
 
         it("create") {
             let sut = DefaultUserEventFactory(clock: ClockStub())

--- a/Tests/HackleTests/Core/Event/DefaultUserEventFactorySpecs.swift
+++ b/Tests/HackleTests/Core/Event/DefaultUserEventFactorySpecs.swift
@@ -69,7 +69,7 @@ class DefaultUserEventFactorySpecs: QuickSpec {
             let exposure1 = events[1] as! UserEvents.Exposure
             expect(exposure1.timestamp) == Date(timeIntervalSince1970: 42)
             expect(exposure1.user).to(beIdenticalTo(request.user))
-            expect(exposure1.experiment as AnyObject).to(beIdenticalTo(evaluation1.experiment as AnyObject))
+            expect(exposure1.experiment as! ExperimentEntity).to(beIdenticalTo(evaluation1.experiment as! ExperimentEntity))
             expect(exposure1.variationId) == 42
             expect(exposure1.variationKey) == "B"
             expect(exposure1.decisionReason) == DecisionReason.TRAFFIC_ALLOCATED
@@ -84,7 +84,7 @@ class DefaultUserEventFactorySpecs: QuickSpec {
             let exposure2 = events[2] as! UserEvents.Exposure
             expect(exposure2.timestamp) == Date(timeIntervalSince1970: 42)
             expect(exposure2.user).to(beIdenticalTo(request.user))
-            expect(exposure2.experiment as AnyObject).to(beIdenticalTo(evaluation2.experiment as AnyObject))
+            expect(exposure2.experiment as! ExperimentEntity).to(beIdenticalTo(evaluation2.experiment as! ExperimentEntity))
             expect(exposure2.variationId) == 320
             expect(exposure2.variationKey) == "A"
             expect(exposure2.decisionReason) == DecisionReason.DEFAULT_RULE
@@ -118,7 +118,7 @@ class DefaultUserEventFactorySpecs: QuickSpec {
             let exposure1 = events[0] as! UserEvents.Exposure
             expect(exposure1.timestamp) == Date(timeIntervalSince1970: 42)
             expect(exposure1.user).to(beIdenticalTo(request.user))
-            expect(exposure1.experiment as AnyObject).to(beIdenticalTo(evaluation1.experiment as AnyObject))
+            expect(exposure1.experiment as! ExperimentEntity).to(beIdenticalTo(evaluation1.experiment as! ExperimentEntity))
             expect(exposure1.variationId) == 42
             expect(exposure1.variationKey) == "B"
             expect(exposure1.decisionReason) == DecisionReason.TRAFFIC_ALLOCATED

--- a/Tests/HackleTests/Core/Event/DefaultUserEventProcessorSpec.swift
+++ b/Tests/HackleTests/Core/Event/DefaultUserEventProcessorSpec.swift
@@ -6,7 +6,7 @@ import MockingKit
 
 class DefaultUserEventProcessorSpec: QuickSpec {
 
-    override func spec() {
+    override class func spec() {
 
         let user = HackleUser.of(userId: "test_id")
 

--- a/Tests/HackleTests/Core/Event/DefaultUserEventProcessorSpec.swift
+++ b/Tests/HackleTests/Core/Event/DefaultUserEventProcessorSpec.swift
@@ -522,7 +522,7 @@ class DefaultUserEventProcessorSpec: QuickSpec {
                 sut.initialize()
 
                 // then
-                expect(eventRepository.updateMock.invokations()[0].arguments.0).to(beIdenticalTo(events))
+                expect(eventRepository.updateMock.invokations()[0].arguments.0.first).to(beIdenticalTo(events.first))
                 expect(eventRepository.updateMock.invokations()[0].arguments.1) == EventEntityStatus.pending
                 verify(exactly: 1) {
                     eventRepository.deleteExpiredEventsMock

--- a/Tests/HackleTests/Core/Event/UserEventSpecs.swift
+++ b/Tests/HackleTests/Core/Event/UserEventSpecs.swift
@@ -4,7 +4,7 @@ import Nimble
 @testable import Hackle
 
 class UserEventSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
         describe("ExposureEvent") {
             it("copy") {
                 let parameterConfiguration = ParameterConfigurationEntity(id: 42, parameters: [:])

--- a/Tests/HackleTests/Core/Event/UserEventSpecs.swift
+++ b/Tests/HackleTests/Core/Event/UserEventSpecs.swift
@@ -22,7 +22,7 @@ class UserEventSpecs: QuickSpec {
                 expect(exposureEvent.variationKey) == event.variationKey
                 expect(exposureEvent.timestamp) == event.timestamp
                 expect(exposureEvent.decisionReason) == event.decisionReason
-                expect(exposureEvent.properties["a"]).to(be("1"))
+                expect(exposureEvent.properties["a"] as? String) == "1"
             }
         }
 

--- a/Tests/HackleTests/Core/HackleCoreSpecs.swift
+++ b/Tests/HackleTests/Core/HackleCoreSpecs.swift
@@ -12,7 +12,7 @@ import Nimble
 
 
 class HackleCoreSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
 
         beforeSuite {
             EvaluationContext.shared.register(DefaultInAppMessageHiddenStorage(keyValueRepository: MemoryKeyValueRepository()))

--- a/Tests/HackleTests/Core/InAppMessage/Delay/DefaultInAppMessageDelayManagerSpecs.swift
+++ b/Tests/HackleTests/Core/InAppMessage/Delay/DefaultInAppMessageDelayManagerSpecs.swift
@@ -5,7 +5,7 @@ import Quick
 @testable import Hackle
 
 class DefaultInAppMessageDelayManagerSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
 
         var scheduler: MockInAppMessageDelayScheduler!
         var sut: DefaultInAppMessageDelayManager!

--- a/Tests/HackleTests/Core/InAppMessage/Delay/DefaultInAppMessageDelaySchedulerSpecs.swift
+++ b/Tests/HackleTests/Core/InAppMessage/Delay/DefaultInAppMessageDelaySchedulerSpecs.swift
@@ -5,7 +5,7 @@ import Quick
 @testable import Hackle
 
 class DefaultInAppMessageDelaySchedulerSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
 
         it("delay trigger") {
             // given

--- a/Tests/HackleTests/Core/InAppMessage/Deliver/DefaultInAppMessageDeliverProcessorSpecs.swift
+++ b/Tests/HackleTests/Core/InAppMessage/Deliver/DefaultInAppMessageDeliverProcessorSpecs.swift
@@ -5,7 +5,7 @@ import Quick
 @testable import Hackle
 
 class DefaultInAppMessageDeliverProcessorSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
 
         var workspaceFetcher: MockWorkspaceFetcher!
         var userManager: MockUserManager!

--- a/Tests/HackleTests/Core/InAppMessage/Deliver/InAppMessageDeliverRequestSpecs.swift
+++ b/Tests/HackleTests/Core/InAppMessage/Deliver/InAppMessageDeliverRequestSpecs.swift
@@ -4,7 +4,7 @@ import Nimble
 @testable import Hackle
 
 class InAppMessageDeliverRequestSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
         it("create") {
             let schedule = InAppMessage.schedule(
                 dispatchId: "111",

--- a/Tests/HackleTests/Core/InAppMessage/Evaluation/DefaultInAppMessageEvaluateProcessorSpecs.swift
+++ b/Tests/HackleTests/Core/InAppMessage/Evaluation/DefaultInAppMessageEvaluateProcessorSpecs.swift
@@ -4,7 +4,7 @@ import Nimble
 @testable import Hackle
 
 class DefaultInAppMessageEvaluateProcessorSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
 
         var core: HackleCore!
         var flowFactory: MockInAppMessageEligibilityFlowFactory!

--- a/Tests/HackleTests/Core/InAppMessage/Evaluation/DefaultInAppMessageEvaluateProcessorSpecs.swift
+++ b/Tests/HackleTests/Core/InAppMessage/Evaluation/DefaultInAppMessageEvaluateProcessorSpecs.swift
@@ -39,15 +39,15 @@ class DefaultInAppMessageEvaluateProcessorSpecs: QuickSpec {
             let actual = try sut.process(type: .trigger, request: request)
 
             // then
-            expect(actual as AnyObject).to(beIdenticalTo(evaluation as AnyObject))
+            expect(actual as! InAppMessageEligibilityEvaluation).to(beIdenticalTo(evaluation))
             verify(exactly: 1) {
                 flowFactory.triggerFlowMock
             }
             verify(exactly: 1) {
                 eventRecorder.recordMock
             }
-            expect(eventRecorder.recordMock.firstInvokation().arguments.0 as AnyObject).to(beIdenticalTo(request as AnyObject))
-            expect(eventRecorder.recordMock.firstInvokation().arguments.1 as AnyObject).to(beIdenticalTo(evaluation as AnyObject))
+            expect(eventRecorder.recordMock.firstInvokation().arguments.0 as! InAppMessageEligibilityRequest).to(beIdenticalTo(request))
+            expect(eventRecorder.recordMock.firstInvokation().arguments.1 as! InAppMessageEligibilityEvaluation).to(beIdenticalTo(evaluation))
         }
 
         it("deliver evaluate") {
@@ -61,15 +61,15 @@ class DefaultInAppMessageEvaluateProcessorSpecs: QuickSpec {
             let actual = try sut.process(type: .deliver, request: request)
 
             // then
-            expect(actual as AnyObject).to(beIdenticalTo(evaluation as AnyObject))
+            expect(actual as! InAppMessageEligibilityEvaluation).to(beIdenticalTo(evaluation))
             verify(exactly: 1) {
                 flowFactory.deliverFlowMock
             }
             verify(exactly: 1) {
                 eventRecorder.recordMock
             }
-            expect(eventRecorder.recordMock.firstInvokation().arguments.0 as AnyObject).to(beIdenticalTo(request as AnyObject))
-            expect(eventRecorder.recordMock.firstInvokation().arguments.1 as AnyObject).to(beIdenticalTo(evaluation as AnyObject))
+            expect(eventRecorder.recordMock.firstInvokation().arguments.0 as! InAppMessageEligibilityRequest).to(beIdenticalTo(request))
+            expect(eventRecorder.recordMock.firstInvokation().arguments.1 as! InAppMessageEligibilityEvaluation).to(beIdenticalTo(evaluation))
         }
     }
 }

--- a/Tests/HackleTests/Core/InAppMessage/Evaluation/DefaultInAppMessageEvaluateProcessorSpecs.swift
+++ b/Tests/HackleTests/Core/InAppMessage/Evaluation/DefaultInAppMessageEvaluateProcessorSpecs.swift
@@ -39,15 +39,15 @@ class DefaultInAppMessageEvaluateProcessorSpecs: QuickSpec {
             let actual = try sut.process(type: .trigger, request: request)
 
             // then
-            expect(actual as! InAppMessageEligibilityEvaluation).to(beIdenticalTo(evaluation))
+            expect(actual as? InAppMessageEligibilityEvaluation).to(beIdenticalTo(evaluation))
             verify(exactly: 1) {
                 flowFactory.triggerFlowMock
             }
             verify(exactly: 1) {
                 eventRecorder.recordMock
             }
-            expect(eventRecorder.recordMock.firstInvokation().arguments.0 as! InAppMessageEligibilityRequest).to(beIdenticalTo(request))
-            expect(eventRecorder.recordMock.firstInvokation().arguments.1 as! InAppMessageEligibilityEvaluation).to(beIdenticalTo(evaluation))
+            expect(eventRecorder.recordMock.firstInvokation().arguments.0 as? InAppMessageEligibilityRequest).to(beIdenticalTo(request))
+            expect(eventRecorder.recordMock.firstInvokation().arguments.1 as? InAppMessageEligibilityEvaluation).to(beIdenticalTo(evaluation))
         }
 
         it("deliver evaluate") {
@@ -61,15 +61,15 @@ class DefaultInAppMessageEvaluateProcessorSpecs: QuickSpec {
             let actual = try sut.process(type: .deliver, request: request)
 
             // then
-            expect(actual as! InAppMessageEligibilityEvaluation).to(beIdenticalTo(evaluation))
+            expect(actual as? InAppMessageEligibilityEvaluation).to(beIdenticalTo(evaluation))
             verify(exactly: 1) {
                 flowFactory.deliverFlowMock
             }
             verify(exactly: 1) {
                 eventRecorder.recordMock
             }
-            expect(eventRecorder.recordMock.firstInvokation().arguments.0 as! InAppMessageEligibilityRequest).to(beIdenticalTo(request))
-            expect(eventRecorder.recordMock.firstInvokation().arguments.1 as! InAppMessageEligibilityEvaluation).to(beIdenticalTo(evaluation))
+            expect(eventRecorder.recordMock.firstInvokation().arguments.0 as? InAppMessageEligibilityRequest).to(beIdenticalTo(request))
+            expect(eventRecorder.recordMock.firstInvokation().arguments.1 as? InAppMessageEligibilityEvaluation).to(beIdenticalTo(evaluation))
         }
     }
 }

--- a/Tests/HackleTests/Core/InAppMessage/Evaluation/DefaultInAppMessageEvaluateProcessorSpecs.swift
+++ b/Tests/HackleTests/Core/InAppMessage/Evaluation/DefaultInAppMessageEvaluateProcessorSpecs.swift
@@ -39,15 +39,15 @@ class DefaultInAppMessageEvaluateProcessorSpecs: QuickSpec {
             let actual = try sut.process(type: .trigger, request: request)
 
             // then
-            expect(actual).to(beIdenticalTo(evaluation))
+            expect(actual as AnyObject).to(beIdenticalTo(evaluation as AnyObject))
             verify(exactly: 1) {
                 flowFactory.triggerFlowMock
             }
             verify(exactly: 1) {
                 eventRecorder.recordMock
             }
-            expect(eventRecorder.recordMock.firstInvokation().arguments.0).to(beIdenticalTo(request))
-            expect(eventRecorder.recordMock.firstInvokation().arguments.1).to(beIdenticalTo(evaluation))
+            expect(eventRecorder.recordMock.firstInvokation().arguments.0 as AnyObject).to(beIdenticalTo(request as AnyObject))
+            expect(eventRecorder.recordMock.firstInvokation().arguments.1 as AnyObject).to(beIdenticalTo(evaluation as AnyObject))
         }
 
         it("deliver evaluate") {
@@ -61,15 +61,15 @@ class DefaultInAppMessageEvaluateProcessorSpecs: QuickSpec {
             let actual = try sut.process(type: .deliver, request: request)
 
             // then
-            expect(actual).to(beIdenticalTo(evaluation))
+            expect(actual as AnyObject).to(beIdenticalTo(evaluation as AnyObject))
             verify(exactly: 1) {
                 flowFactory.deliverFlowMock
             }
             verify(exactly: 1) {
                 eventRecorder.recordMock
             }
-            expect(eventRecorder.recordMock.firstInvokation().arguments.0).to(beIdenticalTo(request))
-            expect(eventRecorder.recordMock.firstInvokation().arguments.1).to(beIdenticalTo(evaluation))
+            expect(eventRecorder.recordMock.firstInvokation().arguments.0 as AnyObject).to(beIdenticalTo(request as AnyObject))
+            expect(eventRecorder.recordMock.firstInvokation().arguments.1 as AnyObject).to(beIdenticalTo(evaluation as AnyObject))
         }
     }
 }

--- a/Tests/HackleTests/Core/InAppMessage/Evaluation/DefaultInAppMessageIdentifierCheckerSpecs.swift
+++ b/Tests/HackleTests/Core/InAppMessage/Evaluation/DefaultInAppMessageIdentifierCheckerSpecs.swift
@@ -4,7 +4,7 @@ import Nimble
 @testable import Hackle
 
 class DefaultInAppMessageIdentifierCheckerSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
 
         var sut: DefaultInAppMessageIdentifierChecker!
         beforeEach {

--- a/Tests/HackleTests/Core/InAppMessage/Evaluation/DefaultInAppMessageLayoutResolverSpecs.swift
+++ b/Tests/HackleTests/Core/InAppMessage/Evaluation/DefaultInAppMessageLayoutResolverSpecs.swift
@@ -33,8 +33,8 @@ class DefaultInAppMessageLayoutResolverSpecs: QuickSpec {
             let actual = try sut.resolve(workspace: workspace, inAppMessage: inAppMessage, user: user)
 
             // then
-            expect(actual as AnyObject).to(beIdenticalTo(evaluation as AnyObject))
-            expect(core.inAppMessageMock.firstInvokation().arguments.2 as AnyObject).to(beIdenticalTo(layoutEvalautor as AnyObject))
+            expect(actual as! InAppMessageLayoutEvaluation).to(beIdenticalTo(evaluation))
+            expect(core.inAppMessageMock.firstInvokation().arguments.2 as! InAppMessageLayoutEvaluator).to(beIdenticalTo(layoutEvalautor))
         }
     }
 }

--- a/Tests/HackleTests/Core/InAppMessage/Evaluation/DefaultInAppMessageLayoutResolverSpecs.swift
+++ b/Tests/HackleTests/Core/InAppMessage/Evaluation/DefaultInAppMessageLayoutResolverSpecs.swift
@@ -33,8 +33,8 @@ class DefaultInAppMessageLayoutResolverSpecs: QuickSpec {
             let actual = try sut.resolve(workspace: workspace, inAppMessage: inAppMessage, user: user)
 
             // then
-            expect(actual).to(beIdenticalTo(evaluation))
-            expect(core.inAppMessageMock.firstInvokation().arguments.2).to(beIdenticalTo(layoutEvalautor))
+            expect(actual as AnyObject).to(beIdenticalTo(evaluation as AnyObject))
+            expect(core.inAppMessageMock.firstInvokation().arguments.2 as AnyObject).to(beIdenticalTo(layoutEvalautor as AnyObject))
         }
     }
 }

--- a/Tests/HackleTests/Core/InAppMessage/Evaluation/DefaultInAppMessageLayoutResolverSpecs.swift
+++ b/Tests/HackleTests/Core/InAppMessage/Evaluation/DefaultInAppMessageLayoutResolverSpecs.swift
@@ -33,8 +33,8 @@ class DefaultInAppMessageLayoutResolverSpecs: QuickSpec {
             let actual = try sut.resolve(workspace: workspace, inAppMessage: inAppMessage, user: user)
 
             // then
-            expect(actual as! InAppMessageLayoutEvaluation).to(beIdenticalTo(evaluation))
-            expect(core.inAppMessageMock.firstInvokation().arguments.2 as! InAppMessageLayoutEvaluator).to(beIdenticalTo(layoutEvalautor))
+            expect(actual as? InAppMessageLayoutEvaluation).to(beIdenticalTo(evaluation))
+            expect(core.inAppMessageMock.firstInvokation().arguments.2 as? InAppMessageLayoutEvaluator).to(beIdenticalTo(layoutEvalautor))
         }
     }
 }

--- a/Tests/HackleTests/Core/InAppMessage/Evaluation/DefaultInAppMessageLayoutResolverSpecs.swift
+++ b/Tests/HackleTests/Core/InAppMessage/Evaluation/DefaultInAppMessageLayoutResolverSpecs.swift
@@ -5,7 +5,7 @@ import Quick
 @testable import Hackle
 
 class DefaultInAppMessageLayoutResolverSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
 
         it("resolve") {
             // given

--- a/Tests/HackleTests/Core/InAppMessage/InAppMessageManagerSpecs.swift
+++ b/Tests/HackleTests/Core/InAppMessage/InAppMessageManagerSpecs.swift
@@ -4,7 +4,7 @@ import Nimble
 @testable import Hackle
 
 class InAppMessageManagerSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
 
         var triggerProcessor: MockInAppMessageTriggerProcessor!
         var resetProcessor: MockInAppMessageResetProcessor!

--- a/Tests/HackleTests/Core/InAppMessage/Present/DefaultInAppMessagePresentProcessorSpecs.swift
+++ b/Tests/HackleTests/Core/InAppMessage/Present/DefaultInAppMessagePresentProcessorSpecs.swift
@@ -4,7 +4,7 @@ import Nimble
 @testable import Hackle
 
 class DefaultInAppMessagePresentProcessorSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
 
         var presenter: MockInAppMessagePresenter!
         var recorder: MockInAppMessageRecorder!

--- a/Tests/HackleTests/Core/InAppMessage/Present/Record/DefaultInAppMessageRecorderSpecs.swift
+++ b/Tests/HackleTests/Core/InAppMessage/Present/Record/DefaultInAppMessageRecorderSpecs.swift
@@ -4,7 +4,7 @@ import Nimble
 @testable import Hackle
 
 class DefaultInAppMessageRecorderSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
 
         var storage: InAppMessageImpressionStorage!
         var sut: DefaultInAppMessageRecorder!

--- a/Tests/HackleTests/Core/InAppMessage/Reset/DefaultInAppMessageResetProcessorSpecs.swift
+++ b/Tests/HackleTests/Core/InAppMessage/Reset/DefaultInAppMessageResetProcessorSpecs.swift
@@ -4,7 +4,7 @@ import Nimble
 @testable import Hackle
 
 class DefaultInAppMessageResetProcessorSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
 
         var identifierChecker: MockInAppMessageIdentifierChecker!
         var delayManager: MockInAppMessageDelayManager!

--- a/Tests/HackleTests/Core/InAppMessage/Schedule/Action/DefaultInAppMessageScheduleActionDeterminerSpecs.swift
+++ b/Tests/HackleTests/Core/InAppMessage/Schedule/Action/DefaultInAppMessageScheduleActionDeterminerSpecs.swift
@@ -5,7 +5,7 @@ import Quick
 @testable import Hackle
 
 class DefaultInAppMessageScheduleActionDeterminerSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
         var sut: DefaultInAppMessageScheduleActionDeterminer!
 
         beforeEach {

--- a/Tests/HackleTests/Core/InAppMessage/Schedule/DefaultInAppMessageScheduleProcessorSpecs.swift
+++ b/Tests/HackleTests/Core/InAppMessage/Schedule/DefaultInAppMessageScheduleProcessorSpecs.swift
@@ -5,7 +5,7 @@ import Quick
 @testable import Hackle
 
 class DefaultInAppMessageScheduleProcessorSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
 
         var actionDeterminer: MockInAppMessageScheduleActionDeterminer!
         var schedulerFactory: MockInAppMessageSchedulerFactory!

--- a/Tests/HackleTests/Core/InAppMessage/Schedule/InAppMessageScheduleRequestSpecs.swift
+++ b/Tests/HackleTests/Core/InAppMessage/Schedule/InAppMessageScheduleRequestSpecs.swift
@@ -5,7 +5,7 @@ import Quick
 @testable import Hackle
 
 class InAppMessageScheduleRequestSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
         it("delay") {
             let startedAt = Date(timeIntervalSince1970: 10)
             let deliverAt = Date(timeIntervalSince1970: 50)

--- a/Tests/HackleTests/Core/InAppMessage/Schedule/InAppMessageScheduleSpecs.swift
+++ b/Tests/HackleTests/Core/InAppMessage/Schedule/InAppMessageScheduleSpecs.swift
@@ -4,7 +4,7 @@ import Quick
 @testable import Hackle
 
 class InAppMessageScheduleSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
         it("time") {
             let startedAt = Date(timeIntervalSince1970: 10)
             let deliverAt = Date(timeIntervalSince1970: 50)

--- a/Tests/HackleTests/Core/InAppMessage/Schedule/Scheduler/DefaultInAppMessageSchedulerFactorySpecs.swift
+++ b/Tests/HackleTests/Core/InAppMessage/Schedule/Scheduler/DefaultInAppMessageSchedulerFactorySpecs.swift
@@ -20,7 +20,7 @@ class DefaultInAppMessageSchedulerFactorySpecs: QuickSpec {
 
             let actual = try sut.get(scheduleType: .triggered)
 
-            expect(actual).to(beIdenticalTo(scheduler2))
+            expect(actual as AnyObject).to(beIdenticalTo(scheduler2 as AnyObject))
         }
 
         it("exception") {

--- a/Tests/HackleTests/Core/InAppMessage/Schedule/Scheduler/DefaultInAppMessageSchedulerFactorySpecs.swift
+++ b/Tests/HackleTests/Core/InAppMessage/Schedule/Scheduler/DefaultInAppMessageSchedulerFactorySpecs.swift
@@ -20,7 +20,7 @@ class DefaultInAppMessageSchedulerFactorySpecs: QuickSpec {
 
             let actual = try sut.get(scheduleType: .triggered)
 
-            expect(actual as! MockInAppMessageScheduler).to(beIdenticalTo(scheduler2))
+            expect(actual as? MockInAppMessageScheduler).to(beIdenticalTo(scheduler2))
         }
 
         it("exception") {

--- a/Tests/HackleTests/Core/InAppMessage/Schedule/Scheduler/DefaultInAppMessageSchedulerFactorySpecs.swift
+++ b/Tests/HackleTests/Core/InAppMessage/Schedule/Scheduler/DefaultInAppMessageSchedulerFactorySpecs.swift
@@ -5,7 +5,7 @@ import Quick
 @testable import Hackle
 
 class DefaultInAppMessageSchedulerFactorySpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
 
         it("get") {
             let scheduler1 = MockInAppMessageScheduler()

--- a/Tests/HackleTests/Core/InAppMessage/Schedule/Scheduler/DefaultInAppMessageSchedulerFactorySpecs.swift
+++ b/Tests/HackleTests/Core/InAppMessage/Schedule/Scheduler/DefaultInAppMessageSchedulerFactorySpecs.swift
@@ -20,7 +20,7 @@ class DefaultInAppMessageSchedulerFactorySpecs: QuickSpec {
 
             let actual = try sut.get(scheduleType: .triggered)
 
-            expect(actual as AnyObject).to(beIdenticalTo(scheduler2 as AnyObject))
+            expect(actual as! MockInAppMessageScheduler).to(beIdenticalTo(scheduler2))
         }
 
         it("exception") {

--- a/Tests/HackleTests/Core/InAppMessage/Schedule/Scheduler/DelayedInAppMessageSchedulerSpecs.swift
+++ b/Tests/HackleTests/Core/InAppMessage/Schedule/Scheduler/DelayedInAppMessageSchedulerSpecs.swift
@@ -5,7 +5,7 @@ import Quick
 @testable import Hackle
 
 class DelayedInAppMessageSchedulerSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
 
         var deliverProcessor: MockInAppMessageDeliverProcessor!
         var delayManager: MockInAppMessageDelayManager!

--- a/Tests/HackleTests/Core/InAppMessage/Schedule/Scheduler/TriggeredInAppMessageSchedulerSpecs.swift
+++ b/Tests/HackleTests/Core/InAppMessage/Schedule/Scheduler/TriggeredInAppMessageSchedulerSpecs.swift
@@ -4,7 +4,7 @@ import Nimble
 @testable import Hackle
 
 class TriggeredInAppMessageSchedulerSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
 
         var deliverProcessor: MockInAppMessageDeliverProcessor!
         var delayManager: MockInAppMessageDelayManager!

--- a/Tests/HackleTests/Core/InAppMessage/Storage/DefaultInAppMessageHiddenStorageSpecs.swift
+++ b/Tests/HackleTests/Core/InAppMessage/Storage/DefaultInAppMessageHiddenStorageSpecs.swift
@@ -12,7 +12,7 @@ import Nimble
 
 
 class DefaultInAppMessageHiddenStorageSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
 
         var keyValueRepository: KeyValueRepository!
         var sut: DefaultInAppMessageHiddenStorage!

--- a/Tests/HackleTests/Core/InAppMessage/Storage/DefaultInAppMessageImpressionStorageSpecs.swift
+++ b/Tests/HackleTests/Core/InAppMessage/Storage/DefaultInAppMessageImpressionStorageSpecs.swift
@@ -5,7 +5,7 @@ import Nimble
 
 
 class DefaultInAppMessageImpressionStorageSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
         var repository: KeyValueRepository!
         var sut: DefaultInAppMessageImpressionStorage!
 

--- a/Tests/HackleTests/Core/InAppMessage/Trigger/DefaultInAppMessageTriggerDeterminerSpecs.swift
+++ b/Tests/HackleTests/Core/InAppMessage/Trigger/DefaultInAppMessageTriggerDeterminerSpecs.swift
@@ -5,7 +5,7 @@ import Quick
 @testable import Hackle
 
 class DefaultInAppMessageTriggerDeterminerSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
 
         var workspaceFetcher: MockWorkspaceFetcher!
         var eventMatcher: InAppMessageTriggerEventMatcherStub!

--- a/Tests/HackleTests/Core/InAppMessage/Trigger/DefaultInAppMessageTriggerEventMatcherSpecs.swift
+++ b/Tests/HackleTests/Core/InAppMessage/Trigger/DefaultInAppMessageTriggerEventMatcherSpecs.swift
@@ -4,7 +4,7 @@ import Nimble
 @testable import Hackle
 
 class DefaultInAppMessageTriggerEventMatcherSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
 
         var targetMatcher: TargetMatcherStub!
         var sut: DefaultInAppMessageTriggerEventMatcher!

--- a/Tests/HackleTests/Core/InAppMessage/Trigger/DefaultInAppMessageTriggerHandlerSpecs.swift
+++ b/Tests/HackleTests/Core/InAppMessage/Trigger/DefaultInAppMessageTriggerHandlerSpecs.swift
@@ -5,7 +5,7 @@ import Quick
 @testable import Hackle
 
 class DefaultInAppMessageTriggerHandlerSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
 
         var scheduleProcessor: MockInAppMessageScheduleProcessor!
         var sut: DefaultInAppMessageTriggerHandler!

--- a/Tests/HackleTests/Core/InAppMessage/Trigger/DefaultInAppMessageTriggerProcessorSpecs.swift
+++ b/Tests/HackleTests/Core/InAppMessage/Trigger/DefaultInAppMessageTriggerProcessorSpecs.swift
@@ -4,7 +4,7 @@ import Nimble
 @testable import Hackle
 
 class DefaultInAppMessageTriggerProcessorSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
 
         var determiner: MockInAppMessageTriggerDeterminer!
         var handler: MockInAppMessageTriggerHandler!

--- a/Tests/HackleTests/Core/Lifecycle/DefaultAppStateManagerSpecs.swift
+++ b/Tests/HackleTests/Core/Lifecycle/DefaultAppStateManagerSpecs.swift
@@ -5,7 +5,7 @@ import UIKit
 @testable import Hackle
 
 class DefaultApplicationLifecycleManagerSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
         var queue: DispatchQueue!
         var listener: MockApplicationLifecycleListener!
 

--- a/Tests/HackleTests/Core/Lifecycle/LifecycleManagerSpecs.swift
+++ b/Tests/HackleTests/Core/Lifecycle/LifecycleManagerSpecs.swift
@@ -5,7 +5,7 @@ import UIKit
 @testable import Hackle
 
 class LifecycleManagerSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
 
         var viewManager: MockViewManager!
         var listener: MockLifecycleListener!

--- a/Tests/HackleTests/Core/Metrics/CounterSpecs.swift
+++ b/Tests/HackleTests/Core/Metrics/CounterSpecs.swift
@@ -6,7 +6,7 @@ import MockingKit
 
 
 class CounterSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
         it("CounterBuilder") {
             let counter = CounterBuilder(name: "counter")
                 .tags(["a": "1", "b": "2"])

--- a/Tests/HackleTests/Core/Metrics/Cumulative/CumulativeCounterSpecs.swift
+++ b/Tests/HackleTests/Core/Metrics/Cumulative/CumulativeCounterSpecs.swift
@@ -6,7 +6,7 @@ import MockingKit
 
 
 class CumulativeCounterSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
         it("concurrency") {
             let counter = CumulativeMetricRegistry().counter(name: "counter")
 

--- a/Tests/HackleTests/Core/Metrics/Cumulative/CumulativeMetricRegistrySpecs.swift
+++ b/Tests/HackleTests/Core/Metrics/Cumulative/CumulativeMetricRegistrySpecs.swift
@@ -6,7 +6,7 @@ import MockingKit
 
 
 class CumulativeMetricRegistrySpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
         it("Counter") {
             let counter = CumulativeMetricRegistry().counter(name: "counter")
             expect(counter).to(beAnInstanceOf(CumulativeCounter.self))

--- a/Tests/HackleTests/Core/Metrics/Cumulative/CumulativeTimerSpecs.swift
+++ b/Tests/HackleTests/Core/Metrics/Cumulative/CumulativeTimerSpecs.swift
@@ -6,7 +6,7 @@ import MockingKit
 
 
 class CumulativeTimerSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
 
         it("negative records should ignored") {
             let timer = CumulativeMetricRegistry().timer(name: "timer")

--- a/Tests/HackleTests/Core/Metrics/Delegate/DelegatingCounterSpecs.swift
+++ b/Tests/HackleTests/Core/Metrics/Delegate/DelegatingCounterSpecs.swift
@@ -6,7 +6,7 @@ import MockingKit
 
 
 class DelegatingCounterSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
 
         it("등록된 Counter 가 없으면 0") {
             let counter = DelegatingMetricRegistry().counter(name: "counter")

--- a/Tests/HackleTests/Core/Metrics/Delegate/DelegatingMetricRegistrySpecs.swift
+++ b/Tests/HackleTests/Core/Metrics/Delegate/DelegatingMetricRegistrySpecs.swift
@@ -6,7 +6,7 @@ import MockingKit
 
 
 class DelegatingMetricRegistrySpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
         describe("create") {
             it("DelegationCounter") {
                 let registry = DelegatingMetricRegistry()

--- a/Tests/HackleTests/Core/Metrics/Delegate/DelegatingTimerSpecs.swift
+++ b/Tests/HackleTests/Core/Metrics/Delegate/DelegatingTimerSpecs.swift
@@ -6,7 +6,7 @@ import MockingKit
 
 
 class DelegatingTimerSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
         it("등록된 Timer 가 없으면 0") {
             let timer = DelegatingMetricRegistry().timer(name: "timer")
             timer.record(amount: 42, unit: .milliseconds)

--- a/Tests/HackleTests/Core/Metrics/Flush/FlushCounterSpecs.swift
+++ b/Tests/HackleTests/Core/Metrics/Flush/FlushCounterSpecs.swift
@@ -6,7 +6,7 @@ import MockingKit
 
 
 class FlushCounterSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
 
         it("increment") {
             let counter = FlushCounter(id: MetricId(name: "counter", tags: [:], type: .counter))

--- a/Tests/HackleTests/Core/Metrics/Flush/FlushMetricRegistrySpecs.swift
+++ b/Tests/HackleTests/Core/Metrics/Flush/FlushMetricRegistrySpecs.swift
@@ -6,7 +6,7 @@ import MockingKit
 
 
 class FlushMetricRegistrySpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
 
         it("Counter") {
             let counter = FlushMetricRegistry(scheduler: Schedulers.dispatch(), pushInterval: 60).counter(name: "counter")

--- a/Tests/HackleTests/Core/Metrics/Flush/FlushTimerSpecs.swift
+++ b/Tests/HackleTests/Core/Metrics/Flush/FlushTimerSpecs.swift
@@ -5,7 +5,7 @@ import MockingKit
 @testable import Hackle
 
 class FlushTimerSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
 
         it("record, flush") {
             let flushTimer = FlushTimer(id: MetricId(name: UUID().uuidString, tags: [:], type: .timer))

--- a/Tests/HackleTests/Core/Metrics/MetricFieldSpecs.swift
+++ b/Tests/HackleTests/Core/Metrics/MetricFieldSpecs.swift
@@ -6,7 +6,7 @@ import MockingKit
 
 
 class MetricFieldSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
         it("tagKey") {
             expect(MetricField.count.rawValue) == "count"
             expect(MetricField.total.rawValue) == "total"

--- a/Tests/HackleTests/Core/Metrics/MetricSpecs.swift
+++ b/Tests/HackleTests/Core/Metrics/MetricSpecs.swift
@@ -6,7 +6,7 @@ import MockingKit
 
 
 class MetricSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
 
         it("Equatable") {
             let counter1 = MetricId(name: "counter_1", tags: [:], type: .counter)

--- a/Tests/HackleTests/Core/Metrics/MetricsSpecs.swift
+++ b/Tests/HackleTests/Core/Metrics/MetricsSpecs.swift
@@ -6,7 +6,7 @@ import MockingKit
 
 
 class MetricsSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
 
         beforeEach {
             Metrics.clear()

--- a/Tests/HackleTests/Core/Metrics/Noop/NoopCounterSpecs.swift
+++ b/Tests/HackleTests/Core/Metrics/Noop/NoopCounterSpecs.swift
@@ -6,7 +6,7 @@ import MockingKit
 
 
 class NoopCounterSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
         it("always zero") {
             let counter = NoopCounter(id: MetricId(name: "counter", tags: [:], type: .counter))
             expect(counter.count()) == 0

--- a/Tests/HackleTests/Core/Metrics/Noop/NoopTimerSpecs.swift
+++ b/Tests/HackleTests/Core/Metrics/Noop/NoopTimerSpecs.swift
@@ -6,7 +6,7 @@ import MockingKit
 
 
 class NoopTimerSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
         it("always zero") {
             let timer = NoopTimer(id: MetricId(name: "timer", tags: [:], type: .timer))
             expect(timer.count()) == 0

--- a/Tests/HackleTests/Core/Metrics/Push/PushMetricRegistrySpecs.swift
+++ b/Tests/HackleTests/Core/Metrics/Push/PushMetricRegistrySpecs.swift
@@ -6,7 +6,7 @@ import MockingKit
 
 
 class PushMetricRegistrySpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
 
         class SchedulerStub: Scheduler {
 

--- a/Tests/HackleTests/Core/Metrics/TimerSpecs.swift
+++ b/Tests/HackleTests/Core/Metrics/TimerSpecs.swift
@@ -6,7 +6,7 @@ import MockingKit
 
 
 class TimerSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
 
         it("TimerBuilder") {
             let timer = TimerBuilder(name: "timer")

--- a/Tests/HackleTests/Core/Model/DeviceSpec.swift
+++ b/Tests/HackleTests/Core/Model/DeviceSpec.swift
@@ -30,7 +30,7 @@ class DeviceSpec : QuickSpec {
             let device = DeviceImpl(deviceId: deviceId)
             MainActor.assumeIsolated { device.initialize() }
             expect(device.id) == deviceId
-            self.assertDevicePropertiesStructure(properties: device.properties)
+            assertDevicePropertiesStructure(properties: device.properties)
         }
 
         it("screenWidth and screenHeight should be positive values") {
@@ -87,7 +87,7 @@ class DeviceSpec : QuickSpec {
 
             MainActor.assumeIsolated { device.initialize() }
             expect(device.properties.count) == 13
-            self.assertDevicePropertiesStructure(properties: device.properties)
+            assertDevicePropertiesStructure(properties: device.properties)
         }
 
         it("multiple initialize calls should be safe") {
@@ -96,11 +96,11 @@ class DeviceSpec : QuickSpec {
                 device.initialize()
                 device.initialize()
             }
-            self.assertDevicePropertiesStructure(properties: device.properties)
+            assertDevicePropertiesStructure(properties: device.properties)
         }
     }
 
-    func assertDevicePropertiesStructure(properties: [String: Any]) {
+    static func assertDevicePropertiesStructure(properties: [String: Any]) {
         expect(properties["platform"] as? String) == "iOS"
         expect(properties["osName"]).notTo(beNil())
         expect(properties["osVersion"]).notTo(beNil())

--- a/Tests/HackleTests/Core/Model/DeviceSpec.swift
+++ b/Tests/HackleTests/Core/Model/DeviceSpec.swift
@@ -4,7 +4,7 @@ import Nimble
 @testable import Hackle
 
 class DeviceSpec : QuickSpec {
-    override func spec() {
+    override class func spec() {
         it("create device with required properties") {
             let deviceId = UUID().uuidString
             let device = DeviceImpl(deviceId: deviceId)

--- a/Tests/HackleTests/Core/Model/HackleValueSpecs.swift
+++ b/Tests/HackleTests/Core/Model/HackleValueSpecs.swift
@@ -11,7 +11,7 @@ import Nimble
 @testable import Hackle
 
 class HackleValueSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
 
         it("stringValue") {
             expect(HackleValue.string("42").stringOrNil) == "42"

--- a/Tests/HackleTests/Core/Model/InAppMessageSpec.swift
+++ b/Tests/HackleTests/Core/Model/InAppMessageSpec.swift
@@ -11,7 +11,7 @@ import Nimble
 @testable import Hackle
 
 class InAppMessageSpec: QuickSpec {
-    override func spec() {
+    override class func spec() {
 
         describe("InAppMessage.Period") {
             context("when period is ALWAYS") {

--- a/Tests/HackleTests/Core/Model/ParameterConfigurationEntitySpecs.swift
+++ b/Tests/HackleTests/Core/Model/ParameterConfigurationEntitySpecs.swift
@@ -12,7 +12,7 @@ import Nimble
 
 class ParameterConfigurationEntitySpecs: QuickSpec {
 
-    override func spec() {
+    override class func spec() {
 
         it("ParameterConfiguration") {
 

--- a/Tests/HackleTests/Core/Notification/NotificationEventSpecs.swift
+++ b/Tests/HackleTests/Core/Notification/NotificationEventSpecs.swift
@@ -5,7 +5,7 @@ import MockingKit
 @testable import Hackle
 
 class NotificationEventSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
         it("register push token event") {
             let event = RegisterPushTokenEvent(token: "abcd1234")
                 .toTrackEvent()

--- a/Tests/HackleTests/Core/Notification/NotificationManagerSpecs.swift
+++ b/Tests/HackleTests/Core/Notification/NotificationManagerSpecs.swift
@@ -5,7 +5,7 @@ import MockingKit
 @testable import Hackle
 
 class NotificationManagerSpec: QuickSpec {
-    override func spec() {
+    override class func spec() {
         let dispatchQueue = DispatchQueue(label: "test")
         var core: HackleCoreStub!
         var workspaceFetcher: MockWorkspaceFetcher!

--- a/Tests/HackleTests/Core/OptOut/OptOutListenerSpec.swift
+++ b/Tests/HackleTests/Core/OptOut/OptOutListenerSpec.swift
@@ -4,7 +4,7 @@ import Nimble
 @testable import Hackle
 
 class OptOutListenerSpec: QuickSpec {
-    override func spec() {
+    override class func spec() {
 
         it("setOptOutTracking(true) 시 리스너에 onOptOutChanged(current: true) 호출") {
             let sut = OptOutManager(configOptOutTracking: false)

--- a/Tests/HackleTests/Core/OptOut/OptOutManagerSpec.swift
+++ b/Tests/HackleTests/Core/OptOut/OptOutManagerSpec.swift
@@ -4,7 +4,7 @@ import Nimble
 @testable import Hackle
 
 class OptOutManagerSpec: QuickSpec {
-    override func spec() {
+    override class func spec() {
 
         describe("init") {
             it("configOptOutTracking=false이면 opt-in") {

--- a/Tests/HackleTests/Core/Property/PropertyOperatorSpecs.swift
+++ b/Tests/HackleTests/Core/Property/PropertyOperatorSpecs.swift
@@ -4,7 +4,7 @@ import Nimble
 @testable import Hackle
 
 class PropertyOperatorSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
         it("PropertySetOperator") {
             let sut = PropertySetOperator()
 

--- a/Tests/HackleTests/Core/Push/DefaultPushEventTrackerSpecs.swift
+++ b/Tests/HackleTests/Core/Push/DefaultPushEventTrackerSpecs.swift
@@ -37,9 +37,9 @@ class DefaultPushEventTrackerSpecs: QuickSpec {
 
         context("PushEventKey") {
             it("isPushEvent") {
-                expect(PushEventKey.isPushEvent(event: UserEvents.track("test"))).to(be(false))
-                expect(PushEventKey.isPushEvent(event: UserEvents.track("$push_click"))).to(be(true))
-                expect(PushEventKey.isPushEvent(event: UserEvents.track("$push_token"))).to(be(true))
+                expect(PushEventKey.isPushEvent(event: UserEvents.track("test"))) == false
+                expect(PushEventKey.isPushEvent(event: UserEvents.track("$push_click"))) == true
+                expect(PushEventKey.isPushEvent(event: UserEvents.track("$push_token"))) == true
             }
         }
     }

--- a/Tests/HackleTests/Core/Push/DefaultPushEventTrackerSpecs.swift
+++ b/Tests/HackleTests/Core/Push/DefaultPushEventTrackerSpecs.swift
@@ -4,7 +4,7 @@ import Nimble
 @testable import Hackle
 
 class DefaultPushEventTrackerSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
         var userManager: MockUserManager!
         var core: MockHackleCore!
         var sut: DefaultPushEventTracker!

--- a/Tests/HackleTests/Core/Push/Token/DefaultPushTokenManagerSpecs.swift
+++ b/Tests/HackleTests/Core/Push/Token/DefaultPushTokenManagerSpecs.swift
@@ -6,7 +6,7 @@ import Nimble
 
 class DefaultPushTokenManagerSpecs: QuickSpec {
 
-    override func spec() {
+    override class func spec() {
         var repository: MemoryKeyValueRepository!
         var userManager: MockUserManager!
         var eventTracker: MockPushEventTracker!

--- a/Tests/HackleTests/Core/Push/Token/DefaultPushTokenRegistrySpecs.swift
+++ b/Tests/HackleTests/Core/Push/Token/DefaultPushTokenRegistrySpecs.swift
@@ -5,7 +5,7 @@ import Nimble
 
 
 class DefaultPushTokenRegistrySpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
         it("register") {
             let sut = DefaultPushTokenRegistry()
             let listener = MockPushTokenListener()

--- a/Tests/HackleTests/Core/RemoteConfig/DefaultRemoteConfigSpecs.swift
+++ b/Tests/HackleTests/Core/RemoteConfig/DefaultRemoteConfigSpecs.swift
@@ -10,7 +10,7 @@ import Nimble
 @testable import Hackle
 
 class DefaultRemoteConfigSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
         var user: User?
         var hackleAppCore: MockHackleAppCore!
         var userManager: MockUserManager!

--- a/Tests/HackleTests/Core/Screen/DefaultScreenManagerSpecs.swift
+++ b/Tests/HackleTests/Core/Screen/DefaultScreenManagerSpecs.swift
@@ -5,7 +5,7 @@ import UIKit
 @testable import Hackle
 
 class DefaultScreenManagerSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
         var userManager: MockUserManager!
         var listener: MockScreenListener!
         var sut: DefaultScreenManager!

--- a/Tests/HackleTests/Core/Screen/ScreenEventTrackerSpecs.swift
+++ b/Tests/HackleTests/Core/Screen/ScreenEventTrackerSpecs.swift
@@ -4,7 +4,7 @@ import Nimble
 @testable import Hackle
 
 class ScreenEventTrackerSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
         var userManager: MockUserManager!
         var core: MockHackleCore!
         var sut: ScreenEventTracker!

--- a/Tests/HackleTests/Core/Screen/ScreenSpecs.swift
+++ b/Tests/HackleTests/Core/Screen/ScreenSpecs.swift
@@ -5,7 +5,7 @@ import UIKit
 @testable import Hackle
 
 class ScreenSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
 
         it("create") {
             let vc = TestViewController()

--- a/Tests/HackleTests/Core/Session/DefaultSessionManagerSpecs.swift
+++ b/Tests/HackleTests/Core/Session/DefaultSessionManagerSpecs.swift
@@ -5,7 +5,7 @@ import MockingKit
 @testable import Hackle
 
 class DefaultSessionManagerSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
 
         func manager(
             persistCondition: HackleSessionPersistCondition = .alwaysNewSession,

--- a/Tests/HackleTests/Core/Session/SessionEventTrackerSpecs.swift
+++ b/Tests/HackleTests/Core/Session/SessionEventTrackerSpecs.swift
@@ -5,7 +5,7 @@ import MockingKit
 @testable import Hackle
 
 class SessionEventTrackerSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
 
         var userManager: MockUserManager!
         var core: HackleCoreStub!

--- a/Tests/HackleTests/Core/Session/SessionUserDecoratorSpecs.swift
+++ b/Tests/HackleTests/Core/Session/SessionUserDecoratorSpecs.swift
@@ -11,7 +11,7 @@ import Nimble
 @testable import Hackle
 
 class SessionUserDecoratorSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
         var sessionManager: MockSessionManager!
         var sut: SessionUserDecorator!
 

--- a/Tests/HackleTests/Core/Storage/DefaultFileStorageSpecs.swift
+++ b/Tests/HackleTests/Core/Storage/DefaultFileStorageSpecs.swift
@@ -4,7 +4,7 @@ import Quick
 @testable import Hackle
 
 class DefaultFileStorageSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
         let sdkKey = "abcd1234"
         let libPath = try! FileManager.default
             .url(for: .libraryDirectory, in: .userDomainMask, appropriateFor: nil, create: false)

--- a/Tests/HackleTests/Core/Sync/CompositeSynchronizerSpecs.swift
+++ b/Tests/HackleTests/Core/Sync/CompositeSynchronizerSpecs.swift
@@ -4,7 +4,7 @@ import Quick
 @testable import Hackle
 
 class CompositeSynchronizerSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
 
         var workspaceSynchronizer: MockSynchronizer!
         var cohortSynchronizer: MockSynchronizer!

--- a/Tests/HackleTests/Core/Sync/PollingSynchronizerSpecs.swift
+++ b/Tests/HackleTests/Core/Sync/PollingSynchronizerSpecs.swift
@@ -4,7 +4,7 @@ import Quick
 @testable import Hackle
 
 class PollingSynchronizerSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
 
         describe("sync") {
             it("delegate") {

--- a/Tests/HackleTests/Core/Sync/SynchronizerSpecs.swift
+++ b/Tests/HackleTests/Core/Sync/SynchronizerSpecs.swift
@@ -4,7 +4,7 @@ import Quick
 @testable import Hackle
 
 class SynchronizerSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
         describe("SynchronizerExtensions") {
             describe("Synchronizer.sync(() -> ())") {
                 it("success") {

--- a/Tests/HackleTests/Core/User/DefaultUserCohortFetcherSpecs.swift
+++ b/Tests/HackleTests/Core/User/DefaultUserCohortFetcherSpecs.swift
@@ -5,7 +5,7 @@ import Quick
 
 
 class DefaultUserCohortFetcherSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
         var httpClient: MockHttpClient!
         var sut: DefaultUserCohortFetcher!
 

--- a/Tests/HackleTests/Core/User/DefaultUserDtoSpecs.swift
+++ b/Tests/HackleTests/Core/User/DefaultUserDtoSpecs.swift
@@ -11,7 +11,7 @@ import Quick
 @testable import Hackle
 
 class DefaultUserDtoSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
         var decoder: JSONDecoder!
 
         beforeEach {

--- a/Tests/HackleTests/Core/User/DefaultUserManagerSpecs.swift
+++ b/Tests/HackleTests/Core/User/DefaultUserManagerSpecs.swift
@@ -5,7 +5,7 @@ import Nimble
 
 
 class DefaultUserManagerSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
         var repository: KeyValueRepository!
         var cohortFetcher: MockUserCohortFetcher!
         var targetFetcher: MockUserTargetFetcher!

--- a/Tests/HackleTests/Core/User/DefaultUserTargetFetcherSpecs.swift
+++ b/Tests/HackleTests/Core/User/DefaultUserTargetFetcherSpecs.swift
@@ -11,7 +11,7 @@ import Quick
 import Foundation
 
 class DefaultUserTargetFetcherSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
         var httpClient: MockHttpClient!
         var sut: DefaultUserTargetEventsFetcher!
 

--- a/Tests/HackleTests/Core/User/HackleUserSpecs.swift
+++ b/Tests/HackleTests/Core/User/HackleUserSpecs.swift
@@ -5,7 +5,7 @@ import Quick
 
 
 class HackleUserSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
 
         it("HackleUser") {
             let user = HackleUser.builder()

--- a/Tests/HackleTests/Core/User/IdentifierSpecs.swift
+++ b/Tests/HackleTests/Core/User/IdentifierSpecs.swift
@@ -4,7 +4,7 @@ import Nimble
 @testable import Hackle
 
 class IdentifierSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
         it("contains") {
             expect(["a": "b"].contains(type: "a", value: "b")) == true
             expect(["a": "b"].contains(type: "a", value: "a")) == false

--- a/Tests/HackleTests/Core/User/UserCohortSpecs.swift
+++ b/Tests/HackleTests/Core/User/UserCohortSpecs.swift
@@ -24,7 +24,7 @@ class UserCohortSpecs: QuickSpec {
                 .build()
 
             // rawCohorts
-            expect(userCohorts.rawCohorts.count) === 3
+            expect(userCohorts.rawCohorts.count) == 3
 
             // get
             expect(userCohorts[Identifier(type: "$id", value: "id")]) == UserCohort(identifier: Identifier(type: "$id", value: "id"), cohorts: [Cohort(id: 1), Cohort(id: 2)])

--- a/Tests/HackleTests/Core/User/UserCohortSpecs.swift
+++ b/Tests/HackleTests/Core/User/UserCohortSpecs.swift
@@ -5,7 +5,7 @@ import Quick
 
 
 class UserCohortSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
         it("UserCohorts") {
             expect(UserCohorts.empty().rawCohorts.count) == 0
 

--- a/Tests/HackleTests/Core/User/UserTargetEventsSpecs.swift
+++ b/Tests/HackleTests/Core/User/UserTargetEventsSpecs.swift
@@ -11,7 +11,7 @@ import Quick
 @testable import Hackle
 
 class UserTargetEventsSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
         var decoder: JSONDecoder!
 
         beforeEach {

--- a/Tests/HackleTests/Core/User/UserTargetEventsSpecs.swift
+++ b/Tests/HackleTests/Core/User/UserTargetEventsSpecs.swift
@@ -54,7 +54,7 @@ class UserTargetEventsSpecs: QuickSpec {
                 .build()
 
             // raw
-            expect(userTargetEvents.count) === 2
+            expect(userTargetEvents.count) == 2
 
 
             // toBuilder

--- a/Tests/HackleTests/Core/Utilities/Concurrency/ConcurrentArraySpecs.swift
+++ b/Tests/HackleTests/Core/Utilities/Concurrency/ConcurrentArraySpecs.swift
@@ -10,7 +10,7 @@ import Nimble
 @testable import Hackle
 
 class ConcurrentArraySpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
         var array: ConcurrentArray<Int>!
 
         beforeEach {

--- a/Tests/HackleTests/Core/Utilities/Concurrency/DefaultThrottlerSpecs.swift
+++ b/Tests/HackleTests/Core/Utilities/Concurrency/DefaultThrottlerSpecs.swift
@@ -5,7 +5,7 @@ import Nimble
 
 class DefaultThrottlerSpecs: QuickSpec {
 
-    override func spec() {
+    override class func spec() {
         it("when cannot acquire then execute reject") {
             // given
             let limiter = ThrottleLimiterStub(acquired: false)

--- a/Tests/HackleTests/Core/Utilities/Concurrency/MimeTypeSpecs.swift
+++ b/Tests/HackleTests/Core/Utilities/Concurrency/MimeTypeSpecs.swift
@@ -10,7 +10,7 @@ import Nimble
 @testable import Hackle
 
 class MimeTypeResolverSpec: QuickSpec {
-    override func spec() {
+    override class func spec() {
         describe("MimeType") {
             describe("preferredFileExtension(mimeType:)") {
                 context("when given a valid MIME type") {

--- a/Tests/HackleTests/Core/Utilities/Concurrency/ScopingThrottleLimiterSpecs.swift
+++ b/Tests/HackleTests/Core/Utilities/Concurrency/ScopingThrottleLimiterSpecs.swift
@@ -5,7 +5,7 @@ import Nimble
 
 
 class ScopingThrottleLimiterSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
         it("throttle 1") {
             let sut = ScopingThrottleLimiter(interval: 1, limit: 1, clock: SystemClock.shared)
             expect(sut.tryAcquire()).to(equal(true))

--- a/Tests/HackleTests/Core/Utilities/ObjectsSpec.swift
+++ b/Tests/HackleTests/Core/Utilities/ObjectsSpec.swift
@@ -5,7 +5,7 @@ import MockingKit
 @testable import Hackle
 
 class ObjectsSpec: QuickSpec {
-    override func spec() {
+    override class func spec() {
         it("to hex string") {
             let data = Data([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
             expect(data.hexString()) == "000102030405060708090a0b0c0d0e0f"

--- a/Tests/HackleTests/Core/Utilities/Time/ClockSpecs.swift
+++ b/Tests/HackleTests/Core/Utilities/Time/ClockSpecs.swift
@@ -6,7 +6,7 @@ import MockingKit
 
 
 class ClockSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
         it("SystemClock") {
             expect(SystemClock.shared.currentMillis()) > 0
             expect(SystemClock.shared.tick()) > 0

--- a/Tests/HackleTests/Core/Utilities/Time/TimeUnitSpecs.swift
+++ b/Tests/HackleTests/Core/Utilities/Time/TimeUnitSpecs.swift
@@ -6,7 +6,7 @@ import MockingKit
 
 
 class TimeUnitSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
 
         func expectEquals<T: Equatable>(_ expected: T, _ actual: T) {
             expect(actual).to(equal(expected))

--- a/Tests/HackleTests/Core/Utilities/Time/TimeUtilSpec.swift
+++ b/Tests/HackleTests/Core/Utilities/Time/TimeUtilSpec.swift
@@ -11,7 +11,7 @@ import Nimble
 @testable import Hackle
 
 class TimeUtilSpec: QuickSpec {
-    override func spec() {
+    override class func spec() {
 
         describe("TimeUtil") {
             describe("dayOfWeek") {

--- a/Tests/HackleTests/Core/WebView/WebViewUserEventDecoratorSpecs.swift
+++ b/Tests/HackleTests/Core/WebView/WebViewUserEventDecoratorSpecs.swift
@@ -11,7 +11,7 @@ import Nimble
 @testable import Hackle
 
 class WebViewUserEventDecoratorSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
         describe("WebViewWrapperUserEventDecorator") {
             var sut: WebViewWrapperUserEventDecorator!
             var originalUser: HackleUser!

--- a/Tests/HackleTests/Core/WebView/WebViewWrapperUserEventFilterSpecs.swift
+++ b/Tests/HackleTests/Core/WebView/WebViewWrapperUserEventFilterSpecs.swift
@@ -4,7 +4,7 @@ import Nimble
 @testable import Hackle
 
 class WebViewWrapperUserEventFilterSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
         it("when not push event then block") {
             let sut = WebViewWrapperUserEventFilter()
             let actual = sut.check(event: UserEvents.track("test"))

--- a/Tests/HackleTests/Core/Workspace/DefaultHttpWorkspaceFetcherSpecs.swift
+++ b/Tests/HackleTests/Core/Workspace/DefaultHttpWorkspaceFetcherSpecs.swift
@@ -12,7 +12,7 @@ import Nimble
 
 class DefaultHttpWorkspaceFetcherSpecs: QuickSpec {
 
-    override func spec() {
+    override class func spec() {
 
         var httpClient: MockHttpClient!
 

--- a/Tests/HackleTests/Core/Workspace/DefaultWorkspaceConfigRepositorySpecs.swift
+++ b/Tests/HackleTests/Core/Workspace/DefaultWorkspaceConfigRepositorySpecs.swift
@@ -4,13 +4,13 @@ import Nimble
 @testable import Hackle
 
 class DefaultWorkspaceConfigRepositorySpecs: QuickSpec {
-    func readTextFromRes(filename: String) -> String {
+    static func readTextFromRes(filename: String) -> String {
         return try! String(contentsOfFile: Bundle(for: DefaultWorkspaceConfigRepositorySpecs.self).path(forResource: filename, ofType: "json")!)
     }
     
     override class func spec() {
         it("get") {
-            let initialData = self.readTextFromRes(filename: "workspace_config")
+            let initialData = readTextFromRes(filename: "workspace_config")
             let mockFileStorage = MockFileStorage(
                 initialData: ["workspace.json": initialData.data(using: .utf8)!]
             )
@@ -34,7 +34,7 @@ class DefaultWorkspaceConfigRepositorySpecs: QuickSpec {
             
             expect(repository.get()).to(beNil())
             
-            let json = self.readTextFromRes(filename: "workspace_config")
+            let json = readTextFromRes(filename: "workspace_config")
             let data = try! JSONDecoder().decode(WorkspaceConfig.self, from: json.data(using: .utf8)!)
             repository.set(value: data)
             
@@ -42,7 +42,7 @@ class DefaultWorkspaceConfigRepositorySpecs: QuickSpec {
         }
         
         it("overwrite") {
-            let initialData = self.readTextFromRes(filename: "workspace_config")
+            let initialData = readTextFromRes(filename: "workspace_config")
             let mockFileStorage = MockFileStorage(
                 initialData: ["workspace.json": initialData.data(using: .utf8)!]
             )
@@ -50,7 +50,7 @@ class DefaultWorkspaceConfigRepositorySpecs: QuickSpec {
             
             expect(repository.get()?.lastModified) == "Tue, 16 Jan 2024 07:39:44 GMT"
             
-            let modifiedData = self.readTextFromRes(filename: "workspace_config_modified")
+            let modifiedData = readTextFromRes(filename: "workspace_config_modified")
             let data = try! JSONDecoder().decode(WorkspaceConfig.self, from: modifiedData.data(using: .utf8)!)
             repository.set(value: data)
             

--- a/Tests/HackleTests/Core/Workspace/DefaultWorkspaceConfigRepositorySpecs.swift
+++ b/Tests/HackleTests/Core/Workspace/DefaultWorkspaceConfigRepositorySpecs.swift
@@ -8,7 +8,7 @@ class DefaultWorkspaceConfigRepositorySpecs: QuickSpec {
         return try! String(contentsOfFile: Bundle(for: DefaultWorkspaceConfigRepositorySpecs.self).path(forResource: filename, ofType: "json")!)
     }
     
-    override func spec() {
+    override class func spec() {
         it("get") {
             let initialData = self.readTextFromRes(filename: "workspace_config")
             let mockFileStorage = MockFileStorage(

--- a/Tests/HackleTests/Core/Workspace/PollingWorkspaceFetcherSpecs.swift
+++ b/Tests/HackleTests/Core/Workspace/PollingWorkspaceFetcherSpecs.swift
@@ -12,7 +12,7 @@
 //
 //
 //class PollingWorkspaceFetcherSpecs: QuickSpec {
-//    override func spec() {
+//    override class func spec() {
 //
 //        var httpWorkspaceFetcher: HttpWorkspaceFetcherStub!
 //        var pollingScheduler: MockScheduler!

--- a/Tests/HackleTests/Core/Workspace/WorkspaceInAppMessageSpecs.swift
+++ b/Tests/HackleTests/Core/Workspace/WorkspaceInAppMessageSpecs.swift
@@ -12,7 +12,7 @@ import Nimble
 
 
 class WorkspaceInAppMessageSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
         it("valid") {
             let workspace = ResourcesWorkspaceFetcher(fileName: "iam").fetch()!
 

--- a/Tests/HackleTests/Core/Workspace/WorkspaceManagerSpecs.swift
+++ b/Tests/HackleTests/Core/Workspace/WorkspaceManagerSpecs.swift
@@ -10,7 +10,7 @@ class WorkspaceManagerSpecs: QuickSpec {
         return try! JSONDecoder().decode(WorkspaceConfig.self, from: json.data(using: .utf8)!)
     }
     
-    override func spec() {
+    override class func spec() {
         it("nil workspace data returns if not sync called and no saved data") {
             let httpWorkspaceFetcher = MockHttpWorkspaceFetcher(returns: [])
             let repository = MockWorkspaceConfigRepository()

--- a/Tests/HackleTests/Core/Workspace/WorkspaceManagerSpecs.swift
+++ b/Tests/HackleTests/Core/Workspace/WorkspaceManagerSpecs.swift
@@ -5,7 +5,7 @@ import MockingKit
 @testable import Hackle
 
 class WorkspaceManagerSpecs: QuickSpec {
-    func loadWorkspaceConfigFromRes(filename: String = "workspace_config") -> WorkspaceConfig {
+    static func loadWorkspaceConfigFromRes(filename: String = "workspace_config") -> WorkspaceConfig {
         let json = try! String(contentsOfFile: Bundle(for: WorkspaceManagerSpecs.self).path(forResource: filename, ofType: "json")!)
         return try! JSONDecoder().decode(WorkspaceConfig.self, from: json.data(using: .utf8)!)
     }
@@ -22,7 +22,7 @@ class WorkspaceManagerSpecs: QuickSpec {
         }
         
         it("workspace data returns and write to repository") {
-            let data = self.loadWorkspaceConfigFromRes()
+            let data = loadWorkspaceConfigFromRes()
             let httpWorkspaceFetcher = MockHttpWorkspaceFetcher(returns: [data])
             let repository = MockWorkspaceConfigRepository()
             let sut = WorkspaceManager(httpWorkspaceFetcher: httpWorkspaceFetcher, repository: repository)
@@ -39,7 +39,7 @@ class WorkspaceManagerSpecs: QuickSpec {
         }
         
         it("workspace data returns from repository") {
-            let data = self.loadWorkspaceConfigFromRes()
+            let data = loadWorkspaceConfigFromRes()
             let httpWorkspaceFetcher = MockHttpWorkspaceFetcher(returns: [])
             let repository = MockWorkspaceConfigRepository(value: data)
             let sut = WorkspaceManager(httpWorkspaceFetcher: httpWorkspaceFetcher, repository: repository)
@@ -51,7 +51,7 @@ class WorkspaceManagerSpecs: QuickSpec {
         }
         
         it("workspace data returns from repository after initialize") {
-            let data = self.loadWorkspaceConfigFromRes()
+            let data = loadWorkspaceConfigFromRes()
             let httpWorkspaceFetcher = MockHttpWorkspaceFetcher(returns: [])
             let repository = MockWorkspaceConfigRepository(value: data)
             let sut = WorkspaceManager(httpWorkspaceFetcher: httpWorkspaceFetcher, repository: repository)
@@ -66,7 +66,7 @@ class WorkspaceManagerSpecs: QuickSpec {
         }
         
         it("write repository workspace value") {
-            let data = self.loadWorkspaceConfigFromRes()
+            let data = loadWorkspaceConfigFromRes()
             let httpWorkspaceFetcher = MockHttpWorkspaceFetcher(returns: [data])
             let repository = MockWorkspaceConfigRepository()
             let sut = WorkspaceManager(httpWorkspaceFetcher: httpWorkspaceFetcher, repository: repository)
@@ -83,8 +83,8 @@ class WorkspaceManagerSpecs: QuickSpec {
         }
         
         it("change last modified value after sync call") {
-            let first = self.loadWorkspaceConfigFromRes()
-            let second = self.loadWorkspaceConfigFromRes(filename: "workspace_config_modified")
+            let first = loadWorkspaceConfigFromRes()
+            let second = loadWorkspaceConfigFromRes(filename: "workspace_config_modified")
             let httpWorkspaceFetcher = MockHttpWorkspaceFetcher(returns: [first, second])
             let repository = MockWorkspaceConfigRepository()
             let sut = WorkspaceManager(httpWorkspaceFetcher: httpWorkspaceFetcher, repository: repository)
@@ -102,7 +102,7 @@ class WorkspaceManagerSpecs: QuickSpec {
         }
         
         it("do nothing if http request returns nil") {
-            let data = self.loadWorkspaceConfigFromRes()
+            let data = loadWorkspaceConfigFromRes()
             let httpWorkspaceFetcher = MockHttpWorkspaceFetcher(returns: [nil])
             let repository = MockWorkspaceConfigRepository(value: data)
             let sut = WorkspaceManager(httpWorkspaceFetcher: httpWorkspaceFetcher, repository: repository)
@@ -129,7 +129,7 @@ class WorkspaceManagerSpecs: QuickSpec {
         }
         
         it("do not overwrite workspace value even http request occours error") {
-            let data = self.loadWorkspaceConfigFromRes()
+            let data = loadWorkspaceConfigFromRes()
             let httpWorkspaceFetcher = MockHttpWorkspaceFetcher(returns: [HackleError.error("fail")])
             let repository = MockWorkspaceConfigRepository(value: data)
             let sut = WorkspaceManager(httpWorkspaceFetcher: httpWorkspaceFetcher, repository: repository)

--- a/Tests/HackleTests/Core/Workspace/WorkspaceSpecs.swift
+++ b/Tests/HackleTests/Core/Workspace/WorkspaceSpecs.swift
@@ -4,7 +4,7 @@ import Quick
 @testable import Hackle
 
 class WorkspaceSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
 
         it("parse") {
             let file = Bundle(for: WorkspaceSpecs.self).path(forResource: "workspace_response", ofType: "json")!

--- a/Tests/HackleTests/HackleAppSpec.swift
+++ b/Tests/HackleTests/HackleAppSpec.swift
@@ -4,7 +4,7 @@ import Nimble
 import Quick
 
 class HackleAppSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
         var core: MockHackleCore!
         var eventQueue: DispatchQueue!
         var synchronizer: MockSynchronizer!

--- a/Tests/HackleTests/HackleConfigSpec.swift
+++ b/Tests/HackleTests/HackleConfigSpec.swift
@@ -65,8 +65,8 @@ class HackleConfigSpec: QuickSpec {
         }
 
         it("mode") {
-            expect(HackleConfig.builder().mode(.native).build().sessionTracking).to(be(true))
-            expect(HackleConfig.builder().mode(.web_view_wrapper).build().sessionTracking).to(be(false))
+            expect(HackleConfig.builder().mode(.native).build().sessionTracking) == true
+            expect(HackleConfig.builder().mode(.web_view_wrapper).build().sessionTracking) == false
         }
 
         context("HackleAppMode") {

--- a/Tests/HackleTests/HackleConfigSpec.swift
+++ b/Tests/HackleTests/HackleConfigSpec.swift
@@ -12,7 +12,7 @@ import Nimble
 
 
 class HackleConfigSpec: QuickSpec {
-    override func spec() {
+    override class func spec() {
 
         it("exposureEventDedupInterval") {
             expect(HackleConfigBuilder().build().exposureEventDedupInterval) == 60

--- a/Tests/HackleTests/Invocator/HackleInvocationSpec.swift
+++ b/Tests/HackleTests/Invocator/HackleInvocationSpec.swift
@@ -17,7 +17,7 @@ class HackleInvocationSpec: QuickSpec {
         ].toJson() ?? ""
     }
     
-    override func spec() {
+    override class func spec() {
         var core: MockHackleAppCore!
         var processor: InvocationProcessor!
         var sut: DefaultHackleInvocator!

--- a/Tests/HackleTests/Invocator/HackleInvocationSpec.swift
+++ b/Tests/HackleTests/Invocator/HackleInvocationSpec.swift
@@ -5,7 +5,7 @@ import Nimble
 import Quick
 
 class HackleInvocationSpec: QuickSpec {
-    func createJsonString(command: String, parameters: [String: Any?]? = nil) -> String {
+    static func createJsonString(command: String, parameters: [String: Any?]? = nil) -> String {
         return [
             "_hackle": [
                 "command": command,
@@ -42,7 +42,7 @@ class HackleInvocationSpec: QuickSpec {
                 let sessionId = "1234567890.abcdefgh"
                 core.sessionId = sessionId
                 
-                let jsonString = self.createJsonString(command: "getSessionId")
+                let jsonString = createJsonString(command: "getSessionId")
                 let result = sut.invoke(string: jsonString)
                 let dict = result.jsonObject()!
                 expect(dict["success"] as? Bool) == true
@@ -59,7 +59,7 @@ class HackleInvocationSpec: QuickSpec {
                     .build()
                 core.user = user
                 
-                let jsonString = self.createJsonString(command: "getUser")
+                let jsonString = createJsonString(command: "getUser")
                 let result = sut.invoke(string: jsonString)
                 
                 let dict = result.jsonObject()!
@@ -99,7 +99,7 @@ class HackleInvocationSpec: QuickSpec {
                         ] as [String: Any]
                     ]
 
-                    let jsonString = self.createJsonString(command: "setUser", parameters: parameters)
+                    let jsonString = createJsonString(command: "setUser", parameters: parameters)
                     let result = sut.invoke(string: jsonString)
                     
                     expect(core.setUserRef.invokations().count) == 1
@@ -123,7 +123,7 @@ class HackleInvocationSpec: QuickSpec {
                     expect(dict["data"]).to(beNil())
                 }
                 it("invalid parameters case") {
-                    let jsonString = self.createJsonString(command: "setUser", parameters: [:])
+                    let jsonString = createJsonString(command: "setUser", parameters: [:])
                     let result = sut.invoke(string: jsonString)
                     
                     expect(core.setUserRef.invokations().count) == 0
@@ -137,7 +137,7 @@ class HackleInvocationSpec: QuickSpec {
             context("set user id") {
                 it("happy case") {
                     let parameters = ["userId": "abcd1234"]
-                    let jsonString = self.createJsonString(command: "setUserId", parameters: parameters)
+                    let jsonString = createJsonString(command: "setUserId", parameters: parameters)
                     let result = sut.invoke(string: jsonString)
                     
                     expect(core.setUserIdRef.invokations().count) == 1
@@ -150,7 +150,7 @@ class HackleInvocationSpec: QuickSpec {
                     expect(dict["data"]).to(beNil())
                 }
                 it("invalid parameters case") {
-                    let jsonString = self.createJsonString(command: "setUserId", parameters: [:])
+                    let jsonString = createJsonString(command: "setUserId", parameters: [:])
                     let result = sut.invoke(string: jsonString)
                     
                     expect(core.setUserIdRef.invokations().count) == 0
@@ -161,7 +161,7 @@ class HackleInvocationSpec: QuickSpec {
                     expect(dict["data"]).to(beNil())
                 }
                 it("nil case") {
-                    let jsonString = self.createJsonString(command: "setUserId", parameters: ["userId": nil])
+                    let jsonString = createJsonString(command: "setUserId", parameters: ["userId": nil])
                     let result = sut.invoke(string: jsonString)
                     
                     expect(core.setUserIdRef.invokations().count) == 1
@@ -175,7 +175,7 @@ class HackleInvocationSpec: QuickSpec {
             context("set device id") {
                 it("happy case") {
                     let parameters = ["deviceId": "abcd1234"]
-                    let jsonString = self.createJsonString(command: "setDeviceId", parameters: parameters)
+                    let jsonString = createJsonString(command: "setDeviceId", parameters: parameters)
                     let result = sut.invoke(string: jsonString)
                     
                     expect(core.setDeviceIdRef.invokations().count) == 1
@@ -188,7 +188,7 @@ class HackleInvocationSpec: QuickSpec {
                     expect(dict["data"]).to(beNil())
                 }
                 it("invalid parameters case") {
-                    let jsonString = self.createJsonString(command: "setDeviceId", parameters: [:])
+                    let jsonString = createJsonString(command: "setDeviceId", parameters: [:])
                     let result = sut.invoke(string: jsonString)
                     
                     expect(core.setDeviceIdRef.invokations().count) == 0
@@ -205,7 +205,7 @@ class HackleInvocationSpec: QuickSpec {
                         "key": "foo",
                         "value": "bar"
                     ]
-                    let jsonString = self.createJsonString(command: "setUserProperty", parameters: parameters)
+                    let jsonString = createJsonString(command: "setUserProperty", parameters: parameters)
                     let result = sut.invoke(string: jsonString)
                     
                     expect(core.updateUserPropertiesRef.invokations().count) == 1
@@ -222,7 +222,7 @@ class HackleInvocationSpec: QuickSpec {
                     expect(core.hackleAppContext?.browserProperties["mock"] as? String) == "mocks"
                 }
                 it("invalid parameters case") {
-                    let jsonString = self.createJsonString(command: "setUserProperty", parameters: [:])
+                    let jsonString = createJsonString(command: "setUserProperty", parameters: [:])
                     let result = sut.invoke(string: jsonString)
 
                     expect(core.updateUserPropertiesRef.invokations().count) == 0
@@ -249,7 +249,7 @@ class HackleInvocationSpec: QuickSpec {
                             ]
                         ]
                     ]
-                    let jsonString = self.createJsonString(command: "updateUserProperties", parameters: parameters)
+                    let jsonString = createJsonString(command: "updateUserProperties", parameters: parameters)
                     let result = sut.invoke(string: jsonString)
                     
                     expect(core.updateUserPropertiesRef.invokations().count) == 1
@@ -276,7 +276,7 @@ class HackleInvocationSpec: QuickSpec {
                     expect(core.hackleAppContext?.browserProperties["mock"] as? String) == "mocks"
                 }
                 it("invalid parameters case") {
-                    let jsonString = self.createJsonString(command: "updateUserProperties", parameters: [:])
+                    let jsonString = createJsonString(command: "updateUserProperties", parameters: [:])
                     let result = sut.invoke(string: jsonString)
 
                     expect(core.updateUserPropertiesRef.invokations().count) == 0
@@ -298,7 +298,7 @@ class HackleInvocationSpec: QuickSpec {
                 ]
                 
                 it("push") {
-                    let jsonString = self.createJsonString(command: "updatePushSubscriptions", parameters: parameters)
+                    let jsonString = createJsonString(command: "updatePushSubscriptions", parameters: parameters)
                     let result = sut.invoke(string: jsonString)
                     
                     expect(core.updatePushSubscriptionsRef.invokations().count) == 1
@@ -322,7 +322,7 @@ class HackleInvocationSpec: QuickSpec {
                 }
                 
                 it("sms") {
-                    let jsonString = self.createJsonString(command: "updateSmsSubscriptions", parameters: parameters)
+                    let jsonString = createJsonString(command: "updateSmsSubscriptions", parameters: parameters)
                     let result = sut.invoke(string: jsonString)
                     
                     expect(core.updateSmsSubscriptionsRef.invokations().count) == 1
@@ -346,7 +346,7 @@ class HackleInvocationSpec: QuickSpec {
                 }
                 
                 it("kakao") {
-                    let jsonString = self.createJsonString(command: "updateKakaoSubscriptions", parameters: parameters)
+                    let jsonString = createJsonString(command: "updateKakaoSubscriptions", parameters: parameters)
                     let result = sut.invoke(string: jsonString)
                     
                     expect(core.updateKakaoSubscriptionsRef.invokations().count) == 1
@@ -370,7 +370,7 @@ class HackleInvocationSpec: QuickSpec {
                 }
             }
             it("reset user") {
-                let jsonString = self.createJsonString(command: "resetUser", parameters: [:])
+                let jsonString = createJsonString(command: "resetUser", parameters: [:])
                 let result = sut.invoke(string: jsonString)
                 
                 expect(core.resetUserRef.invokations().count) == 1
@@ -382,7 +382,7 @@ class HackleInvocationSpec: QuickSpec {
                 expect(core.hackleAppContext?.browserProperties["mock"] as? String) == "mocks"
             }
             it("setPhoneNumber") {
-                let jsonString = self.createJsonString(command: "setPhoneNumber", parameters: ["phoneNumber": "+821012345678"])
+                let jsonString = createJsonString(command: "setPhoneNumber", parameters: ["phoneNumber": "+821012345678"])
                 let result = sut.invoke(string: jsonString)
                 
                 expect(core.setPhoneNumberRef.invokations().count) == 1
@@ -394,7 +394,7 @@ class HackleInvocationSpec: QuickSpec {
                 expect(core.hackleAppContext?.browserProperties["mock"] as? String) == "mocks"
             }
             it("unsetPhoneNumber") {
-                let jsonString = self.createJsonString(command: "unsetPhoneNumber")
+                let jsonString = createJsonString(command: "unsetPhoneNumber")
                 let result = sut.invoke(string: jsonString)
                 
                 expect(core.unsetPhoneNumberRef.invokations().count) == 1
@@ -412,7 +412,7 @@ class HackleInvocationSpec: QuickSpec {
                             "experimentKey": 123,
                             "defaultVariation": "D"
                         ] as [String: Any]
-                        let jsonString = self.createJsonString(command: "variation", parameters: parameters)
+                        let jsonString = createJsonString(command: "variation", parameters: parameters)
                         every(core.variationDetailRef)
                             .returns(Decision.of(experiment: nil, variation: "C", reason: "DEFAULT_RULE"))
                         
@@ -433,7 +433,7 @@ class HackleInvocationSpec: QuickSpec {
                     }
                     it("expect 'A' default variation parameter") {
                         let parameters = ["experimentKey": 123] as [String: Any]
-                        let jsonString = self.createJsonString(command: "variation", parameters: parameters)
+                        let jsonString = createJsonString(command: "variation", parameters: parameters)
                         every(core.variationDetailRef)
                             .returns(Decision.of(experiment: nil, variation: "A", reason: "DEFAULT_RULE"))
                         
@@ -459,7 +459,7 @@ class HackleInvocationSpec: QuickSpec {
                             "defaultVariation": "D",
                             "user": "abcd1234"
                         ] as [String: Any]
-                        let jsonString = self.createJsonString(command: "variation", parameters: parameters)
+                        let jsonString = createJsonString(command: "variation", parameters: parameters)
                         every(core.variationDetailRef)
                             .returns(Decision.of(experiment: nil, variation: "C", reason: "DEFAULT_RULE"))
                         
@@ -483,7 +483,7 @@ class HackleInvocationSpec: QuickSpec {
                             "experimentKey": 123,
                             "user": "abcd1234"
                         ] as [String: Any]
-                        let jsonString = self.createJsonString(command: "variation", parameters: parameters)
+                        let jsonString = createJsonString(command: "variation", parameters: parameters)
                         every(core.variationDetailRef)
                             .returns(Decision.of(experiment: nil, variation: "A", reason: "DEFAULT_RULE"))
                         
@@ -509,7 +509,7 @@ class HackleInvocationSpec: QuickSpec {
                             "defaultVariation": "D",
                             "user": ["id": "foo"]
                         ] as [String: Any]
-                        let jsonString = self.createJsonString(command: "variation", parameters: parameters)
+                        let jsonString = createJsonString(command: "variation", parameters: parameters)
                         every(core.variationDetailRef)
                             .returns(Decision.of(experiment: nil, variation: "C", reason: "DEFAULT_RULE"))
                         
@@ -533,7 +533,7 @@ class HackleInvocationSpec: QuickSpec {
                             "experimentKey": 123,
                             "user": ["id": "foo"]
                         ] as [String: Any]
-                        let jsonString = self.createJsonString(command: "variation", parameters: parameters)
+                        let jsonString = createJsonString(command: "variation", parameters: parameters)
                         every(core.variationDetailRef)
                             .returns(Decision.of(experiment: nil, variation: "A", reason: "DEFAULT_RULE"))
                         
@@ -553,7 +553,7 @@ class HackleInvocationSpec: QuickSpec {
                     }
                 }
                 it("invalid parameters case") {
-                    let jsonString = self.createJsonString(command: "variation", parameters: [:])
+                    let jsonString = createJsonString(command: "variation", parameters: [:])
                     let result = sut.invoke(string: jsonString)
 
                     expect(core.variationDetailRef.invokations().count) == 0
@@ -571,7 +571,7 @@ class HackleInvocationSpec: QuickSpec {
                             "experimentKey": 123,
                             "defaultVariation": "D"
                         ] as [String: Any]
-                        let jsonString = self.createJsonString(command: "variationDetail", parameters: parameters)
+                        let jsonString = createJsonString(command: "variationDetail", parameters: parameters)
                         every(core.variationDetailRef)
                             .returns(Decision.of(experiment: nil, variation: "C", reason: "DEFAULT_RULE"))
                         
@@ -600,7 +600,7 @@ class HackleInvocationSpec: QuickSpec {
                         let parameters = [
                             "experimentKey": 123
                         ] as [String: Any]
-                        let jsonString = self.createJsonString(command: "variationDetail", parameters: parameters)
+                        let jsonString = createJsonString(command: "variationDetail", parameters: parameters)
                         every(core.variationDetailRef)
                             .returns(Decision.of(experiment: nil, variation: "A", reason: "DEFAULT_RULE"))
                         
@@ -633,7 +633,7 @@ class HackleInvocationSpec: QuickSpec {
                             "defaultVariation": "D",
                             "user": "abcd1234"
                         ] as [String: Any]
-                        let jsonString = self.createJsonString(command: "variationDetail", parameters: parameters)
+                        let jsonString = createJsonString(command: "variationDetail", parameters: parameters)
                         every(core.variationDetailRef)
                             .returns(Decision.of(experiment: nil, variation: "C", reason: "DEFAULT_RULE"))
                         
@@ -664,7 +664,7 @@ class HackleInvocationSpec: QuickSpec {
                             "experimentKey": 123,
                             "user": "abcd1234"
                         ] as [String: Any]
-                        let jsonString = self.createJsonString(command: "variationDetail", parameters: parameters)
+                        let jsonString = createJsonString(command: "variationDetail", parameters: parameters)
                         every(core.variationDetailRef)
                             .returns(Decision.of(experiment: nil, variation: "A", reason: "DEFAULT_RULE"))
                         
@@ -697,7 +697,7 @@ class HackleInvocationSpec: QuickSpec {
                             "defaultVariation": "D",
                             "user": ["id": "foo"]
                         ] as [String: Any]
-                        let jsonString = self.createJsonString(command: "variationDetail", parameters: parameters)
+                        let jsonString = createJsonString(command: "variationDetail", parameters: parameters)
                         every(core.variationDetailRef)
                             .returns(Decision.of(experiment: nil, variation: "C", reason: "DEFAULT_RULE"))
                         
@@ -728,7 +728,7 @@ class HackleInvocationSpec: QuickSpec {
                             "experimentKey": 123,
                             "user": ["id": "foo"]
                         ] as [String: Any]
-                        let jsonString = self.createJsonString(command: "variationDetail", parameters: parameters)
+                        let jsonString = createJsonString(command: "variationDetail", parameters: parameters)
                         every(core.variationDetailRef)
                             .returns(Decision.of(experiment: nil, variation: "A", reason: "DEFAULT_RULE"))
                         
@@ -755,7 +755,7 @@ class HackleInvocationSpec: QuickSpec {
                     }
                 }
                 it("invalid parameters case") {
-                    let jsonString = self.createJsonString(command: "variationDetail", parameters: [:])
+                    let jsonString = createJsonString(command: "variationDetail", parameters: [:])
                     let result = sut.invoke(string: jsonString)
 
                     expect(core.variationDetailRef.invokations().count) == 0
@@ -771,7 +771,7 @@ class HackleInvocationSpec: QuickSpec {
                     let parameters = [
                         "featureKey": 123
                     ] as [String: Any]
-                    let jsonString = self.createJsonString(command: "isFeatureOn", parameters: parameters)
+                    let jsonString = createJsonString(command: "isFeatureOn", parameters: parameters)
                     every(core.featureFlagDetailRef)
                         .returns(FeatureFlagDecision.on(featureFlag: nil, reason: "DEFAULT_RULE"))
                         
@@ -793,7 +793,7 @@ class HackleInvocationSpec: QuickSpec {
                         "featureKey": 123,
                         "user": "abcd1234"
                     ] as [String: Any]
-                    let jsonString = self.createJsonString(command: "isFeatureOn", parameters: parameters)
+                    let jsonString = createJsonString(command: "isFeatureOn", parameters: parameters)
                     every(core.featureFlagDetailRef)
                         .returns(FeatureFlagDecision.on(featureFlag: nil, reason: "DEFAULT_RULE"))
                         
@@ -816,7 +816,7 @@ class HackleInvocationSpec: QuickSpec {
                         "featureKey": 123,
                         "user": ["id": "foo"]
                     ] as [String: Any]
-                    let jsonString = self.createJsonString(command: "isFeatureOn", parameters: parameters)
+                    let jsonString = createJsonString(command: "isFeatureOn", parameters: parameters)
                     every(core.featureFlagDetailRef)
                         .returns(FeatureFlagDecision.on(featureFlag: nil, reason: "DEFAULT_RULE"))
                         
@@ -835,7 +835,7 @@ class HackleInvocationSpec: QuickSpec {
                     expect(core.hackleAppContext?.browserProperties["mock"] as? String) == "mocks"
                 }
                 it("invalid parameters case") {
-                    let jsonString = self.createJsonString(command: "isFeatureOn", parameters: [:])
+                    let jsonString = createJsonString(command: "isFeatureOn", parameters: [:])
                     let result = sut.invoke(string: jsonString)
 
                     expect(core.featureFlagDetailRef.invokations().count) == 0
@@ -851,7 +851,7 @@ class HackleInvocationSpec: QuickSpec {
                     let parameters = [
                         "featureKey": 123
                     ] as [String: Any]
-                    let jsonString = self.createJsonString(command: "featureFlagDetail", parameters: parameters)
+                    let jsonString = createJsonString(command: "featureFlagDetail", parameters: parameters)
                     every(core.featureFlagDetailRef)
                         .returns(FeatureFlagDecision.on(featureFlag: nil, reason: "DEFAULT_RULE"))
                         
@@ -880,7 +880,7 @@ class HackleInvocationSpec: QuickSpec {
                         "featureKey": 123,
                         "user": "abcd1234"
                     ] as [String: Any]
-                    let jsonString = self.createJsonString(command: "featureFlagDetail", parameters: parameters)
+                    let jsonString = createJsonString(command: "featureFlagDetail", parameters: parameters)
                     every(core.featureFlagDetailRef)
                         .returns(FeatureFlagDecision.on(featureFlag: nil, reason: "DEFAULT_RULE"))
                         
@@ -910,7 +910,7 @@ class HackleInvocationSpec: QuickSpec {
                         "featureKey": 123,
                         "user": ["id": "foo"]
                     ] as [String: Any]
-                    let jsonString = self.createJsonString(command: "featureFlagDetail", parameters: parameters)
+                    let jsonString = createJsonString(command: "featureFlagDetail", parameters: parameters)
                     every(core.featureFlagDetailRef)
                         .returns(FeatureFlagDecision.on(featureFlag: nil, reason: "DEFAULT_RULE"))
                         
@@ -936,7 +936,7 @@ class HackleInvocationSpec: QuickSpec {
                     expect(core.hackleAppContext?.browserProperties["mock"] as? String) == "mocks"
                 }
                 it("invalid parameters case") {
-                    let jsonString = self.createJsonString(command: "featureFlagDetail", parameters: [:])
+                    let jsonString = createJsonString(command: "featureFlagDetail", parameters: [:])
                     let result = sut.invoke(string: jsonString)
 
                     expect(core.featureFlagDetailRef.invokations().count) == 0
@@ -953,7 +953,7 @@ class HackleInvocationSpec: QuickSpec {
                         let parameters = [
                             "event": "abcd1234"
                         ]
-                        let jsonString = self.createJsonString(command: "track", parameters: parameters)
+                        let jsonString = createJsonString(command: "track", parameters: parameters)
                         let result = sut.invoke(string: jsonString)
                         
                         expect(core.trackRef.invokations().count) == 1
@@ -973,7 +973,7 @@ class HackleInvocationSpec: QuickSpec {
                             "event": "abcd1234",
                             "user": "foo"
                         ]
-                        let jsonString = self.createJsonString(command: "track", parameters: parameters)
+                        let jsonString = createJsonString(command: "track", parameters: parameters)
                         let result = sut.invoke(string: jsonString)
                         
                         expect(core.trackRef.invokations().count) == 1
@@ -994,7 +994,7 @@ class HackleInvocationSpec: QuickSpec {
                             "event": "abcd1234",
                             "user": ["id": "foo"]
                         ] as [String: Any]
-                        let jsonString = self.createJsonString(command: "track", parameters: parameters)
+                        let jsonString = createJsonString(command: "track", parameters: parameters)
                         let result = sut.invoke(string: jsonString)
                         
                         expect(core.trackRef.invokations().count) == 1
@@ -1026,7 +1026,7 @@ class HackleInvocationSpec: QuickSpec {
                                 ] as [String: Any?]
                             ] as [String: Any]
                         ]
-                        let jsonString = self.createJsonString(command: "track", parameters: parameters)
+                        let jsonString = createJsonString(command: "track", parameters: parameters)
                         let result = sut.invoke(string: jsonString)
                         
                         expect(core.trackRef.invokations().count) == 1
@@ -1066,7 +1066,7 @@ class HackleInvocationSpec: QuickSpec {
                             ] as [String: Any],
                             "user": "abcd1234"
                         ] as [String: Any]
-                        let jsonString = self.createJsonString(command: "track", parameters: parameters)
+                        let jsonString = createJsonString(command: "track", parameters: parameters)
                         let result = sut.invoke(string: jsonString)
                         
                         expect(core.trackRef.invokations().count) == 1
@@ -1107,7 +1107,7 @@ class HackleInvocationSpec: QuickSpec {
                             ] as [String: Any],
                             "user": ["id": "abcd1234"]
                         ] as [String: Any]
-                        let jsonString = self.createJsonString(command: "track", parameters: parameters)
+                        let jsonString = createJsonString(command: "track", parameters: parameters)
                         let result = sut.invoke(string: jsonString)
                         
                         expect(core.trackRef.invokations().count) == 1
@@ -1135,7 +1135,7 @@ class HackleInvocationSpec: QuickSpec {
                     }
                 }
                 it("invalid parameters case") {
-                    let jsonString = self.createJsonString(command: "track", parameters: [:])
+                    let jsonString = createJsonString(command: "track", parameters: [:])
                     let result = sut.invoke(string: jsonString)
 
                     expect(core.trackRef.invokations().count) == 0
@@ -1157,7 +1157,7 @@ class HackleInvocationSpec: QuickSpec {
                         
                         every(core.remoteConfigRef).returns(RemoteConfigDecision(value: HackleValue(value: 1234.5678), reason: ""))
                         
-                        let jsonString = self.createJsonString(command: "remoteConfig", parameters: parameters)
+                        let jsonString = createJsonString(command: "remoteConfig", parameters: parameters)
                         let result = sut.invoke(string: jsonString)
                         
                         expect(core.remoteConfigRef.invokations().count) == 1
@@ -1176,7 +1176,7 @@ class HackleInvocationSpec: QuickSpec {
                         ] as [String: Any]
                         every(core.remoteConfigRef).returns(RemoteConfigDecision(value: HackleValue(value: "notnumber"), reason: ""))
                         
-                        let jsonString = self.createJsonString(command: "remoteConfig", parameters: parameters)
+                        let jsonString = createJsonString(command: "remoteConfig", parameters: parameters)
                         let result = sut.invoke(string: jsonString)
                         
                         expect(core.remoteConfigRef.invokations().count) == 1
@@ -1194,7 +1194,7 @@ class HackleInvocationSpec: QuickSpec {
                         ] as [String: Any]
                         every(core.remoteConfigRef).returns(RemoteConfigDecision(value: HackleValue(value: true), reason: ""))
                         
-                        let jsonString = self.createJsonString(command: "remoteConfig", parameters: parameters)
+                        let jsonString = createJsonString(command: "remoteConfig", parameters: parameters)
                         let result = sut.invoke(string: jsonString)
                         
                         expect(core.remoteConfigRef.invokations().count) == 1
@@ -1212,7 +1212,7 @@ class HackleInvocationSpec: QuickSpec {
                         ] as [String: Any]
                         every(core.remoteConfigRef).returns(RemoteConfigDecision(value: HackleValue(value: true), reason: ""))
                         
-                        let jsonString = self.createJsonString(command: "remoteConfig", parameters: parameters)
+                        let jsonString = createJsonString(command: "remoteConfig", parameters: parameters)
                         let result = sut.invoke(string: jsonString)
                         
                         expect(core.remoteConfigRef.invokations().count) == 1
@@ -1230,7 +1230,7 @@ class HackleInvocationSpec: QuickSpec {
                         ] as [String: Any]
                         every(core.remoteConfigRef).returns(RemoteConfigDecision(value: HackleValue(value: "abcd1234"), reason: ""))
                         
-                        let jsonString = self.createJsonString(command: "remoteConfig", parameters: parameters)
+                        let jsonString = createJsonString(command: "remoteConfig", parameters: parameters)
                         let result = sut.invoke(string: jsonString)
                         
                         expect(core.remoteConfigRef.invokations().count) == 1
@@ -1248,7 +1248,7 @@ class HackleInvocationSpec: QuickSpec {
                         ] as [String: Any]
                         every(core.remoteConfigRef).returns(RemoteConfigDecision(value: HackleValue(value: 1234), reason: ""))
                         
-                        let jsonString = self.createJsonString(command: "remoteConfig", parameters: parameters)
+                        let jsonString = createJsonString(command: "remoteConfig", parameters: parameters)
                         let result = sut.invoke(string: jsonString)
                         
                         expect(core.remoteConfigRef.invokations().count) == 1
@@ -1267,7 +1267,7 @@ class HackleInvocationSpec: QuickSpec {
                                 "user": "abcd1234"
                             ] as [String: Any]
                             every(core.remoteConfigRef).returns(RemoteConfigDecision(value: HackleValue(value: 1234.5678), reason: ""))
-                            let jsonString = self.createJsonString(command: "remoteConfig", parameters: parameters)
+                            let jsonString = createJsonString(command: "remoteConfig", parameters: parameters)
                             let result = sut.invoke(string: jsonString)
                             expect(core.remoteConfigRef.invokations().count) == 1
                             let firstInvokation = core.remoteConfigRef.firstInvokation()
@@ -1286,7 +1286,7 @@ class HackleInvocationSpec: QuickSpec {
                                 "user": "abcd1234"
                             ] as [String: Any]
                             every(core.remoteConfigRef).returns(RemoteConfigDecision(value: HackleValue(value: "notnumber"), reason: ""))
-                            let jsonString = self.createJsonString(command: "remoteConfig", parameters: parameters)
+                            let jsonString = createJsonString(command: "remoteConfig", parameters: parameters)
                             let result = sut.invoke(string: jsonString)
                             expect(core.remoteConfigRef.invokations().count) == 1
                             let firstInvokation = core.remoteConfigRef.firstInvokation()
@@ -1305,7 +1305,7 @@ class HackleInvocationSpec: QuickSpec {
                                 "user": "abcd1234"
                             ] as [String: Any]
                             every(core.remoteConfigRef).returns(RemoteConfigDecision(value: HackleValue(value: true), reason: ""))
-                            let jsonString = self.createJsonString(command: "remoteConfig", parameters: parameters)
+                            let jsonString = createJsonString(command: "remoteConfig", parameters: parameters)
                             let result = sut.invoke(string: jsonString)
                             expect(core.remoteConfigRef.invokations().count) == 1
                             let firstInvokation = core.remoteConfigRef.firstInvokation()
@@ -1324,7 +1324,7 @@ class HackleInvocationSpec: QuickSpec {
                                 "user": "abcd1234"
                             ] as [String: Any]
                             every(core.remoteConfigRef).returns(RemoteConfigDecision(value: HackleValue(value: true), reason: ""))
-                            let jsonString = self.createJsonString(command: "remoteConfig", parameters: parameters)
+                            let jsonString = createJsonString(command: "remoteConfig", parameters: parameters)
                             let result = sut.invoke(string: jsonString)
                             expect(core.remoteConfigRef.invokations().count) == 1
                             let firstInvokation = core.remoteConfigRef.firstInvokation()
@@ -1344,7 +1344,7 @@ class HackleInvocationSpec: QuickSpec {
                                 "user": "abcd1234"
                             ] as [String: Any]
                             every(core.remoteConfigRef).returns(RemoteConfigDecision(value: HackleValue(value: "abcd1234"), reason: ""))
-                            let jsonString = self.createJsonString(command: "remoteConfig", parameters: parameters)
+                            let jsonString = createJsonString(command: "remoteConfig", parameters: parameters)
                             let result = sut.invoke(string: jsonString)
                             expect(core.remoteConfigRef.invokations().count) == 1
                             let firstInvokation = core.remoteConfigRef.firstInvokation()
@@ -1364,7 +1364,7 @@ class HackleInvocationSpec: QuickSpec {
                                 "user": "abcd1234"
                             ] as [String: Any]
                             every(core.remoteConfigRef).returns(RemoteConfigDecision(value: HackleValue(value: true), reason: ""))
-                            let jsonString = self.createJsonString(command: "remoteConfig", parameters: parameters)
+                            let jsonString = createJsonString(command: "remoteConfig", parameters: parameters)
                             let result = sut.invoke(string: jsonString)
                             expect(core.remoteConfigRef.invokations().count) == 1
                             let firstInvokation = core.remoteConfigRef.firstInvokation()
@@ -1386,7 +1386,7 @@ class HackleInvocationSpec: QuickSpec {
                                 "user": ["id": "abcd1234"]
                             ] as [String: Any]
                             every(core.remoteConfigRef).returns(RemoteConfigDecision(value: HackleValue(value: 1234.5678), reason: ""))
-                            let jsonString = self.createJsonString(command: "remoteConfig", parameters: parameters)
+                            let jsonString = createJsonString(command: "remoteConfig", parameters: parameters)
                             let result = sut.invoke(string: jsonString)
                             expect(core.remoteConfigRef.invokations().count) == 1
                             let firstInvokation = core.remoteConfigRef.firstInvokation()
@@ -1407,7 +1407,7 @@ class HackleInvocationSpec: QuickSpec {
                                 "user": ["id": "abcd1234"]
                             ] as [String: Any]
                             every(core.remoteConfigRef).returns(RemoteConfigDecision(value: HackleValue(value: true), reason: ""))
-                            let jsonString = self.createJsonString(command: "remoteConfig", parameters: parameters)
+                            let jsonString = createJsonString(command: "remoteConfig", parameters: parameters)
                             let result = sut.invoke(string: jsonString)
                             expect(core.remoteConfigRef.invokations().count) == 1
                             let firstInvokation = core.remoteConfigRef.firstInvokation()
@@ -1427,7 +1427,7 @@ class HackleInvocationSpec: QuickSpec {
                                 "user": ["id": "abcd1234"]
                             ] as [String: Any]
                             every(core.remoteConfigRef).returns(RemoteConfigDecision(value: HackleValue(value: true), reason: ""))
-                            let jsonString = self.createJsonString(command: "remoteConfig", parameters: parameters)
+                            let jsonString = createJsonString(command: "remoteConfig", parameters: parameters)
                             let result = sut.invoke(string: jsonString)
                             expect(core.remoteConfigRef.invokations().count) == 1
                             let firstInvokation = core.remoteConfigRef.firstInvokation()
@@ -1447,7 +1447,7 @@ class HackleInvocationSpec: QuickSpec {
                                 "user": ["id": "abcd1234"]
                             ] as [String: Any]
                             every(core.remoteConfigRef).returns(RemoteConfigDecision(value: HackleValue(value: true), reason: ""))
-                            let jsonString = self.createJsonString(command: "remoteConfig", parameters: parameters)
+                            let jsonString = createJsonString(command: "remoteConfig", parameters: parameters)
                             let result = sut.invoke(string: jsonString)
                             expect(core.remoteConfigRef.invokations().count) == 1
                             let firstInvokation = core.remoteConfigRef.firstInvokation()
@@ -1467,7 +1467,7 @@ class HackleInvocationSpec: QuickSpec {
                                 "user": ["id": "abcd1234"]
                             ] as [String: Any]
                             every(core.remoteConfigRef).returns(RemoteConfigDecision(value: HackleValue(value: "abcd1234"), reason: ""))
-                            let jsonString = self.createJsonString(command: "remoteConfig", parameters: parameters)
+                            let jsonString = createJsonString(command: "remoteConfig", parameters: parameters)
                             let result = sut.invoke(string: jsonString)
                             expect(core.remoteConfigRef.invokations().count) == 1
                             let firstInvokation = core.remoteConfigRef.firstInvokation()
@@ -1487,7 +1487,7 @@ class HackleInvocationSpec: QuickSpec {
                                 "user": ["id": "abcd1234"]
                             ] as [String: Any]
                             every(core.remoteConfigRef).returns(RemoteConfigDecision(value: HackleValue(value: 1234), reason: ""))
-                            let jsonString = self.createJsonString(command: "remoteConfig", parameters: parameters)
+                            let jsonString = createJsonString(command: "remoteConfig", parameters: parameters)
                             let result = sut.invoke(string: jsonString)
                             expect(core.remoteConfigRef.invokations().count) == 1
                             let firstInvokation = core.remoteConfigRef.firstInvokation()
@@ -1502,7 +1502,7 @@ class HackleInvocationSpec: QuickSpec {
                     }
                 }
                 it("invalid parameters case") {
-                    let jsonString = self.createJsonString(command: "remoteConfig", parameters: [:])
+                    let jsonString = createJsonString(command: "remoteConfig", parameters: [:])
                     let result = sut.invoke(string: jsonString)
                     
                     expect(core.remoteConfigRef.invokations().count) == 0
@@ -1519,7 +1519,7 @@ class HackleInvocationSpec: QuickSpec {
                         "screenName": "main",
                         "className": "UIViewController"
                     ]
-                    let jsonString = self.createJsonString(command: "setCurrentScreen", parameters: parameters)
+                    let jsonString = createJsonString(command: "setCurrentScreen", parameters: parameters)
                     let result = sut.invoke(string: jsonString)
                     
                     expect(core.setCurrentScreenRef.invokations().count) == 1
@@ -1533,7 +1533,7 @@ class HackleInvocationSpec: QuickSpec {
             }
             describe("setOptOutTracking") {
                 it("optOut=true이면 setOptOutTracking(true) 호출") {
-                    let jsonString = self.createJsonString(command: "setOptOutTracking", parameters: ["optOut": true])
+                    let jsonString = createJsonString(command: "setOptOutTracking", parameters: ["optOut": true])
                     let result = sut.invoke(string: jsonString)
 
                     expect(core.setOptOutTrackingRef.invokations().count) == 1
@@ -1546,7 +1546,7 @@ class HackleInvocationSpec: QuickSpec {
                 }
 
                 it("optOut=false이면 setOptOutTracking(false) 호출") {
-                    let jsonString = self.createJsonString(command: "setOptOutTracking", parameters: ["optOut": false])
+                    let jsonString = createJsonString(command: "setOptOutTracking", parameters: ["optOut": false])
                     let result = sut.invoke(string: jsonString)
 
                     expect(core.setOptOutTrackingRef.invokations().count) == 1
@@ -1559,7 +1559,7 @@ class HackleInvocationSpec: QuickSpec {
                 }
 
                 it("optOut 파라미터 누락 시 에러 응답") {
-                    let jsonString = self.createJsonString(command: "setOptOutTracking", parameters: [:])
+                    let jsonString = createJsonString(command: "setOptOutTracking", parameters: [:])
                     let result = sut.invoke(string: jsonString)
 
                     expect(core.setOptOutTrackingRef.invokations().count) == 0
@@ -1571,7 +1571,7 @@ class HackleInvocationSpec: QuickSpec {
             describe("isOptOutTracking") {
                 it("isOptOutTracking이 true이면 data=true 반환") {
                     core.isOptOutTracking = true
-                    let jsonString = self.createJsonString(command: "isOptOutTracking")
+                    let jsonString = createJsonString(command: "isOptOutTracking")
                     let result = sut.invoke(string: jsonString)
 
                     let dict = result.jsonObject()!
@@ -1582,7 +1582,7 @@ class HackleInvocationSpec: QuickSpec {
 
                 it("isOptOutTracking이 false이면 data=false 반환") {
                     core.isOptOutTracking = false
-                    let jsonString = self.createJsonString(command: "isOptOutTracking")
+                    let jsonString = createJsonString(command: "isOptOutTracking")
                     let result = sut.invoke(string: jsonString)
 
                     let dict = result.jsonObject()!
@@ -1593,7 +1593,7 @@ class HackleInvocationSpec: QuickSpec {
             }
             describe("user explorer") {
                 it("show") {
-                    let jsonString = self.createJsonString(command: "showUserExplorer", parameters: [:])
+                    let jsonString = createJsonString(command: "showUserExplorer", parameters: [:])
                     let result = sut.invoke(string: jsonString)
                     
                     expect(core.showUserExplorerRef.invokations().count) == 1
@@ -1605,7 +1605,7 @@ class HackleInvocationSpec: QuickSpec {
                 }
                 
                 it("hide") {
-                    let jsonString = self.createJsonString(command: "hideUserExplorer", parameters: [:])
+                    let jsonString = createJsonString(command: "hideUserExplorer", parameters: [:])
                     let result = sut.invoke(string: jsonString)
 
                     expect(core.hideUserExplorerRef.invokations().count) == 1

--- a/Tests/HackleTests/Invocator/HackleJavascriptBridgeSpecs.swift
+++ b/Tests/HackleTests/Invocator/HackleJavascriptBridgeSpecs.swift
@@ -12,7 +12,7 @@ import WebKit
 @testable import Hackle
 
 class HackleWebBridgeSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
         describe("WKWebView+HackleJavascriptBridge") {
 
             var webView: WKWebView!

--- a/Tests/HackleTests/Invocator/HackleUIDelegateSpecs.swift
+++ b/Tests/HackleTests/Invocator/HackleUIDelegateSpecs.swift
@@ -87,7 +87,7 @@ class HackleUIDelegateSpecs: QuickSpec {
                     let sut = HackleUIDelegate(invocator: mockInvocator)
                     let selector = #selector(WKUIDelegate.webView(_:runJavaScriptTextInputPanelWithPrompt:defaultText:initiatedByFrame:completionHandler:))
                     let target = sut.forwardingTarget(for: selector)
-                    expect(target as AnyObject).to(beIdenticalTo(sut as AnyObject))
+                    expect(target as! HackleUIDelegate).to(beIdenticalTo(sut))
                 }
             }
 
@@ -97,7 +97,7 @@ class HackleUIDelegateSpecs: QuickSpec {
                     let sut = HackleUIDelegate(invocator: mockInvocator, uiDelegate: mockUIDelegate)
                     let selector = #selector(MockWKUIDelegate.customMethod)
                     let target = sut.forwardingTarget(for: selector)
-                    expect(target as AnyObject).to(beIdenticalTo(mockUIDelegate as AnyObject))
+                    expect(target as! MockWKUIDelegate).to(beIdenticalTo(mockUIDelegate))
                 }
             }
 

--- a/Tests/HackleTests/Invocator/HackleUIDelegateSpecs.swift
+++ b/Tests/HackleTests/Invocator/HackleUIDelegateSpecs.swift
@@ -87,7 +87,7 @@ class HackleUIDelegateSpecs: QuickSpec {
                     let sut = HackleUIDelegate(invocator: mockInvocator)
                     let selector = #selector(WKUIDelegate.webView(_:runJavaScriptTextInputPanelWithPrompt:defaultText:initiatedByFrame:completionHandler:))
                     let target = sut.forwardingTarget(for: selector)
-                    expect(target).to(beIdenticalTo(sut))
+                    expect(target as AnyObject).to(beIdenticalTo(sut as AnyObject))
                 }
             }
 
@@ -97,7 +97,7 @@ class HackleUIDelegateSpecs: QuickSpec {
                     let sut = HackleUIDelegate(invocator: mockInvocator, uiDelegate: mockUIDelegate)
                     let selector = #selector(MockWKUIDelegate.customMethod)
                     let target = sut.forwardingTarget(for: selector)
-                    expect(target).to(beIdenticalTo(mockUIDelegate))
+                    expect(target as AnyObject).to(beIdenticalTo(mockUIDelegate as AnyObject))
                 }
             }
 

--- a/Tests/HackleTests/Invocator/HackleUIDelegateSpecs.swift
+++ b/Tests/HackleTests/Invocator/HackleUIDelegateSpecs.swift
@@ -13,104 +13,6 @@ class HackleUIDelegateSpecs: QuickSpec {
             mockInvocator = MockInvocator()
         }
 
-        describe("webView runJavaScriptTextInputPanelWithPrompt") {
-
-            it("invocable prompt should invoke and return result via completionHandler") {
-                MainActor.assumeIsolated {
-                    let sut = HackleUIDelegate(invocator: mockInvocator)
-                    mockInvocator.invocable = true
-                    mockInvocator.invokeResult = "{\"result\":\"ok\"}"
-
-                    let webView = WKWebView()
-                    let frame = WKFrameInfo()
-                    var callbackResult: String? = "not_called"
-
-                    sut.webView(
-                        webView,
-                        runJavaScriptTextInputPanelWithPrompt: "test_prompt",
-                        defaultText: nil,
-                        initiatedByFrame: frame
-                    ) { result in
-                        callbackResult = result
-                    }
-
-                    expect(mockInvocator.invokedString) == "test_prompt"
-                    expect(callbackResult) == "{\"result\":\"ok\"}"
-                }
-            }
-
-            it("non-invocable prompt without uiDelegate should call completionHandler with nil") {
-                MainActor.assumeIsolated {
-                    let sut = HackleUIDelegate(invocator: mockInvocator, uiDelegate: nil)
-                    mockInvocator.invocable = false
-
-                    let webView = WKWebView()
-                    let frame = WKFrameInfo()
-                    var callbackResult: String? = "not_called"
-
-                    sut.webView(
-                        webView,
-                        runJavaScriptTextInputPanelWithPrompt: "non_hackle_prompt",
-                        defaultText: nil,
-                        initiatedByFrame: frame
-                    ) { result in
-                        callbackResult = result
-                    }
-
-                    expect(callbackResult).to(beNil())
-                }
-            }
-
-            it("non-invocable prompt with uiDelegate should forward to uiDelegate") {
-                MainActor.assumeIsolated {
-                    let mockUIDelegate = MockWKUIDelegate()
-                    let sut = HackleUIDelegate(invocator: mockInvocator, uiDelegate: mockUIDelegate)
-                    mockInvocator.invocable = false
-
-                    let webView = WKWebView()
-                    let frame = WKFrameInfo()
-                    var callbackResult: String? = "not_called"
-
-                    sut.webView(
-                        webView,
-                        runJavaScriptTextInputPanelWithPrompt: "external_prompt",
-                        defaultText: "default",
-                        initiatedByFrame: frame
-                    ) { result in
-                        callbackResult = result
-                    }
-
-                    expect(mockUIDelegate.promptCalled) == true
-                    expect(mockUIDelegate.receivedPrompt) == "external_prompt"
-                    expect(mockUIDelegate.receivedDefaultText) == "default"
-                    expect(callbackResult) == "delegated_result"
-                }
-            }
-
-            it("non-invocable prompt with uiDelegate that does not implement prompt method should call completionHandler with nil") {
-                MainActor.assumeIsolated {
-                    let minimalDelegate = MinimalWKUIDelegate()
-                    let sut = HackleUIDelegate(invocator: mockInvocator, uiDelegate: minimalDelegate)
-                    mockInvocator.invocable = false
-
-                    let webView = WKWebView()
-                    let frame = WKFrameInfo()
-                    var callbackResult: String? = "not_called"
-
-                    sut.webView(
-                        webView,
-                        runJavaScriptTextInputPanelWithPrompt: "some_prompt",
-                        defaultText: nil,
-                        initiatedByFrame: frame
-                    ) { result in
-                        callbackResult = result
-                    }
-
-                    expect(callbackResult).to(beNil())
-                }
-            }
-        }
-
         describe("responds(to:)") {
 
             it("should return true for selectors HackleUIDelegate responds to") {
@@ -135,6 +37,45 @@ class HackleUIDelegateSpecs: QuickSpec {
                     let sut = HackleUIDelegate(invocator: mockInvocator, uiDelegate: nil)
                     let selector = #selector(MockWKUIDelegate.customMethod)
                     expect(sut.responds(to: selector)) == false
+                }
+            }
+        }
+
+        describe("weak uiDelegate reference") {
+
+            it("should not retain uiDelegate") {
+                MainActor.assumeIsolated {
+                    var mockDelegate: MockWKUIDelegate? = MockWKUIDelegate()
+                    weak var weakRef = mockDelegate
+
+                    let sut = HackleUIDelegate(invocator: mockInvocator, uiDelegate: mockDelegate)
+                    _ = sut
+                    mockDelegate = nil
+
+                    expect(weakRef).to(beNil())
+                }
+            }
+
+            it("responds(to:) should return false after uiDelegate is deallocated") {
+                MainActor.assumeIsolated {
+                    var mockDelegate: MockWKUIDelegate? = MockWKUIDelegate()
+                    let sut = HackleUIDelegate(invocator: mockInvocator, uiDelegate: mockDelegate)
+                    mockDelegate = nil
+
+                    let selector = #selector(MockWKUIDelegate.customMethod)
+                    expect(sut.responds(to: selector)) == false
+                }
+            }
+
+            it("forwardingTarget(for:) should return nil after uiDelegate is deallocated") {
+                MainActor.assumeIsolated {
+                    var mockDelegate: MockWKUIDelegate? = MockWKUIDelegate()
+                    let sut = HackleUIDelegate(invocator: mockInvocator, uiDelegate: mockDelegate)
+                    mockDelegate = nil
+
+                    let selector = #selector(MockWKUIDelegate.customMethod)
+                    let target = sut.forwardingTarget(for: selector)
+                    expect(target).to(beNil())
                 }
             }
         }
@@ -198,13 +139,6 @@ private class MockWKUIDelegate: NSObject, WKUIDelegate {
     var promptCalled = false
     var receivedPrompt: String?
     var receivedDefaultText: String?
-
-    func webView(_ webView: WKWebView, runJavaScriptTextInputPanelWithPrompt prompt: String, defaultText: String?, initiatedByFrame frame: WKFrameInfo, completionHandler: @escaping @MainActor @Sendable (String?) -> Void) {
-        promptCalled = true
-        receivedPrompt = prompt
-        receivedDefaultText = defaultText
-        completionHandler("delegated_result")
-    }
 
     @objc func customMethod() {}
 }

--- a/Tests/HackleTests/Invocator/HackleUIDelegateSpecs.swift
+++ b/Tests/HackleTests/Invocator/HackleUIDelegateSpecs.swift
@@ -5,7 +5,7 @@ import WebKit
 @testable import Hackle
 
 class HackleUIDelegateSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
 
         var mockInvocator: MockInvocator!
 

--- a/Tests/HackleTests/Invocator/HackleUIDelegateSpecs.swift
+++ b/Tests/HackleTests/Invocator/HackleUIDelegateSpecs.swift
@@ -87,7 +87,7 @@ class HackleUIDelegateSpecs: QuickSpec {
                     let sut = HackleUIDelegate(invocator: mockInvocator)
                     let selector = #selector(WKUIDelegate.webView(_:runJavaScriptTextInputPanelWithPrompt:defaultText:initiatedByFrame:completionHandler:))
                     let target = sut.forwardingTarget(for: selector)
-                    expect(target as! HackleUIDelegate).to(beIdenticalTo(sut))
+                    expect(target as? HackleUIDelegate).to(beIdenticalTo(sut))
                 }
             }
 
@@ -97,7 +97,7 @@ class HackleUIDelegateSpecs: QuickSpec {
                     let sut = HackleUIDelegate(invocator: mockInvocator, uiDelegate: mockUIDelegate)
                     let selector = #selector(MockWKUIDelegate.customMethod)
                     let target = sut.forwardingTarget(for: selector)
-                    expect(target as! MockWKUIDelegate).to(beIdenticalTo(mockUIDelegate))
+                    expect(target as? MockWKUIDelegate).to(beIdenticalTo(mockUIDelegate))
                 }
             }
 

--- a/Tests/HackleTests/Invocator/Invocation/DefaultInvocationHandlerFactorySpecs.swift
+++ b/Tests/HackleTests/Invocator/Invocation/DefaultInvocationHandlerFactorySpecs.swift
@@ -5,7 +5,7 @@ import Nimble
 import Quick
 
 class DefaultInvocationHandlerFactorySpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
         it("get") {
             let sut = DefaultInvocationHandlerFactory(core: MockHackleAppCore())
 

--- a/Tests/HackleTests/Invocator/Invocation/DefaultInvocationProcessorSpecs.swift
+++ b/Tests/HackleTests/Invocator/Invocation/DefaultInvocationProcessorSpecs.swift
@@ -5,7 +5,7 @@ import Nimble
 import Quick
 
 class DefaultInvocationProcessorSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
         var handler: MockInvocationHandler!
         var handlerFactory: MockInvocationHandlerFactory!
         var sut: DefaultInvocationProcessor!

--- a/Tests/HackleTests/Invocator/Invocation/InvocationHandlerSpecs.swift
+++ b/Tests/HackleTests/Invocator/Invocation/InvocationHandlerSpecs.swift
@@ -4,7 +4,7 @@ import Nimble
 import Quick
 
 class InvocationHandlerSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
         var core: MockHackleAppCore!
         
         beforeEach {

--- a/Tests/HackleTests/Invocator/Invocation/InvocationRequestSpecs.swift
+++ b/Tests/HackleTests/Invocator/Invocation/InvocationRequestSpecs.swift
@@ -5,7 +5,7 @@ import Nimble
 import Quick
 
 class InvocationRequestSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
         it("isInvocable") {
             expect(InvocationRequest.isInvocable(string: "{\"_hackle\":{\"command\":\"foo\"}}")) == true
             expect(InvocationRequest.isInvocable(string: "{\"_hackle\":{\"command\":\"\"}}")) == false

--- a/Tests/HackleTests/Invocator/Invocation/InvocationResponseSpecs.swift
+++ b/Tests/HackleTests/Invocator/Invocation/InvocationResponseSpecs.swift
@@ -5,7 +5,7 @@ import Nimble
 import Quick
 
 class InvocationResponseSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
         it("toJsonString") {
             expect(InvocationResponse<Any>.success().toJsonString())
                 .to(contain("\"success\":true"))

--- a/Tests/HackleTests/Invocator/InvocationDtoSpecs.swift
+++ b/Tests/HackleTests/Invocator/InvocationDtoSpecs.swift
@@ -13,7 +13,7 @@ import Foundation
 // MARK: - Test Spec
 
 class InvokeDtoSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
 
         // MARK: - User
         describe("User extension") {

--- a/Tests/HackleTests/UI/InAppMessageUI/Event/Action/DefaultInAppMessageActionHandlerFactorySpecs.swift
+++ b/Tests/HackleTests/UI/InAppMessageUI/Event/Action/DefaultInAppMessageActionHandlerFactorySpecs.swift
@@ -12,7 +12,7 @@ class DefaultInAppMessageActionHandlerFactorySpecs: QuickSpec {
             let handler2 = MockInAppMessageActionHandler()
             every(handler2.supportsMock).returns(true)
             
-            expect(DefaultInAppMessageActionHandlerFactory(handlers: [handler1, handler2]).get(action: InAppMessage.action())).to(beIdenticalTo(handler2))
+            expect(DefaultInAppMessageActionHandlerFactory(handlers: [handler1, handler2]).get(action: InAppMessage.action()) as AnyObject).to(beIdenticalTo(handler2 as AnyObject))
             
             expect(DefaultInAppMessageActionHandlerFactory(handlers: [handler1]).get(action: InAppMessage.action())).to(beNil())
         }

--- a/Tests/HackleTests/UI/InAppMessageUI/Event/Action/DefaultInAppMessageActionHandlerFactorySpecs.swift
+++ b/Tests/HackleTests/UI/InAppMessageUI/Event/Action/DefaultInAppMessageActionHandlerFactorySpecs.swift
@@ -12,7 +12,7 @@ class DefaultInAppMessageActionHandlerFactorySpecs: QuickSpec {
             let handler2 = MockInAppMessageActionHandler()
             every(handler2.supportsMock).returns(true)
             
-            expect(DefaultInAppMessageActionHandlerFactory(handlers: [handler1, handler2]).get(action: InAppMessage.action()) as AnyObject).to(beIdenticalTo(handler2 as AnyObject))
+            expect(DefaultInAppMessageActionHandlerFactory(handlers: [handler1, handler2]).get(action: InAppMessage.action()) as! MockInAppMessageActionHandler).to(beIdenticalTo(handler2))
             
             expect(DefaultInAppMessageActionHandlerFactory(handlers: [handler1]).get(action: InAppMessage.action())).to(beNil())
         }

--- a/Tests/HackleTests/UI/InAppMessageUI/Event/Action/DefaultInAppMessageActionHandlerFactorySpecs.swift
+++ b/Tests/HackleTests/UI/InAppMessageUI/Event/Action/DefaultInAppMessageActionHandlerFactorySpecs.swift
@@ -12,7 +12,7 @@ class DefaultInAppMessageActionHandlerFactorySpecs: QuickSpec {
             let handler2 = MockInAppMessageActionHandler()
             every(handler2.supportsMock).returns(true)
             
-            expect(DefaultInAppMessageActionHandlerFactory(handlers: [handler1, handler2]).get(action: InAppMessage.action()) as! MockInAppMessageActionHandler).to(beIdenticalTo(handler2))
+            expect(DefaultInAppMessageActionHandlerFactory(handlers: [handler1, handler2]).get(action: InAppMessage.action()) as? MockInAppMessageActionHandler).to(beIdenticalTo(handler2))
             
             expect(DefaultInAppMessageActionHandlerFactory(handlers: [handler1]).get(action: InAppMessage.action())).to(beNil())
         }

--- a/Tests/HackleTests/UI/InAppMessageUI/Event/Action/DefaultInAppMessageActionHandlerFactorySpecs.swift
+++ b/Tests/HackleTests/UI/InAppMessageUI/Event/Action/DefaultInAppMessageActionHandlerFactorySpecs.swift
@@ -4,7 +4,7 @@ import Nimble
 import Quick
 
 class DefaultInAppMessageActionHandlerFactorySpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
         it("get") {
             let handler1 = MockInAppMessageActionHandler()
             every(handler1.supportsMock).returns(false)

--- a/Tests/HackleTests/UI/InAppMessageUI/Event/Action/DefaultInAppMessageViewEventActorFactorySpecs.swift
+++ b/Tests/HackleTests/UI/InAppMessageUI/Event/Action/DefaultInAppMessageViewEventActorFactorySpecs.swift
@@ -15,7 +15,7 @@ class DefaultInAppMessageViewEventActorFactorySpecs: QuickSpec {
             let sut = DefaultInAppMessageViewEventActorFactory(actors: [actor1, actor2])
             
             let actual = sut.get(type: .action)
-            expect(actual as AnyObject).to(beIdenticalTo(actor2 as AnyObject))
+            expect(actual as! MockInAppMessageViewEventActor).to(beIdenticalTo(actor2))
             
             expect(DefaultInAppMessageViewEventActorFactory(actors: [actor1]).get(type: .action)).to(beNil())
          }

--- a/Tests/HackleTests/UI/InAppMessageUI/Event/Action/DefaultInAppMessageViewEventActorFactorySpecs.swift
+++ b/Tests/HackleTests/UI/InAppMessageUI/Event/Action/DefaultInAppMessageViewEventActorFactorySpecs.swift
@@ -4,7 +4,7 @@ import Nimble
 import Quick
 
 class DefaultInAppMessageViewEventActorFactorySpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
         it("get") {
             let actor1 = MockInAppMessageViewEventActor()
             every(actor1.supportsMock).returns(false)

--- a/Tests/HackleTests/UI/InAppMessageUI/Event/Action/DefaultInAppMessageViewEventActorFactorySpecs.swift
+++ b/Tests/HackleTests/UI/InAppMessageUI/Event/Action/DefaultInAppMessageViewEventActorFactorySpecs.swift
@@ -15,7 +15,7 @@ class DefaultInAppMessageViewEventActorFactorySpecs: QuickSpec {
             let sut = DefaultInAppMessageViewEventActorFactory(actors: [actor1, actor2])
             
             let actual = sut.get(type: .action)
-            expect(actual).to(beIdenticalTo(actor2))
+            expect(actual as AnyObject).to(beIdenticalTo(actor2 as AnyObject))
             
             expect(DefaultInAppMessageViewEventActorFactory(actors: [actor1]).get(type: .action)).to(beNil())
          }

--- a/Tests/HackleTests/UI/InAppMessageUI/Event/Action/DefaultInAppMessageViewEventActorFactorySpecs.swift
+++ b/Tests/HackleTests/UI/InAppMessageUI/Event/Action/DefaultInAppMessageViewEventActorFactorySpecs.swift
@@ -15,7 +15,7 @@ class DefaultInAppMessageViewEventActorFactorySpecs: QuickSpec {
             let sut = DefaultInAppMessageViewEventActorFactory(actors: [actor1, actor2])
             
             let actual = sut.get(type: .action)
-            expect(actual as! MockInAppMessageViewEventActor).to(beIdenticalTo(actor2))
+            expect(actual as? MockInAppMessageViewEventActor).to(beIdenticalTo(actor2))
             
             expect(DefaultInAppMessageViewEventActorFactory(actors: [actor1]).get(type: .action)).to(beNil())
          }

--- a/Tests/HackleTests/UI/InAppMessageUI/Event/Action/InAppMessageActionHandlerSpecs.swift
+++ b/Tests/HackleTests/UI/InAppMessageUI/Event/Action/InAppMessageActionHandlerSpecs.swift
@@ -4,7 +4,7 @@ import Nimble
 import Quick
 
 class InAppMessageActionHandlerSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
         describe("InAppMessageCloseActionHandler") {
             var sut: InAppMessageCloseActionHandler!
 

--- a/Tests/HackleTests/UI/InAppMessageUI/Event/Action/InAppMessageViewEventActionHandlerSpecs.swift
+++ b/Tests/HackleTests/UI/InAppMessageUI/Event/Action/InAppMessageViewEventActionHandlerSpecs.swift
@@ -4,7 +4,7 @@ import Nimble
 import Quick
 
 class InAppMessageViewEventActionHandlerSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
         var actor: MockInAppMessageViewEventActor!
         var actorFactory: MockInAppMessageViewEventActorFactory!
         var sut: InAppMessageViewEventActionHandler!

--- a/Tests/HackleTests/UI/InAppMessageUI/Event/Action/InAppMessageViewEventActorSpecs.swift
+++ b/Tests/HackleTests/UI/InAppMessageUI/Event/Action/InAppMessageViewEventActorSpecs.swift
@@ -4,7 +4,7 @@ import Nimble
 import Quick
 
 class InAppMessageViewEventActorSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
         describe("InAppMessageViewImpressionEventActor") {
             var sut: InAppMessageViewImpressionEventActor!
             

--- a/Tests/HackleTests/UI/InAppMessageUI/Event/DefaultInAppMessageViewEventProcessorSpecs.swift
+++ b/Tests/HackleTests/UI/InAppMessageUI/Event/DefaultInAppMessageViewEventProcessorSpecs.swift
@@ -4,7 +4,7 @@ import Nimble
 import Quick
 
 class DefaultInAppMessageViewEventProcessorSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
         it("process") {
             let trackHandler = MockInAppMessageViewEventHandler(handleType: .track)
             let actionHandler = MockInAppMessageViewEventHandler(handleType: .action)

--- a/Tests/HackleTests/UI/InAppMessageUI/Event/Track/DefaultInAppMessageEventTrackerSpecs.swift
+++ b/Tests/HackleTests/UI/InAppMessageUI/Event/Track/DefaultInAppMessageEventTrackerSpecs.swift
@@ -11,7 +11,7 @@ import Nimble
 import Quick
 
 class DefaultInAppMessageEventTrackerSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
         var core: HackleCoreStub!
         var sut: DefaultInAppMessageEventTracker!
 

--- a/Tests/HackleTests/UI/InAppMessageUI/Event/Track/InAppMessageViewEventTrackHandlerSpecs.swift
+++ b/Tests/HackleTests/UI/InAppMessageUI/Event/Track/InAppMessageViewEventTrackHandlerSpecs.swift
@@ -4,7 +4,7 @@ import Nimble
 import Quick
 
 class InAppMessageViewEventTrackHandlerSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
         var tracker: MockInAppMessageEventTracker!
         var sut: InAppMessageViewEventTrackHandler!
 

--- a/Tests/HackleTests/UI/InAppMessageUI/Views/Html/HtmlViewBridgeScriptSpecs.swift
+++ b/Tests/HackleTests/UI/InAppMessageUI/Views/Html/HtmlViewBridgeScriptSpecs.swift
@@ -4,7 +4,7 @@ import Nimble
 import Quick
 
 class HtmlViewBridgeScriptSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
         typealias BridgeScript = HackleInAppMessageUI.HtmlViewBridgeScript
         typealias Loader = HackleInAppMessageUI.WebViewResourceLoader
 

--- a/Tests/HackleTests/UI/InAppMessageUI/Views/InAppMessageButtonViewSpecs.swift
+++ b/Tests/HackleTests/UI/InAppMessageUI/Views/InAppMessageButtonViewSpecs.swift
@@ -12,7 +12,7 @@ import UIKit
 @testable import Hackle
 
 class ButtonViewSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
         describe("ButtonView") {
             var button: InAppMessage.Message.Button!
             var sut: HackleInAppMessageUI.ButtonView!
@@ -62,7 +62,7 @@ class ButtonViewSpecs: QuickSpec {
 }
 
 class PositionalButtonViewSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
         describe("PositionalButtonView") {
             var button: InAppMessage.Message.Button!
             var alignment: InAppMessage.Message.Alignment!

--- a/Tests/HackleTests/UI/InAppMessageUI/Views/InAppMessageExtSpecs.swift
+++ b/Tests/HackleTests/UI/InAppMessageUI/Views/InAppMessageExtSpecs.swift
@@ -12,7 +12,7 @@ import UIKit
 @testable import Hackle
 
 class InAppMessageExtSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
         describe("InAppMessage supports(orientation:)") {
             it("포함된 orientation이면 true 반환") {
                 let msgContext = InAppMessage.MessageContext(

--- a/Tests/HackleTests/UI/InAppMessageUI/Views/WebViewResourceLoaderSpecs.swift
+++ b/Tests/HackleTests/UI/InAppMessageUI/Views/WebViewResourceLoaderSpecs.swift
@@ -4,7 +4,7 @@ import Nimble
 import Quick
 
 class WebViewResourceLoaderSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
         typealias Loader = HackleInAppMessageUI.WebViewResourceLoader
 
         var sut: Loader!

--- a/Tests/HackleTests/UI/Internal/ApplicationUrlHandlerSpecs.swift
+++ b/Tests/HackleTests/UI/Internal/ApplicationUrlHandlerSpecs.swift
@@ -12,7 +12,7 @@ import UIKit
 @testable import Hackle
 
 class ApplicationUrlHandlerSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
         describe("ApplicationUrlHandler") {
             var sut: ApplicationUrlHandler!
 

--- a/Tests/HackleTests/UI/Internal/HackleUIUtilsSpec.swift
+++ b/Tests/HackleTests/UI/Internal/HackleUIUtilsSpec.swift
@@ -4,7 +4,7 @@ import Nimble
 @testable import Hackle
 
 class HackleUIUtilsSpec: QuickSpec {
-    override func spec() {
+    override class func spec() {
         describe("UIUtils") {
             describe("currentScreen") {
                 it("should return a valid UIScreen") {

--- a/Tests/HackleTests/UI/Notification/NotificationClickActionSpecs.swift
+++ b/Tests/HackleTests/UI/Notification/NotificationClickActionSpecs.swift
@@ -12,7 +12,7 @@ import MockingKit
 @testable import Hackle
 
 class NotificationClickActionSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
         it("from valid string") {
             expect(NotificationClickAction.from(rawValue: "DEEP_LINK")).to(equal(NotificationClickAction.deepLink))
             expect(NotificationClickAction.from(rawValue: "APP_OPEN")).to(equal(NotificationClickAction.appOpen))

--- a/Tests/HackleTests/UI/Notification/NotificationDataReceiverSpecs.swift
+++ b/Tests/HackleTests/UI/Notification/NotificationDataReceiverSpecs.swift
@@ -11,7 +11,7 @@ import Nimble
 import Foundation
 
 class DefaultNotificationDataReceiverSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
         var mockRepository: MockNotificationRepository!
         var dispatchQueue: DispatchQueue!
         var receiver: DefaultNotificationDataReceiver!

--- a/Tests/HackleTests/UI/Notification/NotificationDataSpecs.swift
+++ b/Tests/HackleTests/UI/Notification/NotificationDataSpecs.swift
@@ -5,7 +5,7 @@ import MockingKit
 @testable import Hackle
 
 class NotificationDataSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
         it("from dictionary") {
             let data = ["hackle": [
                 "workspaceId": 123,

--- a/Tests/HackleTests/UI/Notification/NotificationHandlerSpecs.swift
+++ b/Tests/HackleTests/UI/Notification/NotificationHandlerSpecs.swift
@@ -23,7 +23,7 @@ class MockNotificationDataReceiver: NotificationDataReceiver {
 
 // NotificationHandler 테스트
 class NotificationHandlerSpecs: QuickSpec {
-    override func spec() {
+    override class func spec() {
         describe("NotificationHandler") {
             var handler: NotificationHandler!
             var mockReceiver: MockNotificationDataReceiver!


### PR DESCRIPTION
## 개요
Quick 7.6.x, Nimble 13.8.x로 업그레이드하고 테스트 코드를 새 버전에 맞게 마이그레이션합니다.

## 주요 변경사항

| 카테고리 | 내용 |
|----------|------|
| 의존성 업그레이드 | Quick 7.6.x, Nimble 13.8.x로 버전 업데이트 (Package.swift, xcodeproj) |
| Quick 7 마이그레이션 | `override func spec()` → `override class func spec()`, instance method/property를 class context로 변환 |
| Nimble 13 대응 | `beIdenticalTo`의 class 타입 제약에 맞춰 `as! AnyObject` → 구체 타입 conditional cast(`as?`)로 변경 |