### PR TITLE
ci: auto-update Hackle.xcodeproj on JS SDK version bump

### DIFF
--- a/.github/workflows/update_javascript_sdk.yml
+++ b/.github/workflows/update_javascript_sdk.yml
@@ -98,6 +98,17 @@ jobs:
             echo "Error: stale JS SDK references remain in project.pbxproj"
             exit 1
           fi
+          if grep -E "hackle-javascript-sdk-[0-9]+\.[0-9]+\.[0-9]+\.min\.js" \
+               Package.swift | grep -v "hackle-javascript-sdk-${JS_SDK_VERSION}.min.js"; then
+            echo "Error: stale JS SDK references remain in Package.swift"
+            exit 1
+          fi
+          if grep -E "javascriptSdkVersion = \"[0-9]+\.[0-9]+\.[0-9]+\"" \
+               Sources/Hackle/UI/InAppMessageUI/Views/Html/InAppMessageUIHtmlViewBridgeScript.swift \
+               | grep -v "javascriptSdkVersion = \"${JS_SDK_VERSION}\""; then
+            echo "Error: stale javascriptSdkVersion remains in InAppMessageUIHtmlViewBridgeScript.swift"
+            exit 1
+          fi
 
       - name: Commit and push
         run: |

--- a/.github/workflows/update_javascript_sdk.yml
+++ b/.github/workflows/update_javascript_sdk.yml
@@ -91,6 +91,8 @@ jobs:
           sed -i -E "s/hackle-javascript-sdk-[0-9]+\.[0-9]+\.[0-9]+\.min\.js/hackle-javascript-sdk-${JS_SDK_VERSION}.min.js/g" \
             Hackle.xcodeproj/project.pbxproj
 
+      - name: Verify no stale JS SDK references
+        run: |
           if grep -E "hackle-javascript-sdk-[0-9]+\.[0-9]+\.[0-9]+\.min\.js" \
                Hackle.xcodeproj/project.pbxproj | grep -v "hackle-javascript-sdk-${JS_SDK_VERSION}.min.js"; then
             echo "Error: stale JS SDK references remain in project.pbxproj"

--- a/.github/workflows/update_javascript_sdk.yml
+++ b/.github/workflows/update_javascript_sdk.yml
@@ -88,6 +88,15 @@ jobs:
           sed -i -E "s/\.process\(\"Resources\/hackle-javascript-sdk-[^\"]+\.min\.js\"\)/.process(\"Resources\/hackle-javascript-sdk-${JS_SDK_VERSION}.min.js\")/" \
             Package.swift
 
+          sed -i -E "s/hackle-javascript-sdk-[0-9]+\.[0-9]+\.[0-9]+\.min\.js/hackle-javascript-sdk-${JS_SDK_VERSION}.min.js/g" \
+            Hackle.xcodeproj/project.pbxproj
+
+          if grep -E "hackle-javascript-sdk-[0-9]+\.[0-9]+\.[0-9]+\.min\.js" \
+               Hackle.xcodeproj/project.pbxproj | grep -v "hackle-javascript-sdk-${JS_SDK_VERSION}.min.js"; then
+            echo "Error: stale JS SDK references remain in project.pbxproj"
+            exit 1
+          fi
+
       - name: Commit and push
         run: |
           FEATURE_BRANCH="update-javascript-sdk-$JS_SDK_VERSION"
@@ -97,7 +106,8 @@ jobs:
           git add \
             Sources/Hackle/Resources/ \
             Sources/Hackle/UI/InAppMessageUI/Views/Html/InAppMessageUIHtmlViewBridgeScript.swift \
-            Package.swift
+            Package.swift \
+            Hackle.xcodeproj/project.pbxproj
           git commit -m "chore: update @hackler/javascript-sdk@$JS_SDK_VERSION"
           git push origin "$FEATURE_BRANCH"
         env:
@@ -112,6 +122,4 @@ jobs:
             --base "$DEV_BRANCH" \
             --title "[Automation] Update @hackler/javascript-sdk@$JS_SDK_VERSION" \
             --body "## Description
-          - Update @hackler/javascript-sdk@$JS_SDK_VERSION
-
-          > **Note:** \`Hackle.xcodeproj\`는 수동으로 업데이트 필요"
+          - Update @hackler/javascript-sdk@$JS_SDK_VERSION"


### PR DESCRIPTION
## 개요
JS SDK 자동 업데이트 워크플로우에서 `Hackle.xcodeproj`를 더 이상 수동으로 업데이트하지 않도록 개선합니다.
함께, stale JS SDK 버전 reference가 남아있는지 검증하는 단계를 추가하였습니다.

## 작업 내용
- `Hackle.xcodeproj/project.pbxproj` 내 JS SDK 파일명을 `sed`로 자동 치환
- 자동 커밋 대상 파일에 `Hackle.xcodeproj/project.pbxproj` 추가
- Verify 단계 추가: `project.pbxproj`, `Package.swift`, `InAppMessageUIHtmlViewBridgeScript.swift`에 stale reference가 남아있으면 빌드 실패
- 자동 생성되는 PR 본문에서 "`Hackle.xcodeproj`는 수동으로 업데이트 필요" 안내 문구 제거