### PR TITLE
fix: prevent TimerSample underflow crash

### DIFF
--- a/Hackle.xcodeproj/project.pbxproj
+++ b/Hackle.xcodeproj/project.pbxproj
@@ -348,6 +348,7 @@
 		EE29DA4E29CD82C200B1FEAA /* murmur_numeric.csv in Resources */ = {isa = PBXBuildFile; fileRef = EE29D9C929CD82C100B1FEAA /* murmur_numeric.csv */; };
 		EE29DA4F29CD82C200B1FEAA /* bucketing_alphanumeric.csv in Resources */ = {isa = PBXBuildFile; fileRef = EE29D9CA29CD82C100B1FEAA /* bucketing_alphanumeric.csv */; };
 		EE29DA5029CD82C200B1FEAA /* TimerSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE29D9CD29CD82C100B1FEAA /* TimerSpecs.swift */; };
+		3C9570AE1B46AD3387FD3CF5 /* TimerSampleClockUnderflowSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22EB8D35DFE5D41D9C99D864 /* TimerSampleClockUnderflowSpecs.swift */; };
 		EE29DA5129CD82C200B1FEAA /* NoopTimerSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE29D9CF29CD82C100B1FEAA /* NoopTimerSpecs.swift */; };
 		EE29DA5229CD82C200B1FEAA /* NoopCounterSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE29D9D029CD82C100B1FEAA /* NoopCounterSpecs.swift */; };
 		EE29DA5329CD82C200B1FEAA /* FlushCounterSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE29D9D229CD82C100B1FEAA /* FlushCounterSpecs.swift */; };
@@ -1087,6 +1088,7 @@
 		EE29D9C929CD82C100B1FEAA /* murmur_numeric.csv */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = murmur_numeric.csv; sourceTree = "<group>"; };
 		EE29D9CA29CD82C100B1FEAA /* bucketing_alphanumeric.csv */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = bucketing_alphanumeric.csv; sourceTree = "<group>"; };
 		EE29D9CD29CD82C100B1FEAA /* TimerSpecs.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TimerSpecs.swift; sourceTree = "<group>"; };
+		22EB8D35DFE5D41D9C99D864 /* TimerSampleClockUnderflowSpecs.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TimerSampleClockUnderflowSpecs.swift; sourceTree = "<group>"; };
 		EE29D9CF29CD82C100B1FEAA /* NoopTimerSpecs.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NoopTimerSpecs.swift; sourceTree = "<group>"; };
 		EE29D9D029CD82C100B1FEAA /* NoopCounterSpecs.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NoopCounterSpecs.swift; sourceTree = "<group>"; };
 		EE29D9D229CD82C100B1FEAA /* FlushCounterSpecs.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FlushCounterSpecs.swift; sourceTree = "<group>"; };
@@ -2549,6 +2551,7 @@
 				EE29D9DF29CD82C100B1FEAA /* Cumulative */,
 				EE29D9DB29CD82C100B1FEAA /* CounterSpecs.swift */,
 				EE29D9CD29CD82C100B1FEAA /* TimerSpecs.swift */,
+				22EB8D35DFE5D41D9C99D864 /* TimerSampleClockUnderflowSpecs.swift */,
 				EE29D9D529CD82C100B1FEAA /* MetricFieldSpecs.swift */,
 				EE29D9D629CD82C100B1FEAA /* HackleTimer.swift */,
 				EE29D9E329CD82C100B1FEAA /* MetricSpecs.swift */,
@@ -4461,6 +4464,7 @@
 				EE4D044E2E5DAB05007BE61A /* MockInAppMessageScheduler.swift in Sources */,
 				B29C536B2DCB3820001724B2 /* HacklePushSubscriptionStatusSpecs.swift in Sources */,
 				EE29DA5029CD82C200B1FEAA /* TimerSpecs.swift in Sources */,
+				3C9570AE1B46AD3387FD3CF5 /* TimerSampleClockUnderflowSpecs.swift in Sources */,
 				EE29DA3D29CD82C200B1FEAA /* MockWorkspace.swift in Sources */,
 				B21A14952E9E24E80088EBEC /* SessionUserDecoratorSpecs.swift in Sources */,
 				EEFA31E82BC18E0F00E133F8 /* MockUserEventDedupDeterminer.swift in Sources */,

--- a/Sources/Hackle/Core/Metrics/Timer.swift
+++ b/Sources/Hackle/Core/Metrics/Timer.swift
@@ -79,7 +79,11 @@ class TimerSample {
     }
 
     func stop(timer: Timer) {
-        let durationNanos = Double(clock.tick() - startTick)
+        let endTick = clock.tick()
+        // Defensive guard for non-monotonic Clock implementations:
+        // UInt64 subtraction would otherwise trap on underflow.
+        guard endTick >= startTick else { return }
+        let durationNanos = Double(endTick - startTick)
         timer.record(amount: durationNanos, unit: .nanoseconds)
     }
 }

--- a/Sources/Hackle/Core/Utilities/Time/Clock.swift
+++ b/Sources/Hackle/Core/Utilities/Time/Clock.swift
@@ -30,6 +30,6 @@ final class SystemClock: Clock, Sendable {
     }
 
     func tick() -> UInt64 {
-        UInt64(Date().timeIntervalSince1970 * 1000 * 1000 * 1000)
+        DispatchTime.now().uptimeNanoseconds
     }
 }

--- a/Tests/HackleTests/Core/Metrics/TimerSampleClockUnderflowSpecs.swift
+++ b/Tests/HackleTests/Core/Metrics/TimerSampleClockUnderflowSpecs.swift
@@ -1,0 +1,66 @@
+import Foundation
+import Quick
+import Nimble
+@testable import Hackle
+
+
+/// Regression guard for the metric crash (EXC_BREAKPOINT / SIGTRAP).
+///
+/// Background: a `Clock` whose `tick()` is wall-clock based (e.g. NTP step-adjust,
+/// user changing system time) can return a smaller value on the second call.
+/// `Double(clock.tick() - startTick)` then performs a `UInt64` subtraction that
+/// traps with "Swift runtime failure: arithmetic overflow".
+///
+/// `TimerSample.stop` must tolerate that scenario without trapping.
+class TimerSampleClockUnderflowSpecs: QuickSpec {
+    override class func spec() {
+
+        describe("TimerSample.stop with a backwards-moving clock") {
+
+            it("does not trap and skips recording when stop tick < start tick") {
+                // First tick: T0. Second tick: T0 - 500ms (clock moved backwards).
+                let backwards = BackwardsClock(
+                    ticks: [
+                        1_000_000_000_000,
+                        999_500_000_000
+                    ]
+                )
+
+                let sample = TimerSample.start(clock: backwards)
+                let timer = CumulativeMetricRegistry().timer(name: "underflow.repro")
+
+                sample.stop(timer: timer)
+
+                expect(timer.count()) == 0
+            }
+
+            it("records zero duration when stop tick == start tick") {
+                let same = BackwardsClock(ticks: [1_000, 1_000])
+
+                let sample = TimerSample.start(clock: same)
+                let timer = CumulativeMetricRegistry().timer(name: "equal.tick")
+
+                sample.stop(timer: timer)
+
+                expect(timer.count()) == 1
+                expect(timer.totalTime(unit: .nanoseconds)) == 0.0
+            }
+        }
+    }
+}
+
+private final class BackwardsClock: Clock {
+    private var queue: [UInt64]
+
+    init(ticks: [UInt64]) {
+        self.queue = ticks
+    }
+
+    func now() -> Date { Date() }
+    func currentMillis() -> Int64 { 0 }
+
+    func tick() -> UInt64 {
+        precondition(!queue.isEmpty, "BackwardsClock ran out of scripted ticks")
+        return queue.removeFirst()
+    }
+}


### PR DESCRIPTION
## 개요
`TimerSample.stop`에서 clock tick이 시작 시점보다 작아질 때 `UInt64` subtraction underflow로 crash가 발생할 수 있는 문제를 수정합니다.
`SystemClock.tick()`을 wall-clock 기반 `Date` 대신 monotonic clock인 `DispatchTime.now().uptimeNanoseconds` 기준으로 변경했습니다.

## 작업 내용
- `TimerSample.stop`에서 종료 tick이 시작 tick보다 작으면 기록을 건너뛰도록 방어 로직 추가
- `SystemClock.tick()`을 monotonic nanoseconds 기반으로 변경
- clock이 역행하는 경우 crash 없이 기록을 skip하는 회귀 테스트 추가
- 신규 테스트 파일을 `Hackle.xcodeproj`에 등록