### PR TITLE
fix: use RecursiveLock in metric registry to prevent re-entrancy deadlock

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,5 +105,6 @@ jobs:
                 -only-testing:HackleTests/ConcurrentArrayRaceSpecs \
                 -only-testing:HackleTests/AtomicReferenceRaceSpecs \
                 -only-testing:HackleTests/DelegatingMetricRegistrySpecs/concurrency \
+                -only-testing:HackleTests/MetricsRaceSpecs \
                 -parallel-testing-enabled NO \
                 | xcbeautify --renderer github-actions --quiet

--- a/Hackle.xcodeproj/project.pbxproj
+++ b/Hackle.xcodeproj/project.pbxproj
@@ -137,6 +137,7 @@
 		B29C53562DCB1FA9001724B2 /* ConcurrentArraySpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = B29C53552DCB1F9F001724B2 /* ConcurrentArraySpecs.swift */; };
 		DC902D6EC27FC62B366CE337 /* ConcurrentArrayRaceSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F9CC1E0FB4A5ADA9E2DF7EA /* ConcurrentArrayRaceSpecs.swift */; };
 		9B441640DC8CAA8104E04335 /* AtomicReferenceRaceSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = C88B14D9B2CE4E3AE6750A75 /* AtomicReferenceRaceSpecs.swift */; };
+		A1B2C3D4E5F60718293A4B5F /* RecursiveLockSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60718293A4B5E /* RecursiveLockSpecs.swift */; };
 		B29C53582DCB23C8001724B2 /* NotificationDataReceiverSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = B29C53572DCB23BB001724B2 /* NotificationDataReceiverSpecs.swift */; };
 		B29C535A2DCB2621001724B2 /* NotificationHandlerSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = B29C53592DCB2613001724B2 /* NotificationHandlerSpecs.swift */; };
 		B29C535C2DCB2A4E001724B2 /* InAppMessageButtonViewSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = B29C535B2DCB2A44001724B2 /* InAppMessageButtonViewSpecs.swift */; };
@@ -264,6 +265,7 @@
 		EE29D97429CD825400B1FEAA /* TimeUnit.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE29D8EF29CD825300B1FEAA /* TimeUnit.swift */; };
 		EE29D97529CD825400B1FEAA /* AtomicDouble.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE29D8F129CD825300B1FEAA /* AtomicDouble.swift */; };
 		EE29D97629CD825400B1FEAA /* ReadWriteLock.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE29D8F229CD825300B1FEAA /* ReadWriteLock.swift */; };
+		A1B2C3D4E5F60718293A4B5D /* RecursiveLock.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60718293A4B5C /* RecursiveLock.swift */; };
 		EE29D97729CD825400B1FEAA /* AtomicInt64.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE29D8F329CD825300B1FEAA /* AtomicInt64.swift */; };
 		EE29D97829CD825400B1FEAA /* AtomicReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE29D8F429CD825300B1FEAA /* AtomicReference.swift */; };
 		EE29D97929CD825400B1FEAA /* UserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE29D8F529CD825300B1FEAA /* UserDefaults.swift */; };
@@ -872,6 +874,7 @@
 		B29C53552DCB1F9F001724B2 /* ConcurrentArraySpecs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConcurrentArraySpecs.swift; sourceTree = "<group>"; };
 		5F9CC1E0FB4A5ADA9E2DF7EA /* ConcurrentArrayRaceSpecs.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConcurrentArrayRaceSpecs.swift; sourceTree = "<group>"; };
 		C88B14D9B2CE4E3AE6750A75 /* AtomicReferenceRaceSpecs.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AtomicReferenceRaceSpecs.swift; sourceTree = "<group>"; };
+		A1B2C3D4E5F60718293A4B5E /* RecursiveLockSpecs.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecursiveLockSpecs.swift; sourceTree = "<group>"; };
 		B29C53572DCB23BB001724B2 /* NotificationDataReceiverSpecs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationDataReceiverSpecs.swift; sourceTree = "<group>"; };
 		B29C53592DCB2613001724B2 /* NotificationHandlerSpecs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationHandlerSpecs.swift; sourceTree = "<group>"; };
 		B29C535B2DCB2A44001724B2 /* InAppMessageButtonViewSpecs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppMessageButtonViewSpecs.swift; sourceTree = "<group>"; };
@@ -999,6 +1002,7 @@
 		EE29D8EF29CD825300B1FEAA /* TimeUnit.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TimeUnit.swift; sourceTree = "<group>"; };
 		EE29D8F129CD825300B1FEAA /* AtomicDouble.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AtomicDouble.swift; sourceTree = "<group>"; };
 		EE29D8F229CD825300B1FEAA /* ReadWriteLock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReadWriteLock.swift; sourceTree = "<group>"; };
+		A1B2C3D4E5F60718293A4B5C /* RecursiveLock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecursiveLock.swift; sourceTree = "<group>"; };
 		EE29D8F329CD825300B1FEAA /* AtomicInt64.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AtomicInt64.swift; sourceTree = "<group>"; };
 		EE29D8F429CD825300B1FEAA /* AtomicReference.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AtomicReference.swift; sourceTree = "<group>"; };
 		EE29D8F529CD825300B1FEAA /* UserDefaults.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserDefaults.swift; sourceTree = "<group>"; };
@@ -2220,6 +2224,7 @@
 			children = (
 				EE29D8F129CD825300B1FEAA /* AtomicDouble.swift */,
 				EE29D8F229CD825300B1FEAA /* ReadWriteLock.swift */,
+				A1B2C3D4E5F60718293A4B5C /* RecursiveLock.swift */,
 				EE29D8F329CD825300B1FEAA /* AtomicInt64.swift */,
 				EE29D8F429CD825300B1FEAA /* AtomicReference.swift */,
 				EE42A53A2BBC42B30008B003 /* ThrottleLimiter.swift */,
@@ -2672,6 +2677,7 @@
 				B29C53552DCB1F9F001724B2 /* ConcurrentArraySpecs.swift */,
 				5F9CC1E0FB4A5ADA9E2DF7EA /* ConcurrentArrayRaceSpecs.swift */,
 				C88B14D9B2CE4E3AE6750A75 /* AtomicReferenceRaceSpecs.swift */,
+				A1B2C3D4E5F60718293A4B5E /* RecursiveLockSpecs.swift */,
 				7E9065B52B59466C00FE6E52 /* DefaultThrottlerSpecs.swift */,
 				EE29D9F429CD82C100B1FEAA /* DispatchQueueExtensions.swift */,
 				EEFA31DB2BC1831700E133F8 /* ScopingThrottleLimiterSpecs.swift */,
@@ -4043,6 +4049,7 @@
 				EE29D94E29CD825400B1FEAA /* DelegatingMetric.swift in Sources */,
 				EECDF3E32C11B271009B2F56 /* InAppMessageUIBannerImageView.swift in Sources */,
 				EE29D97629CD825400B1FEAA /* ReadWriteLock.swift in Sources */,
+				A1B2C3D4E5F60718293A4B5D /* RecursiveLock.swift in Sources */,
 				EE29D97D29CD825400B1FEAA /* HttpResponse.swift in Sources */,
 				EE29D97A29CD825400B1FEAA /* Scheduler.swift in Sources */,
 				EE4D037E2E5C3597007BE61A /* InAppMessageEligibilityEvaluator.swift in Sources */,
@@ -4281,6 +4288,7 @@
 				B29C53562DCB1FA9001724B2 /* ConcurrentArraySpecs.swift in Sources */,
 				DC902D6EC27FC62B366CE337 /* ConcurrentArrayRaceSpecs.swift in Sources */,
 				9B441640DC8CAA8104E04335 /* AtomicReferenceRaceSpecs.swift in Sources */,
+				A1B2C3D4E5F60718293A4B5F /* RecursiveLockSpecs.swift in Sources */,
 				EE1ABAC12F66CF2500D10076 /* InAppMessageViewEventActorSpecs.swift in Sources */,
 				EEF895A02A49BCAF00722CF6 /* HackleCoreStub.swift in Sources */,
 				EE4D041B2E5D7C1B007BE61A /* DefaultInAppMessageScheduleActionDeterminerSpecs.swift in Sources */,

--- a/Hackle.xcodeproj/project.pbxproj
+++ b/Hackle.xcodeproj/project.pbxproj
@@ -21,6 +21,12 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		0A7893D8E2AB66A2E340D8C3 /* UserInfoSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A933F105F82764448558AE2B /* UserInfoSectionView.swift */; };
+		1CD2C17ACB50BF925CCF6150 /* MetricRegistryRaceSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29181C5D4B1E6C512C027033 /* MetricRegistryRaceSpecs.swift */; };
+		4CC1D087764AF18B9BFCA76D /* FeatureFlagListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D61999A83013137BA1EDD851 /* FeatureFlagListView.swift */; };
+		50F8E294C1E4B2851F20A359 /* ToastView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F8907AA42715F33F426C206 /* ToastView.swift */; };
+		52667C9099D965A3C611D5AC /* AbTestListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D138C0A0F36FF3A3CEE9E9A /* AbTestListView.swift */; };
+		56E32E0C528A5FA22CCF491B /* ExplorerListLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 949DEAE029633DAA02AE963A /* ExplorerListLayout.swift */; };
 		7E0F05472AD7BA6800631B42 /* MockRemoteConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E0F05462AD7BA6800631B42 /* MockRemoteConfig.swift */; };
 		7E2B7EF42B35276300D0CF4B /* NotificationProviderType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E2B7EF32B35276300D0CF4B /* NotificationProviderType.swift */; };
 		7E3F4FC72AA6FC52004E0EB0 /* BundleInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E3F4FC62AA6FC52004E0EB0 /* BundleInfo.swift */; };
@@ -59,16 +65,10 @@
 		7E9F7E892B6CCC3700A6B0B8 /* MockFileStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E9F7E882B6CCC3700A6B0B8 /* MockFileStorage.swift */; };
 		7EE320D82B56707800105A6C /* workspace_config.json in Resources */ = {isa = PBXBuildFile; fileRef = 7EE320D72B56707800105A6C /* workspace_config.json */; };
 		7EE320DA2B5692D900105A6C /* workspace_response.json in Resources */ = {isa = PBXBuildFile; fileRef = 7EE320D92B5692D900105A6C /* workspace_response.json */; };
-		D31962349B4532F0ECF333FA /* HackleHostingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6195ED6D96F452A75F509FA6 /* HackleHostingController.swift */; };
-		F49ECCCEE9BB75A6CA576C46 /* ExplorerRootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B481338F3C07B5B7D8762FD8 /* ExplorerRootView.swift */; };
-		0A7893D8E2AB66A2E340D8C3 /* UserInfoSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A933F105F82764448558AE2B /* UserInfoSectionView.swift */; };
-		52667C9099D965A3C611D5AC /* AbTestListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D138C0A0F36FF3A3CEE9E9A /* AbTestListView.swift */; };
-		4CC1D087764AF18B9BFCA76D /* FeatureFlagListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D61999A83013137BA1EDD851 /* FeatureFlagListView.swift */; };
-		CB082D93222B8E127E090395 /* ExperimentRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87717123329FBFE77C021AFF /* ExperimentRowView.swift */; };
-		D625A0C044A01FD2886C2C81 /* ExplorerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCCE4897E17E845FF8012191 /* ExplorerViewModel.swift */; };
-		50F8E294C1E4B2851F20A359 /* ToastView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F8907AA42715F33F426C206 /* ToastView.swift */; };
 		9579538A4F80A3243411D31B /* ExplorerColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8007EA972A906BFA5E1A9DB8 /* ExplorerColors.swift */; };
-		56E32E0C528A5FA22CCF491B /* ExplorerListLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 949DEAE029633DAA02AE963A /* ExplorerListLayout.swift */; };
+		9B441640DC8CAA8104E04335 /* AtomicReferenceRaceSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = C88B14D9B2CE4E3AE6750A75 /* AtomicReferenceRaceSpecs.swift */; };
+		A1B2C3D4E5F60718293A4B5D /* RecursiveLock.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60718293A4B5C /* RecursiveLock.swift */; };
+		A1B2C3D4E5F60718293A4B5F /* RecursiveLockSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60718293A4B5E /* RecursiveLockSpecs.swift */; };
 		B203A5842F8E17BD00BDAD31 /* HackleUIDelegateSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = B203A5832F8E17BD00BDAD31 /* HackleUIDelegateSpecs.swift */; };
 		B20B23142E56F0100019EAA7 /* MimeType.swift in Sources */ = {isa = PBXBuildFile; fileRef = B20B23132E56F0040019EAA7 /* MimeType.swift */; };
 		B20B234E2E56FB980019EAA7 /* MimeTypeSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = B20B234D2E56FB910019EAA7 /* MimeTypeSpecs.swift */; };
@@ -135,9 +135,6 @@
 		B2931DEA2DFFBEA500E5931E /* DefaultUserDtoSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2931DE92DFFBE9A00E5931E /* DefaultUserDtoSpecs.swift */; };
 		B2931DEC2DFFF15200E5931E /* HackleSubscriptionStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2931DEB2DFFF14200E5931E /* HackleSubscriptionStatus.swift */; };
 		B29C53562DCB1FA9001724B2 /* ConcurrentArraySpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = B29C53552DCB1F9F001724B2 /* ConcurrentArraySpecs.swift */; };
-		DC902D6EC27FC62B366CE337 /* ConcurrentArrayRaceSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F9CC1E0FB4A5ADA9E2DF7EA /* ConcurrentArrayRaceSpecs.swift */; };
-		9B441640DC8CAA8104E04335 /* AtomicReferenceRaceSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = C88B14D9B2CE4E3AE6750A75 /* AtomicReferenceRaceSpecs.swift */; };
-		A1B2C3D4E5F60718293A4B5F /* RecursiveLockSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60718293A4B5E /* RecursiveLockSpecs.swift */; };
 		B29C53582DCB23C8001724B2 /* NotificationDataReceiverSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = B29C53572DCB23BB001724B2 /* NotificationDataReceiverSpecs.swift */; };
 		B29C535A2DCB2621001724B2 /* NotificationHandlerSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = B29C53592DCB2613001724B2 /* NotificationHandlerSpecs.swift */; };
 		B29C535C2DCB2A4E001724B2 /* InAppMessageButtonViewSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = B29C535B2DCB2A44001724B2 /* InAppMessageButtonViewSpecs.swift */; };
@@ -168,9 +165,14 @@
 		B2E7B4B12C9C0A60005FB7A9 /* HacklePushSubscriptionOperations.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2E7B4B02C9C0A60005FB7A9 /* HacklePushSubscriptionOperations.swift */; };
 		B2F175A72E1E0708003F2BF4 /* UserEventConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2F175A62E1E0700003F2BF4 /* UserEventConstants.swift */; };
 		B2F9D5BF2D4C912700F0C0E0 /* TargetEventConditionMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2F9D5BE2D4C911F00F0C0E0 /* TargetEventConditionMatcher.swift */; };
+		B2FCA5782FBD42BC001C344C /* MetricsRaceSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2FCA5772FBD42B3001C344C /* MetricsRaceSpecs.swift */; };
 		B2FCB8BA2EB0CAFD001C6B14 /* HackleWebViewConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2FCB8B92EB0CAF6001C6B14 /* HackleWebViewConfig.swift */; };
 		B2FCB8BD2EB1AAB0001C6B14 /* HackleWebViewConfigSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2FCB8BC2EB1AAAD001C6B14 /* HackleWebViewConfigSpecs.swift */; };
 		B2FCB8C02EB1B069001C6B14 /* HackleJavascriptBridgeSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2FCB8BF2EB1B069001C6B14 /* HackleJavascriptBridgeSpecs.swift */; };
+		CB082D93222B8E127E090395 /* ExperimentRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87717123329FBFE77C021AFF /* ExperimentRowView.swift */; };
+		D31962349B4532F0ECF333FA /* HackleHostingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6195ED6D96F452A75F509FA6 /* HackleHostingController.swift */; };
+		D625A0C044A01FD2886C2C81 /* ExplorerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCCE4897E17E845FF8012191 /* ExplorerViewModel.swift */; };
+		DC902D6EC27FC62B366CE337 /* ConcurrentArrayRaceSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F9CC1E0FB4A5ADA9E2DF7EA /* ConcurrentArrayRaceSpecs.swift */; };
 		EE0202262F67EE52002A8D4F /* WebViewUserScript.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0202252F67EE52002A8D4F /* WebViewUserScript.swift */; };
 		EE0202282F67F408002A8D4F /* HackleJavascriptBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0202272F67F408002A8D4F /* HackleJavascriptBridge.swift */; };
 		EE02022B2F680F3C002A8D4F /* InAppMessageHtmlContentResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE02022A2F680F3C002A8D4F /* InAppMessageHtmlContentResolver.swift */; };
@@ -265,7 +267,6 @@
 		EE29D97429CD825400B1FEAA /* TimeUnit.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE29D8EF29CD825300B1FEAA /* TimeUnit.swift */; };
 		EE29D97529CD825400B1FEAA /* AtomicDouble.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE29D8F129CD825300B1FEAA /* AtomicDouble.swift */; };
 		EE29D97629CD825400B1FEAA /* ReadWriteLock.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE29D8F229CD825300B1FEAA /* ReadWriteLock.swift */; };
-		A1B2C3D4E5F60718293A4B5D /* RecursiveLock.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60718293A4B5C /* RecursiveLock.swift */; };
 		EE29D97729CD825400B1FEAA /* AtomicInt64.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE29D8F329CD825300B1FEAA /* AtomicInt64.swift */; };
 		EE29D97829CD825400B1FEAA /* AtomicReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE29D8F429CD825300B1FEAA /* AtomicReference.swift */; };
 		EE29D97929CD825400B1FEAA /* UserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE29D8F529CD825300B1FEAA /* UserDefaults.swift */; };
@@ -359,7 +360,6 @@
 		EE29DA5A29CD82C200B1FEAA /* DelegatingTimerSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE29D9DA29CD82C100B1FEAA /* DelegatingTimerSpecs.swift */; };
 		EE29DA5B29CD82C200B1FEAA /* CounterSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE29D9DB29CD82C100B1FEAA /* CounterSpecs.swift */; };
 		EE29DA5C29CD82C200B1FEAA /* MetricsSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE29D9DC29CD82C100B1FEAA /* MetricsSpecs.swift */; };
-		1CD2C17ACB50BF925CCF6150 /* MetricRegistryRaceSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29181C5D4B1E6C512C027033 /* MetricRegistryRaceSpecs.swift */; };
 		EE29DA5D29CD82C200B1FEAA /* PushMetricRegistrySpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE29D9DE29CD82C100B1FEAA /* PushMetricRegistrySpecs.swift */; };
 		EE29DA5E29CD82C200B1FEAA /* CumulativeMetricRegistrySpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE29D9E029CD82C100B1FEAA /* CumulativeMetricRegistrySpecs.swift */; };
 		EE29DA5F29CD82C200B1FEAA /* CumulativeCounterSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE29D9E129CD82C100B1FEAA /* CumulativeCounterSpecs.swift */; };
@@ -743,8 +743,9 @@
 		EEFA31E82BC18E0F00E133F8 /* MockUserEventDedupDeterminer.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEFA31E72BC18E0F00E133F8 /* MockUserEventDedupDeterminer.swift */; };
 		EEFA31EA2BC1942000E133F8 /* RemoteConfigEventDedupDeterminerSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEFA31E92BC1942000E133F8 /* RemoteConfigEventDedupDeterminerSpecs.swift */; };
 		EEFA31EC2BC1942700E133F8 /* DelegatingUserEventDedupDeterminerSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEFA31EB2BC1942700E133F8 /* DelegatingUserEventDedupDeterminerSpecs.swift */; };
-		OBJ_43 /* Hackle.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "Hackle::Hackle::Product" /* Hackle.framework */; };
 		F0DB00715AF8EE936A8C631C /* UIImageExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEC412DFB0C2D0D297974E0B /* UIImageExtension.swift */; };
+		F49ECCCEE9BB75A6CA576C46 /* ExplorerRootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B481338F3C07B5B7D8762FD8 /* ExplorerRootView.swift */; };
+		OBJ_43 /* Hackle.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "Hackle::Hackle::Product" /* Hackle.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -758,6 +759,10 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		29181C5D4B1E6C512C027033 /* MetricRegistryRaceSpecs.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MetricRegistryRaceSpecs.swift; sourceTree = "<group>"; };
+		3D138C0A0F36FF3A3CEE9E9A /* AbTestListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AbTestListView.swift; sourceTree = "<group>"; };
+		5F9CC1E0FB4A5ADA9E2DF7EA /* ConcurrentArrayRaceSpecs.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConcurrentArrayRaceSpecs.swift; sourceTree = "<group>"; };
+		6195ED6D96F452A75F509FA6 /* HackleHostingController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HackleHostingController.swift; sourceTree = "<group>"; };
 		7E0F05462AD7BA6800631B42 /* MockRemoteConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockRemoteConfig.swift; sourceTree = "<group>"; };
 		7E2B7EF32B35276300D0CF4B /* NotificationProviderType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationProviderType.swift; sourceTree = "<group>"; };
 		7E3F4FC62AA6FC52004E0EB0 /* BundleInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundleInfo.swift; sourceTree = "<group>"; };
@@ -796,16 +801,13 @@
 		7E9F7E882B6CCC3700A6B0B8 /* MockFileStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockFileStorage.swift; sourceTree = "<group>"; };
 		7EE320D72B56707800105A6C /* workspace_config.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = workspace_config.json; sourceTree = "<group>"; };
 		7EE320D92B5692D900105A6C /* workspace_response.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = workspace_response.json; sourceTree = "<group>"; };
-		6195ED6D96F452A75F509FA6 /* HackleHostingController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HackleHostingController.swift; sourceTree = "<group>"; };
-		B481338F3C07B5B7D8762FD8 /* ExplorerRootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExplorerRootView.swift; sourceTree = "<group>"; };
-		A933F105F82764448558AE2B /* UserInfoSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfoSectionView.swift; sourceTree = "<group>"; };
-		3D138C0A0F36FF3A3CEE9E9A /* AbTestListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AbTestListView.swift; sourceTree = "<group>"; };
-		D61999A83013137BA1EDD851 /* FeatureFlagListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlagListView.swift; sourceTree = "<group>"; };
-		87717123329FBFE77C021AFF /* ExperimentRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperimentRowView.swift; sourceTree = "<group>"; };
-		BCCE4897E17E845FF8012191 /* ExplorerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExplorerViewModel.swift; sourceTree = "<group>"; };
 		7F8907AA42715F33F426C206 /* ToastView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToastView.swift; sourceTree = "<group>"; };
 		8007EA972A906BFA5E1A9DB8 /* ExplorerColors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExplorerColors.swift; sourceTree = "<group>"; };
+		87717123329FBFE77C021AFF /* ExperimentRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperimentRowView.swift; sourceTree = "<group>"; };
 		949DEAE029633DAA02AE963A /* ExplorerListLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExplorerListLayout.swift; sourceTree = "<group>"; };
+		A1B2C3D4E5F60718293A4B5C /* RecursiveLock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecursiveLock.swift; sourceTree = "<group>"; };
+		A1B2C3D4E5F60718293A4B5E /* RecursiveLockSpecs.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecursiveLockSpecs.swift; sourceTree = "<group>"; };
+		A933F105F82764448558AE2B /* UserInfoSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfoSectionView.swift; sourceTree = "<group>"; };
 		B203A5832F8E17BD00BDAD31 /* HackleUIDelegateSpecs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HackleUIDelegateSpecs.swift; sourceTree = "<group>"; };
 		B20B23132E56F0040019EAA7 /* MimeType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MimeType.swift; sourceTree = "<group>"; };
 		B20B234D2E56FB910019EAA7 /* MimeTypeSpecs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MimeTypeSpecs.swift; sourceTree = "<group>"; };
@@ -872,9 +874,6 @@
 		B2931DE92DFFBE9A00E5931E /* DefaultUserDtoSpecs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultUserDtoSpecs.swift; sourceTree = "<group>"; };
 		B2931DEB2DFFF14200E5931E /* HackleSubscriptionStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HackleSubscriptionStatus.swift; sourceTree = "<group>"; };
 		B29C53552DCB1F9F001724B2 /* ConcurrentArraySpecs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConcurrentArraySpecs.swift; sourceTree = "<group>"; };
-		5F9CC1E0FB4A5ADA9E2DF7EA /* ConcurrentArrayRaceSpecs.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConcurrentArrayRaceSpecs.swift; sourceTree = "<group>"; };
-		C88B14D9B2CE4E3AE6750A75 /* AtomicReferenceRaceSpecs.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AtomicReferenceRaceSpecs.swift; sourceTree = "<group>"; };
-		A1B2C3D4E5F60718293A4B5E /* RecursiveLockSpecs.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecursiveLockSpecs.swift; sourceTree = "<group>"; };
 		B29C53572DCB23BB001724B2 /* NotificationDataReceiverSpecs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationDataReceiverSpecs.swift; sourceTree = "<group>"; };
 		B29C53592DCB2613001724B2 /* NotificationHandlerSpecs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationHandlerSpecs.swift; sourceTree = "<group>"; };
 		B29C535B2DCB2A44001724B2 /* InAppMessageButtonViewSpecs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppMessageButtonViewSpecs.swift; sourceTree = "<group>"; };
@@ -905,9 +904,14 @@
 		B2E7B4B02C9C0A60005FB7A9 /* HacklePushSubscriptionOperations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HacklePushSubscriptionOperations.swift; sourceTree = "<group>"; };
 		B2F175A62E1E0700003F2BF4 /* UserEventConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserEventConstants.swift; sourceTree = "<group>"; };
 		B2F9D5BE2D4C911F00F0C0E0 /* TargetEventConditionMatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TargetEventConditionMatcher.swift; sourceTree = "<group>"; };
+		B2FCA5772FBD42B3001C344C /* MetricsRaceSpecs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetricsRaceSpecs.swift; sourceTree = "<group>"; };
 		B2FCB8B92EB0CAF6001C6B14 /* HackleWebViewConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HackleWebViewConfig.swift; sourceTree = "<group>"; };
 		B2FCB8BC2EB1AAAD001C6B14 /* HackleWebViewConfigSpecs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HackleWebViewConfigSpecs.swift; sourceTree = "<group>"; };
 		B2FCB8BF2EB1B069001C6B14 /* HackleJavascriptBridgeSpecs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HackleJavascriptBridgeSpecs.swift; sourceTree = "<group>"; };
+		B481338F3C07B5B7D8762FD8 /* ExplorerRootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExplorerRootView.swift; sourceTree = "<group>"; };
+		BCCE4897E17E845FF8012191 /* ExplorerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExplorerViewModel.swift; sourceTree = "<group>"; };
+		C88B14D9B2CE4E3AE6750A75 /* AtomicReferenceRaceSpecs.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AtomicReferenceRaceSpecs.swift; sourceTree = "<group>"; };
+		D61999A83013137BA1EDD851 /* FeatureFlagListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlagListView.swift; sourceTree = "<group>"; };
 		EE0202252F67EE52002A8D4F /* WebViewUserScript.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewUserScript.swift; sourceTree = "<group>"; };
 		EE0202272F67F408002A8D4F /* HackleJavascriptBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HackleJavascriptBridge.swift; sourceTree = "<group>"; };
 		EE02022A2F680F3C002A8D4F /* InAppMessageHtmlContentResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppMessageHtmlContentResolver.swift; sourceTree = "<group>"; };
@@ -1002,7 +1006,6 @@
 		EE29D8EF29CD825300B1FEAA /* TimeUnit.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TimeUnit.swift; sourceTree = "<group>"; };
 		EE29D8F129CD825300B1FEAA /* AtomicDouble.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AtomicDouble.swift; sourceTree = "<group>"; };
 		EE29D8F229CD825300B1FEAA /* ReadWriteLock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReadWriteLock.swift; sourceTree = "<group>"; };
-		A1B2C3D4E5F60718293A4B5C /* RecursiveLock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecursiveLock.swift; sourceTree = "<group>"; };
 		EE29D8F329CD825300B1FEAA /* AtomicInt64.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AtomicInt64.swift; sourceTree = "<group>"; };
 		EE29D8F429CD825300B1FEAA /* AtomicReference.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AtomicReference.swift; sourceTree = "<group>"; };
 		EE29D8F529CD825300B1FEAA /* UserDefaults.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserDefaults.swift; sourceTree = "<group>"; };
@@ -1096,7 +1099,6 @@
 		EE29D9DA29CD82C100B1FEAA /* DelegatingTimerSpecs.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DelegatingTimerSpecs.swift; sourceTree = "<group>"; };
 		EE29D9DB29CD82C100B1FEAA /* CounterSpecs.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CounterSpecs.swift; sourceTree = "<group>"; };
 		EE29D9DC29CD82C100B1FEAA /* MetricsSpecs.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MetricsSpecs.swift; sourceTree = "<group>"; };
-		29181C5D4B1E6C512C027033 /* MetricRegistryRaceSpecs.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MetricRegistryRaceSpecs.swift; sourceTree = "<group>"; };
 		EE29D9DE29CD82C100B1FEAA /* PushMetricRegistrySpecs.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PushMetricRegistrySpecs.swift; sourceTree = "<group>"; };
 		EE29D9E029CD82C100B1FEAA /* CumulativeMetricRegistrySpecs.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CumulativeMetricRegistrySpecs.swift; sourceTree = "<group>"; };
 		EE29D9E129CD82C100B1FEAA /* CumulativeCounterSpecs.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CumulativeCounterSpecs.swift; sourceTree = "<group>"; };
@@ -1480,9 +1482,9 @@
 		EEFA31E72BC18E0F00E133F8 /* MockUserEventDedupDeterminer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockUserEventDedupDeterminer.swift; sourceTree = "<group>"; };
 		EEFA31E92BC1942000E133F8 /* RemoteConfigEventDedupDeterminerSpecs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigEventDedupDeterminerSpecs.swift; sourceTree = "<group>"; };
 		EEFA31EB2BC1942700E133F8 /* DelegatingUserEventDedupDeterminerSpecs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DelegatingUserEventDedupDeterminerSpecs.swift; sourceTree = "<group>"; };
+		FEC412DFB0C2D0D297974E0B /* UIImageExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIImageExtension.swift; sourceTree = "<group>"; };
 		"Hackle::Hackle::Product" /* Hackle.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Hackle.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		"Hackle::HackleTests::Product" /* HackleTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; path = HackleTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		FEC412DFB0C2D0D297974E0B /* UIImageExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIImageExtension.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1507,6 +1509,44 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		101791CDF033B6AD5C9C8442 /* UserInfo */ = {
+			isa = PBXGroup;
+			children = (
+				A933F105F82764448558AE2B /* UserInfoSectionView.swift */,
+			);
+			path = UserInfo;
+			sourceTree = "<group>";
+		};
+		15361DCD3CED4398FC541931 /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+				BCCE4897E17E845FF8012191 /* ExplorerViewModel.swift */,
+			);
+			path = ViewModel;
+			sourceTree = "<group>";
+		};
+		1C8A327D23EF894A087C8F28 /* View */ = {
+			isa = PBXGroup;
+			children = (
+				6195ED6D96F452A75F509FA6 /* HackleHostingController.swift */,
+				B481338F3C07B5B7D8762FD8 /* ExplorerRootView.swift */,
+				101791CDF033B6AD5C9C8442 /* UserInfo */,
+				63FF6C005CCE629072BEDC47 /* Experiment */,
+				CCFAC86CA3F34B53F6A0A0E7 /* Common */,
+			);
+			path = View;
+			sourceTree = "<group>";
+		};
+		63FF6C005CCE629072BEDC47 /* Experiment */ = {
+			isa = PBXGroup;
+			children = (
+				3D138C0A0F36FF3A3CEE9E9A /* AbTestListView.swift */,
+				D61999A83013137BA1EDD851 /* FeatureFlagListView.swift */,
+				87717123329FBFE77C021AFF /* ExperimentRowView.swift */,
+			);
+			path = Experiment;
+			sourceTree = "<group>";
+		};
 		7E0E2D7E2AD8D8D100578C74 /* Web */ = {
 			isa = PBXGroup;
 			children = (
@@ -1639,55 +1679,6 @@
 				7E9F7E802B6B96ED00A6B0B8 /* FileStorage.swift */,
 			);
 			path = Storage;
-			sourceTree = "<group>";
-		};
-		1C8A327D23EF894A087C8F28 /* View */ = {
-			isa = PBXGroup;
-			children = (
-				6195ED6D96F452A75F509FA6 /* HackleHostingController.swift */,
-				B481338F3C07B5B7D8762FD8 /* ExplorerRootView.swift */,
-				101791CDF033B6AD5C9C8442 /* UserInfo */,
-				63FF6C005CCE629072BEDC47 /* Experiment */,
-				CCFAC86CA3F34B53F6A0A0E7 /* Common */,
-			);
-			path = View;
-			sourceTree = "<group>";
-		};
-		15361DCD3CED4398FC541931 /* ViewModel */ = {
-			isa = PBXGroup;
-			children = (
-				BCCE4897E17E845FF8012191 /* ExplorerViewModel.swift */,
-			);
-			path = ViewModel;
-			sourceTree = "<group>";
-		};
-		CCFAC86CA3F34B53F6A0A0E7 /* Common */ = {
-			isa = PBXGroup;
-			children = (
-				7F8907AA42715F33F426C206 /* ToastView.swift */,
-				8007EA972A906BFA5E1A9DB8 /* ExplorerColors.swift */,
-				949DEAE029633DAA02AE963A /* ExplorerListLayout.swift */,
-				FEC412DFB0C2D0D297974E0B /* UIImageExtension.swift */,
-			);
-			path = Common;
-			sourceTree = "<group>";
-		};
-		63FF6C005CCE629072BEDC47 /* Experiment */ = {
-			isa = PBXGroup;
-			children = (
-				3D138C0A0F36FF3A3CEE9E9A /* AbTestListView.swift */,
-				D61999A83013137BA1EDD851 /* FeatureFlagListView.swift */,
-				87717123329FBFE77C021AFF /* ExperimentRowView.swift */,
-			);
-			path = Experiment;
-			sourceTree = "<group>";
-		};
-		101791CDF033B6AD5C9C8442 /* UserInfo */ = {
-			isa = PBXGroup;
-			children = (
-				A933F105F82764448558AE2B /* UserInfoSectionView.swift */,
-			);
-			path = UserInfo;
 			sourceTree = "<group>";
 		};
 		B21078422E90C28500D26B60 /* Bundle */ = {
@@ -1839,6 +1830,17 @@
 				B29C535E2DCB2F13001724B2 /* DefaultRemoteConfigSpecs.swift */,
 			);
 			path = RemoteConfig;
+			sourceTree = "<group>";
+		};
+		CCFAC86CA3F34B53F6A0A0E7 /* Common */ = {
+			isa = PBXGroup;
+			children = (
+				7F8907AA42715F33F426C206 /* ToastView.swift */,
+				8007EA972A906BFA5E1A9DB8 /* ExplorerColors.swift */,
+				949DEAE029633DAA02AE963A /* ExplorerListLayout.swift */,
+				FEC412DFB0C2D0D297974E0B /* UIImageExtension.swift */,
+			);
+			path = Common;
 			sourceTree = "<group>";
 		};
 		EE02021D2F67DF16002A8D4F /* Modal */ = {
@@ -2552,6 +2554,7 @@
 				EE29D9E329CD82C100B1FEAA /* MetricSpecs.swift */,
 				EE29D9DC29CD82C100B1FEAA /* MetricsSpecs.swift */,
 				29181C5D4B1E6C512C027033 /* MetricRegistryRaceSpecs.swift */,
+				B2FCA5772FBD42B3001C344C /* MetricsRaceSpecs.swift */,
 			);
 			path = Metrics;
 			sourceTree = "<group>";
@@ -4243,6 +4246,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 0;
 			files = (
+				B2FCA5782FBD42BC001C344C /* MetricsRaceSpecs.swift in Sources */,
 				B2DDF7692DB778D4006572E2 /* WebViewUserEventDecoratorSpecs.swift in Sources */,
 				EE0F34082A669659009DE640 /* MockUrlHandler.swift in Sources */,
 				7E64779F2AD50E5200971F20 /* MockHackleApp.swift in Sources */,

--- a/Sources/Hackle/Core/Metrics/Delegate/DelegatingCounter.swift
+++ b/Sources/Hackle/Core/Metrics/Delegate/DelegatingCounter.swift
@@ -11,12 +11,12 @@ class DelegatingCounter: DelegatingMetric, Counter, @unchecked Sendable {
 
     let id: MetricId
 
-    private let lock = RecursiveLock(label: "io.hackle.DelegatingCounter.Lock")
+    private let recursiveLock = RecursiveLock(label: "io.hackle.DelegatingCounter.Lock")
     private let noopCounter: Counter
     private var _counters: [MetricRegistry: Counter]
 
     private var counters: [Counter] {
-        lock.locked { Array(_counters.values) }
+        recursiveLock.lock { Array(_counters.values) }
     }
 
     private var first: Counter {
@@ -31,7 +31,7 @@ class DelegatingCounter: DelegatingMetric, Counter, @unchecked Sendable {
 
     func add(registry: MetricRegistry) {
         let newCounter = registry.counter(id: id)
-        lock.locked {
+        recursiveLock.lock {
             if _counters[registry] == nil {
                 _counters[registry] = newCounter
             }

--- a/Sources/Hackle/Core/Metrics/Delegate/DelegatingCounter.swift
+++ b/Sources/Hackle/Core/Metrics/Delegate/DelegatingCounter.swift
@@ -11,12 +11,12 @@ class DelegatingCounter: DelegatingMetric, Counter, @unchecked Sendable {
 
     let id: MetricId
 
-    private let lock = ReadWriteLock(label: "io.hackle.DelegatingCounter.Lock")
+    private let lock = RecursiveLock(label: "io.hackle.DelegatingCounter.Lock")
     private let noopCounter: Counter
     private var _counters: [MetricRegistry: Counter]
 
     private var counters: [Counter] {
-        lock.read { Array(_counters.values) }
+        lock.locked { Array(_counters.values) }
     }
 
     private var first: Counter {
@@ -31,7 +31,7 @@ class DelegatingCounter: DelegatingMetric, Counter, @unchecked Sendable {
 
     func add(registry: MetricRegistry) {
         let newCounter = registry.counter(id: id)
-        lock.write {
+        lock.locked {
             if _counters[registry] == nil {
                 _counters[registry] = newCounter
             }

--- a/Sources/Hackle/Core/Metrics/Delegate/DelegatingMetricRegistry.swift
+++ b/Sources/Hackle/Core/Metrics/Delegate/DelegatingMetricRegistry.swift
@@ -25,10 +25,7 @@ class DelegatingMetricRegistry: MetricRegistry, @unchecked Sendable {
     }
 
     private func addRegistries(metric: DelegatingMetric) {
-        // Holds `lock` (re-entered if called from createTimer/createCounter under
-        // getOrCreateMetric). Without this, `registries` Set is iterated lock-free
-        // while another thread mutates it via add(registry:) — the production race.
-        lock.locked {
+        recursiveLock.lock {
             for registry in registries {
                 metric.add(registry: registry)
             }
@@ -39,19 +36,22 @@ class DelegatingMetricRegistry: MetricRegistry, @unchecked Sendable {
         if registry is DelegatingMetricRegistry {
             return
         }
-
-        let inserted = lock.locked { registries.insert(registry).inserted }
-        guard inserted else { return }
-
-        for metric in metrics {
-            if let delegatingMetric = metric as? DelegatingMetric {
-                delegatingMetric.add(registry: registry)
+        
+        recursiveLock.lock {
+            guard registries.insert(registry).inserted else {
+                return
+            }
+            
+            for metric in metrics {
+                if let delegatingMetric = metric as? DelegatingMetric {
+                    delegatingMetric.add(registry: registry)
+                }
             }
         }
     }
 
     func clear() {
-        lock.locked {
+        recursiveLock.lock {
             registries.removeAll()
         }
     }

--- a/Sources/Hackle/Core/Metrics/Delegate/DelegatingMetricRegistry.swift
+++ b/Sources/Hackle/Core/Metrics/Delegate/DelegatingMetricRegistry.swift
@@ -25,8 +25,13 @@ class DelegatingMetricRegistry: MetricRegistry, @unchecked Sendable {
     }
 
     private func addRegistries(metric: DelegatingMetric) {
-        for registry in registries {
-            metric.add(registry: registry)
+        // Holds `lock` (re-entered if called from createTimer/createCounter under
+        // getOrCreateMetric). Without this, `registries` Set is iterated lock-free
+        // while another thread mutates it via add(registry:) — the production race.
+        lock.locked {
+            for registry in registries {
+                metric.add(registry: registry)
+            }
         }
     }
 
@@ -35,7 +40,7 @@ class DelegatingMetricRegistry: MetricRegistry, @unchecked Sendable {
             return
         }
 
-        let inserted = lock { registries.insert(registry).inserted }
+        let inserted = lock.locked { registries.insert(registry).inserted }
         guard inserted else { return }
 
         for metric in metrics {
@@ -46,7 +51,7 @@ class DelegatingMetricRegistry: MetricRegistry, @unchecked Sendable {
     }
 
     func clear() {
-        lock {
+        lock.locked {
             registries.removeAll()
         }
     }

--- a/Sources/Hackle/Core/Metrics/Delegate/DelegatingTimer.swift
+++ b/Sources/Hackle/Core/Metrics/Delegate/DelegatingTimer.swift
@@ -12,12 +12,12 @@ class DelegatingTimer: DelegatingMetric, Timer {
 
     let id: MetricId
 
-    private let lock = RecursiveLock(label: "io.hackle.DelegatingTimer.Lock")
+    private let recursiveLock = RecursiveLock(label: "io.hackle.DelegatingTimer.Lock")
     private let noopTimer: Timer
     private var _timers: [MetricRegistry: Timer]
 
     private var timers: [Timer] {
-        lock.locked { Array(_timers.values) }
+        recursiveLock.lock { Array(_timers.values) }
     }
 
     init(id: MetricId) {
@@ -28,7 +28,7 @@ class DelegatingTimer: DelegatingMetric, Timer {
 
     func add(registry: MetricRegistry) {
         let newTimer = registry.timer(id: id)
-        lock.locked {
+        recursiveLock.lock {
             if _timers[registry] == nil {
                 _timers[registry] = newTimer
             }

--- a/Sources/Hackle/Core/Metrics/Delegate/DelegatingTimer.swift
+++ b/Sources/Hackle/Core/Metrics/Delegate/DelegatingTimer.swift
@@ -12,12 +12,12 @@ class DelegatingTimer: DelegatingMetric, Timer {
 
     let id: MetricId
 
-    private let lock = ReadWriteLock(label: "io.hackle.DelegatingTimer.Lock")
+    private let lock = RecursiveLock(label: "io.hackle.DelegatingTimer.Lock")
     private let noopTimer: Timer
     private var _timers: [MetricRegistry: Timer]
 
     private var timers: [Timer] {
-        lock.read { Array(_timers.values) }
+        lock.locked { Array(_timers.values) }
     }
 
     init(id: MetricId) {
@@ -28,7 +28,7 @@ class DelegatingTimer: DelegatingMetric, Timer {
 
     func add(registry: MetricRegistry) {
         let newTimer = registry.timer(id: id)
-        lock.write {
+        lock.locked {
             if _timers[registry] == nil {
                 _timers[registry] = newTimer
             }

--- a/Sources/Hackle/Core/Metrics/MetricRegistry.swift
+++ b/Sources/Hackle/Core/Metrics/MetricRegistry.swift
@@ -14,18 +14,14 @@ class MetricRegistry: @unchecked Sendable {
         "\(self)"
     }
 
-    private let _lock = ReadWriteLock(label: "io.hackle.MetricRegistry.Lock")
-
-    /// Acquires the registry's write barrier. Use for any mutation of `_metrics`
-    /// or subclass-owned state. For read-only access, use `metrics` (already read-locked).
-    @discardableResult
-    func lock<T>(block: () throws -> T) rethrows -> T {
-        try _lock.write(block: block)
-    }
+    /// Domain lock for `_metrics` and subclass-owned state.
+    /// `RecursiveLock` so subclass overrides (e.g. `DelegatingMetricRegistry.createTimer`)
+    /// can re-enter the same lock without deadlock.
+    let lock = RecursiveLock(label: "io.hackle.MetricRegistry.Lock")
 
     private var _metrics = [MetricId: Metric]()
     final var metrics: [Metric] {
-        _lock.read { Array(_metrics.values) }
+        lock.locked { Array(_metrics.values) }
     }
 
     final func counter(name: String, tags: [String: String] = [:]) -> Counter {
@@ -64,17 +60,14 @@ class MetricRegistry: @unchecked Sendable {
     }
 
     private func getOrCreateMetric(id: MetricId, create: (MetricId) -> Metric) -> Metric {
-        var metric: Metric!
-        lock {
+        lock.locked {
             if let registeredMetric = _metrics[id] {
-                metric = registeredMetric
-            } else {
-                let newMetric = create(id)
-                _metrics[id] = newMetric
-                metric = newMetric
+                return registeredMetric
             }
+            let newMetric = create(id)
+            _metrics[id] = newMetric
+            return newMetric
         }
-        return metric
     }
 }
 

--- a/Sources/Hackle/Core/Metrics/MetricRegistry.swift
+++ b/Sources/Hackle/Core/Metrics/MetricRegistry.swift
@@ -17,11 +17,11 @@ class MetricRegistry: @unchecked Sendable {
     /// Domain lock for `_metrics` and subclass-owned state.
     /// `RecursiveLock` so subclass overrides (e.g. `DelegatingMetricRegistry.createTimer`)
     /// can re-enter the same lock without deadlock.
-    let lock = RecursiveLock(label: "io.hackle.MetricRegistry.Lock")
+    let recursiveLock = RecursiveLock(label: "io.hackle.MetricRegistry.Lock")
 
     private var _metrics = [MetricId: Metric]()
     final var metrics: [Metric] {
-        lock.locked { Array(_metrics.values) }
+        recursiveLock.lock { Array(_metrics.values) }
     }
 
     final func counter(name: String, tags: [String: String] = [:]) -> Counter {
@@ -60,7 +60,7 @@ class MetricRegistry: @unchecked Sendable {
     }
 
     private func getOrCreateMetric(id: MetricId, create: (MetricId) -> Metric) -> Metric {
-        lock.locked {
+        recursiveLock.lock {
             if let registeredMetric = _metrics[id] {
                 return registeredMetric
             }

--- a/Sources/Hackle/Core/Metrics/Push/PushMetricRegistry.swift
+++ b/Sources/Hackle/Core/Metrics/Push/PushMetricRegistry.swift
@@ -11,7 +11,7 @@ import UIKit
 
 class PushMetricRegistry: MetricRegistry, @unchecked Sendable {
 
-    private let lock = ReadWriteLock(label: "io.hackle.PushMetricRegistry.Lock")
+    private let publishingLock = ReadWriteLock(label: "io.hackle.PushMetricRegistry.Lock")
 
     private var publishingJob: ScheduledJob? = nil
 
@@ -28,7 +28,7 @@ class PushMetricRegistry: MetricRegistry, @unchecked Sendable {
     }
 
     final func start() {
-        lock.write { [weak self] in
+        publishingLock.write { [weak self] in
             guard let self = self else { return }
 
             if self.publishingJob != nil {
@@ -46,7 +46,7 @@ class PushMetricRegistry: MetricRegistry, @unchecked Sendable {
     }
 
     final func stop() {
-        lock.write { [weak self] in
+        publishingLock.write { [weak self] in
             self?.publishingJob?.cancel()
             self?.publishingJob = nil
             self?.publish()

--- a/Sources/Hackle/Core/Metrics/Push/PushMetricRegistry.swift
+++ b/Sources/Hackle/Core/Metrics/Push/PushMetricRegistry.swift
@@ -11,7 +11,7 @@ import UIKit
 
 class PushMetricRegistry: MetricRegistry, @unchecked Sendable {
 
-    private let publishingLock = ReadWriteLock(label: "io.hackle.PushMetricRegistry.Lock")
+    private let lock = ReadWriteLock(label: "io.hackle.PushMetricRegistry.Lock")
 
     private var publishingJob: ScheduledJob? = nil
 
@@ -28,7 +28,7 @@ class PushMetricRegistry: MetricRegistry, @unchecked Sendable {
     }
 
     final func start() {
-        publishingLock.write { [weak self] in
+        lock.write { [weak self] in
             guard let self = self else { return }
 
             if self.publishingJob != nil {
@@ -46,7 +46,7 @@ class PushMetricRegistry: MetricRegistry, @unchecked Sendable {
     }
 
     final func stop() {
-        publishingLock.write { [weak self] in
+        lock.write { [weak self] in
             self?.publishingJob?.cancel()
             self?.publishingJob = nil
             self?.publish()

--- a/Sources/Hackle/Core/Utilities/Concurrency/RecursiveLock.swift
+++ b/Sources/Hackle/Core/Utilities/Concurrency/RecursiveLock.swift
@@ -7,16 +7,16 @@ import Foundation
 
 final class RecursiveLock: @unchecked Sendable {
 
-    private let lock = NSRecursiveLock()
+    private let recursiveLock = NSRecursiveLock()
 
     init(label: String) {
-        lock.name = label
+        recursiveLock.name = label
     }
 
     @discardableResult
-    func locked<T>(_ block: () throws -> T) rethrows -> T {
-        lock.lock()
-        defer { lock.unlock() }
+    func lock<T>(_ block: () throws -> T) rethrows -> T {
+        recursiveLock.lock()
+        defer { recursiveLock.unlock() }
         return try block()
     }
 }

--- a/Sources/Hackle/Core/Utilities/Concurrency/RecursiveLock.swift
+++ b/Sources/Hackle/Core/Utilities/Concurrency/RecursiveLock.swift
@@ -1,0 +1,22 @@
+//
+//  RecursiveLock.swift
+//  Hackle
+//
+
+import Foundation
+
+final class RecursiveLock: @unchecked Sendable {
+
+    private let lock = NSRecursiveLock()
+
+    init(label: String) {
+        lock.name = label
+    }
+
+    @discardableResult
+    func locked<T>(_ block: () throws -> T) rethrows -> T {
+        lock.lock()
+        defer { lock.unlock() }
+        return try block()
+    }
+}

--- a/Tests/HackleTests/Core/Metrics/Delegate/DelegatingMetricRegistrySpecs.swift
+++ b/Tests/HackleTests/Core/Metrics/Delegate/DelegatingMetricRegistrySpecs.swift
@@ -73,6 +73,25 @@ class DelegatingMetricRegistrySpecs: QuickSpec {
 
                 expect(cumulative.counter(name: "counter").count()) == 1
             }
+
+            it("재진입 — sub-registry add 후 timer 생성이 hang 없이 완료") {
+                // addRegistries는 getOrCreateMetric의 lock 보유 상태에서 호출된다.
+                // RecursiveLock이 아닌 mutex/RW lock으로 회귀하면 이 호출은 deadlock된다.
+                // DispatchSemaphore로 hang을 명시적으로 감지한다.
+                let delegating = DelegatingMetricRegistry()
+                delegating.add(registry: CumulativeMetricRegistry())
+                delegating.add(registry: CumulativeMetricRegistry())
+
+                let done = DispatchSemaphore(value: 0)
+                DispatchQueue.global(qos: .utility).async {
+                    _ = delegating.timer(name: "reentrant.timer")
+                    _ = delegating.counter(name: "reentrant.counter")
+                    done.signal()
+                }
+
+                let result = done.wait(timeout: .now() + 2.0)
+                expect(result) == .success
+            }
         }
         
         it("concurrency") {

--- a/Tests/HackleTests/Core/Metrics/Delegate/DelegatingMetricRegistrySpecs.swift
+++ b/Tests/HackleTests/Core/Metrics/Delegate/DelegatingMetricRegistrySpecs.swift
@@ -89,7 +89,7 @@ class DelegatingMetricRegistrySpecs: QuickSpec {
                     done.signal()
                 }
 
-                let result = done.wait(timeout: .now() + 2.0)
+                let result = done.wait(timeout: .now() + 10.0)
                 expect(result) == .success
             }
         }

--- a/Tests/HackleTests/Core/Metrics/MetricsRaceSpecs.swift
+++ b/Tests/HackleTests/Core/Metrics/MetricsRaceSpecs.swift
@@ -1,0 +1,44 @@
+//
+//  MetricsRaceSpecs.swift
+//  Hackle
+//
+//  Created by sungwoo.yeo on 5/20/26.
+//
+
+import Foundation
+import Quick
+import Nimble
+@testable import Hackle
+
+class MetricsRaceSpecs: QuickSpec {
+    override class func spec() {
+        it("test") {
+            let q1 = DispatchQueue.concurrent()
+            let q2 = DispatchQueue.concurrent()
+
+            let global = DelegatingMetricRegistry()
+            let registry = CumulativeMetricRegistry()
+            global.add(registry: registry)
+
+            q1.async {
+                print("read start")
+                for _ in 0..<1000 {
+                    let _ = registry.metrics
+                }
+                print("read end")
+            }
+
+            q2.async {
+                print("write start")
+                for it in 0..<1000 {
+                    let _ = global.counter(name: String(it))
+                }
+                print("write end")
+            }
+
+            q1.await()
+            q2.await()
+        }
+        
+    }
+}

--- a/Tests/HackleTests/Core/Utilities/Concurrency/RecursiveLockSpecs.swift
+++ b/Tests/HackleTests/Core/Utilities/Concurrency/RecursiveLockSpecs.swift
@@ -1,0 +1,57 @@
+import Foundation
+import Quick
+import Nimble
+@testable import Hackle
+
+
+class RecursiveLockSpecs: QuickSpec {
+    override class func spec() {
+
+        it("같은 스레드에서 재진입해도 deadlock 없이 통과한다") {
+            let lock = RecursiveLock(label: "io.hackle.test.RecursiveLock")
+
+            let result: Int = lock.locked {
+                return lock.locked {
+                    return lock.locked {
+                        return 42
+                    }
+                }
+            }
+
+            expect(result) == 42
+        }
+
+        it("throw하면 unlock 후 에러 전파") {
+            let lock = RecursiveLock(label: "io.hackle.test.RecursiveLock")
+
+            struct E: Error {}
+            expect {
+                try lock.locked { throw E() }
+            }.to(throwError())
+
+            // 같은 lock을 다시 사용해도 정상 동작 (unlock 보장)
+            let value: Int = lock.locked { 1 }
+            expect(value) == 1
+        }
+
+        it("다른 스레드에서 mutual exclusion") {
+            let lock = RecursiveLock(label: "io.hackle.test.RecursiveLock")
+            var counter = 0
+            let iterations = 1000
+            let group = DispatchGroup()
+
+            for _ in 0..<4 {
+                DispatchQueue.global(qos: .utility).async(group: group) {
+                    for _ in 0..<iterations {
+                        lock.locked {
+                            counter += 1
+                        }
+                    }
+                }
+            }
+
+            group.wait()
+            expect(counter) == 4 * iterations
+        }
+    }
+}

--- a/Tests/HackleTests/Core/Utilities/Concurrency/RecursiveLockSpecs.swift
+++ b/Tests/HackleTests/Core/Utilities/Concurrency/RecursiveLockSpecs.swift
@@ -8,11 +8,11 @@ class RecursiveLockSpecs: QuickSpec {
     override class func spec() {
 
         it("같은 스레드에서 재진입해도 deadlock 없이 통과한다") {
-            let lock = RecursiveLock(label: "io.hackle.test.RecursiveLock")
+            let recursiveLock = RecursiveLock(label: "io.hackle.test.RecursiveLock")
 
-            let result: Int = lock.locked {
-                return lock.locked {
-                    return lock.locked {
+            let result: Int = recursiveLock.lock {
+                return recursiveLock.lock {
+                    return recursiveLock.lock {
                         return 42
                     }
                 }
@@ -26,11 +26,11 @@ class RecursiveLockSpecs: QuickSpec {
 
             struct E: Error {}
             expect {
-                try lock.locked { throw E() }
+                try lock.lock { throw E() }
             }.to(throwError())
 
             // 같은 lock을 다시 사용해도 정상 동작 (unlock 보장)
-            let value: Int = lock.locked { 1 }
+            let value: Int = lock.lock { 1 }
             expect(value) == 1
         }
 
@@ -43,7 +43,7 @@ class RecursiveLockSpecs: QuickSpec {
             for _ in 0..<4 {
                 DispatchQueue.global(qos: .utility).async(group: group) {
                     for _ in 0..<iterations {
-                        lock.locked {
+                        lock.lock {
                             counter += 1
                         }
                     }


### PR DESCRIPTION
## 개요
메트릭 도메인의 락 모델을 `NSRecursiveLock` 기반(`RecursiveLock`)으로 통합하여 단순화합니다.

## 주요 변경사항

| 카테고리 | 내용 |
|----------|------|
| `RecursiveLock` 추가  | `NSRecursiveLock` thin wrapper 신규 추가 |
| 도메인 통합 | `MetricRegistry`의 `_lock` 제거, `recursiveLock`을 internal로 노출하여 서브클래스가 동일 락 도메인 사용 |
| `getOrCreateMetric` 단순화 | `var metric: Metric!` out-of-block 패턴 제거, 단일 `recursiveLock.lock` 블록 내에서 lookup + create + insert + return |
| `addRegistries(metric:)` | `registries` 순회를 `recursiveLock.lock` 블록 안으로 이동(부모 락 안에서 호출되므로 RecursiveLock 필요) |
| `add(registry:)` atomicity | insert 후 락 해제, 별도 `metrics` 락으로 iterate하던 split 패턴을 단일 락 블록으로 통합 |
| `DelegatingCounter`/`DelegatingTimer` | 각자 `ReadWriteLock` → `RecursiveLock`, `read`/`write` 분리 제거 |
