### PR TITLE
fix: protect DefaultUserManager.toHackleUser context read against data race

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -106,5 +106,6 @@ jobs:
                 -only-testing:HackleTests/AtomicReferenceRaceSpecs \
                 -only-testing:HackleTests/DelegatingMetricRegistrySpecs/concurrency \
                 -only-testing:HackleTests/MetricsRaceSpecs \
+                -only-testing:HackleTests/UserManagerRaceSpecs \
                 -parallel-testing-enabled NO \
                 | xcbeautify --renderer github-actions --quiet

--- a/Hackle.xcodeproj/project.pbxproj
+++ b/Hackle.xcodeproj/project.pbxproj
@@ -133,6 +133,7 @@
 		B290E6622D55DF9700F68D35 /* workspace_target.json in Resources */ = {isa = PBXBuildFile; fileRef = B290E6612D55DF9700F68D35 /* workspace_target.json */; };
 		B2931DE82DFFB45300E5931E /* dto.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2931DE72DFFB45200E5931E /* dto.swift */; };
 		B2931DEA2DFFBEA500E5931E /* DefaultUserDtoSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2931DE92DFFBE9A00E5931E /* DefaultUserDtoSpecs.swift */; };
+		EE29DA9929CD82C200B1FE02 /* UserManagerRaceSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE29DA9929CD82C200B1FE01 /* UserManagerRaceSpecs.swift */; };
 		B2931DEC2DFFF15200E5931E /* HackleSubscriptionStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2931DEB2DFFF14200E5931E /* HackleSubscriptionStatus.swift */; };
 		B29C53562DCB1FA9001724B2 /* ConcurrentArraySpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = B29C53552DCB1F9F001724B2 /* ConcurrentArraySpecs.swift */; };
 		B29C53582DCB23C8001724B2 /* NotificationDataReceiverSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = B29C53572DCB23BB001724B2 /* NotificationDataReceiverSpecs.swift */; };
@@ -873,6 +874,7 @@
 		B290E6612D55DF9700F68D35 /* workspace_target.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = workspace_target.json; sourceTree = "<group>"; };
 		B2931DE72DFFB45200E5931E /* dto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = dto.swift; sourceTree = "<group>"; };
 		B2931DE92DFFBE9A00E5931E /* DefaultUserDtoSpecs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultUserDtoSpecs.swift; sourceTree = "<group>"; };
+		EE29DA9929CD82C200B1FE01 /* UserManagerRaceSpecs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserManagerRaceSpecs.swift; sourceTree = "<group>"; };
 		B2931DEB2DFFF14200E5931E /* HackleSubscriptionStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HackleSubscriptionStatus.swift; sourceTree = "<group>"; };
 		B29C53552DCB1F9F001724B2 /* ConcurrentArraySpecs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConcurrentArraySpecs.swift; sourceTree = "<group>"; };
 		B29C53572DCB23BB001724B2 /* NotificationDataReceiverSpecs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationDataReceiverSpecs.swift; sourceTree = "<group>"; };
@@ -2652,6 +2654,7 @@
 				EE5A78E22ADCCD06005A0F9E /* DefaultUserCohortFetcherSpecs.swift */,
 				B290E65F2D55DE2200F68D35 /* DefaultUserTargetFetcherSpecs.swift */,
 				B2931DE92DFFBE9A00E5931E /* DefaultUserDtoSpecs.swift */,
+				EE29DA9929CD82C200B1FE01 /* UserManagerRaceSpecs.swift */,
 			);
 			path = User;
 			sourceTree = "<group>";
@@ -4383,6 +4386,7 @@
 				7E64779B2AD4F19D00971F20 /* HackleInvocationSpec.swift in Sources */,
 				EED6A1272A0E267D00A8875D /* PropertyOperatorSpecs.swift in Sources */,
 				B2931DEA2DFFBEA500E5931E /* DefaultUserDtoSpecs.swift in Sources */,
+				EE29DA9929CD82C200B1FE02 /* UserManagerRaceSpecs.swift in Sources */,
 				EE5A78FE2ADCF1B5005A0F9E /* MockUserListener.swift in Sources */,
 				EE29DA9129CD82C200B1FEAA /* MockBucketer.swift in Sources */,
 				7E3F4FCD2AA6FE7B004E0EB0 /* DeviceSpec.swift in Sources */,

--- a/Sources/Hackle/Core/User/UserManager.swift
+++ b/Sources/Hackle/Core/User/UserManager.swift
@@ -69,9 +69,7 @@ class DefaultUserManager: UserManager {
     }
 
     func addListener(listener: UserListener) {
-        recursiveLock.lock {
-            userListeners.append(listener)
-        }
+        userListeners.append(listener)
         Log.debug("UserListener added [\(listener)]")
     }
 

--- a/Sources/Hackle/Core/User/UserManager.swift
+++ b/Sources/Hackle/Core/User/UserManager.swift
@@ -33,7 +33,7 @@ protocol UserManager: Synchronizer {
 class DefaultUserManager: UserManager {
 
     private static let USER_KEY = "user"
-    private let lock = ReadWriteLock(label: "io.hackle.DefaultUserManager")
+    private let lock = RecursiveLock(label: "io.hackle.DefaultUserManager")
     private let dispatchQueue: DispatchQueue = DispatchQueue(label: "io.hackle.DefaultUserManager.dispatchQueue")
 
     private var userListeners: [UserListener]
@@ -48,7 +48,7 @@ class DefaultUserManager: UserManager {
     private var context: UserContext
 
     private var currentContext: UserContext {
-        lock.read {
+        lock.lock {
             context
         }
     }
@@ -69,12 +69,14 @@ class DefaultUserManager: UserManager {
     }
 
     func addListener(listener: UserListener) {
-        userListeners.append(listener)
+        lock.lock {
+            userListeners.append(listener)
+        }
         Log.debug("UserListener added [\(listener)]")
     }
 
     func initialize(user: User?) {
-        lock.write { [weak self] in
+        lock.lock { [weak self] in
             guard let self = self else {
                 Log.debug("UserManager instance deallocated")
                 return
@@ -92,14 +94,16 @@ class DefaultUserManager: UserManager {
             return toHackleUser(context: currentContext, hackleAppContext: hackleAppContext)
         }
 
-        let context = lock.write {
+        let context = lock.lock {
             updateUser(user: user)
         }
         return toHackleUser(context: context.current, hackleAppContext: hackleAppContext)
     }
 
     func toHackleUser(user: User) -> HackleUser {
-        let context = context.with(user: user)
+        let context = lock.lock {
+            self.context.with(user: user)
+        }
         return toHackleUser(context: context, hackleAppContext: .default)
     }
 
@@ -220,7 +224,7 @@ class DefaultUserManager: UserManager {
     private func handle(result: Result<UserCohorts, Error>, completion: @escaping (Result<(), Error>) -> ()) {
         switch result {
         case .success(let cohorts):
-            lock.write {
+            lock.lock {
                 context = context.update(cohorts: cohorts)
             }
             completion(.success(()))
@@ -234,7 +238,7 @@ class DefaultUserManager: UserManager {
     private func handle(result: Result<UserTargetEvents, Error>, completion: @escaping (Result<(), Error>) -> ()) {
         switch result {
         case .success(let target):
-            lock.write {
+            lock.lock {
                 context = context.update(targetEvents: target)
             }
             completion(.success(()))
@@ -248,7 +252,7 @@ class DefaultUserManager: UserManager {
     // User update
 
     func setUser(user: User) -> Updated<User> {
-        lock.write {
+        lock.lock {
             updateUser(user: user).map { it in
                 it.user
             }
@@ -256,7 +260,7 @@ class DefaultUserManager: UserManager {
     }
 
     func setUserId(userId: String?) -> Updated<User> {
-        lock.write {
+        lock.lock {
             updateUser(user: context.user.toBuilder().userId(userId).build()).map { it in
                 it.user
             }
@@ -264,7 +268,7 @@ class DefaultUserManager: UserManager {
     }
 
     func setDeviceId(deviceId: String) -> Updated<User> {
-        lock.write {
+        lock.lock {
             updateUser(user: context.user.toBuilder().deviceId(deviceId).build()).map { it in
                 it.user
             }
@@ -272,7 +276,7 @@ class DefaultUserManager: UserManager {
     }
 
     func resetUser() -> Updated<User> {
-        lock.write {
+        lock.lock {
             let context = updateContext { _ in
                 defaultUser
             }
@@ -283,7 +287,7 @@ class DefaultUserManager: UserManager {
     }
 
     func updateProperties(operations: PropertyOperations) -> Updated<User> {
-        lock.write {
+        lock.lock {
             operateProperties(operations: operations).map { it in
                 it.user
             }

--- a/Sources/Hackle/Core/User/UserManager.swift
+++ b/Sources/Hackle/Core/User/UserManager.swift
@@ -33,7 +33,7 @@ protocol UserManager: Synchronizer {
 class DefaultUserManager: UserManager {
 
     private static let USER_KEY = "user"
-    private let lock = RecursiveLock(label: "io.hackle.DefaultUserManager")
+    private let recursiveLock = RecursiveLock(label: "io.hackle.DefaultUserManager")
     private let dispatchQueue: DispatchQueue = DispatchQueue(label: "io.hackle.DefaultUserManager.dispatchQueue")
 
     private var userListeners: [UserListener]
@@ -48,7 +48,7 @@ class DefaultUserManager: UserManager {
     private var context: UserContext
 
     private var currentContext: UserContext {
-        lock.lock {
+        recursiveLock.lock {
             context
         }
     }
@@ -69,14 +69,14 @@ class DefaultUserManager: UserManager {
     }
 
     func addListener(listener: UserListener) {
-        lock.lock {
+        recursiveLock.lock {
             userListeners.append(listener)
         }
         Log.debug("UserListener added [\(listener)]")
     }
 
     func initialize(user: User?) {
-        lock.lock { [weak self] in
+        recursiveLock.lock { [weak self] in
             guard let self = self else {
                 Log.debug("UserManager instance deallocated")
                 return
@@ -94,14 +94,14 @@ class DefaultUserManager: UserManager {
             return toHackleUser(context: currentContext, hackleAppContext: hackleAppContext)
         }
 
-        let context = lock.lock {
+        let context = recursiveLock.lock {
             updateUser(user: user)
         }
         return toHackleUser(context: context.current, hackleAppContext: hackleAppContext)
     }
 
     func toHackleUser(user: User) -> HackleUser {
-        let context = lock.lock {
+        let context = recursiveLock.lock {
             self.context.with(user: user)
         }
         return toHackleUser(context: context, hackleAppContext: .default)
@@ -224,7 +224,7 @@ class DefaultUserManager: UserManager {
     private func handle(result: Result<UserCohorts, Error>, completion: @escaping (Result<(), Error>) -> ()) {
         switch result {
         case .success(let cohorts):
-            lock.lock {
+            recursiveLock.lock {
                 context = context.update(cohorts: cohorts)
             }
             completion(.success(()))
@@ -238,7 +238,7 @@ class DefaultUserManager: UserManager {
     private func handle(result: Result<UserTargetEvents, Error>, completion: @escaping (Result<(), Error>) -> ()) {
         switch result {
         case .success(let target):
-            lock.lock {
+            recursiveLock.lock {
                 context = context.update(targetEvents: target)
             }
             completion(.success(()))
@@ -252,7 +252,7 @@ class DefaultUserManager: UserManager {
     // User update
 
     func setUser(user: User) -> Updated<User> {
-        lock.lock {
+        recursiveLock.lock {
             updateUser(user: user).map { it in
                 it.user
             }
@@ -260,7 +260,7 @@ class DefaultUserManager: UserManager {
     }
 
     func setUserId(userId: String?) -> Updated<User> {
-        lock.lock {
+        recursiveLock.lock {
             updateUser(user: context.user.toBuilder().userId(userId).build()).map { it in
                 it.user
             }
@@ -268,7 +268,7 @@ class DefaultUserManager: UserManager {
     }
 
     func setDeviceId(deviceId: String) -> Updated<User> {
-        lock.lock {
+        recursiveLock.lock {
             updateUser(user: context.user.toBuilder().deviceId(deviceId).build()).map { it in
                 it.user
             }
@@ -276,7 +276,7 @@ class DefaultUserManager: UserManager {
     }
 
     func resetUser() -> Updated<User> {
-        lock.lock {
+        recursiveLock.lock {
             let context = updateContext { _ in
                 defaultUser
             }
@@ -287,7 +287,7 @@ class DefaultUserManager: UserManager {
     }
 
     func updateProperties(operations: PropertyOperations) -> Updated<User> {
-        lock.lock {
+        recursiveLock.lock {
             operateProperties(operations: operations).map { it in
                 it.user
             }

--- a/Tests/HackleTests/Core/User/DefaultUserManagerSpecs.swift
+++ b/Tests/HackleTests/Core/User/DefaultUserManagerSpecs.swift
@@ -984,5 +984,38 @@ class DefaultUserManagerSpecs: QuickSpec {
                 expect(repository.getData(key: "user")).notTo(beNil())
             }
         }
+
+        // setUser -> changeUser -> SessionManager -> SessionEventTracker -> toHackleUser(user:) 재진입 체인.
+        // 비재진입 lock이면 deadlock한다.
+        describe("re-entrant lock") {
+            it("listener가 onUserUpdated에서 toHackleUser를 재호출해도 deadlock 없이 완료된다") {
+                let reentrant = ReentrantUserListener(userManager: sut)
+                sut.addListener(listener: reentrant)
+                sut.initialize(user: nil)
+
+                let done = DispatchSemaphore(value: 0)
+                DispatchQueue.global().async {
+                    _ = sut.setUser(user: User.builder().userId("user_id").build())
+                    done.signal()
+                }
+
+                expect(done.wait(timeout: .now() + 3)) == DispatchTimeoutResult.success
+                expect(reentrant.reentrantUser?.identifiers["$userId"]) == "user_id"
+            }
+        }
+    }
+}
+
+// onUserUpdated 시점에 toHackleUser(user:)를 재호출해 lock 재진입을 유발하는 테스트 전용 listener.
+fileprivate class ReentrantUserListener: UserListener {
+    private weak var userManager: DefaultUserManager?
+    private(set) var reentrantUser: HackleUser?
+
+    init(userManager: DefaultUserManager) {
+        self.userManager = userManager
+    }
+
+    func onUserUpdated(oldUser: User, newUser: User, timestamp: Date) {
+        reentrantUser = userManager?.toHackleUser(user: newUser)
     }
 }

--- a/Tests/HackleTests/Core/User/UserManagerRaceSpecs.swift
+++ b/Tests/HackleTests/Core/User/UserManagerRaceSpecs.swift
@@ -1,0 +1,65 @@
+import Foundation
+import Quick
+import Nimble
+import MockingKit
+@testable import Hackle
+
+
+/// DefaultUserManager.context에 대한 data race 재현 스펙.
+/// -enableThreadSanitizer YES 로 실행할 것.
+class UserManagerRaceSpecs: QuickSpec {
+    override class func spec() {
+
+        it("DefaultUserManager: concurrent context write (background sync) vs read (toHackleUser/currentUser)") {
+            let repository = MemoryKeyValueRepository()
+            let cohortFetcher = MockUserCohortFetcher()
+            let targetFetcher = MockUserTargetFetcher()
+            let clock = FixedClock(date: Date(timeIntervalSince1970: 42))
+            let deviceImpl = DeviceImpl(deviceId: "hackle_device_id")
+            MainActor.assumeIsolated { deviceImpl.initialize() }
+            let bundleInfo = BundleInfoImpl()
+            let sut = DefaultUserManager(
+                device: deviceImpl,
+                bundleInfo: bundleInfo,
+                repository: repository,
+                cohortFetcher: cohortFetcher,
+                targetFetcher: targetFetcher,
+                clock: clock
+            )
+            every(cohortFetcher.fetchMock).answers { _, completion in
+                completion(.success(UserCohorts()))
+            }
+            every(targetFetcher.fetchMock).answers { _, completion in
+                completion(.success(UserTargetEvents()))
+            }
+            sut.initialize(user: User.builder().id("id").build())
+
+            let writerIterations = 2_000
+            let readerCount = 4
+            let readerIterations = 15_000
+            let group = DispatchGroup()
+
+            DispatchQueue.global(qos: .utility).async(group: group) {
+                for _ in 0..<writerIterations {
+                    let sem = DispatchSemaphore(value: 0)
+                    sut.sync { sem.signal() }
+                    sem.wait()
+                }
+            }
+
+            for _ in 0..<readerCount {
+                DispatchQueue.global(qos: .utility).async(group: group) {
+                    for i in 0..<readerIterations {
+                        _ = sut.toHackleUser(user: User.builder().id("r-\(i)").build())
+                        _ = sut.currentUser
+                        _ = sut.resolve(user: nil, hackleAppContext: .default)
+                    }
+                }
+            }
+
+            group.wait()
+
+            expect(sut.currentUser.id) == "id"
+        }
+    }
+}


### PR DESCRIPTION
## 개요

`DefaultUserManager.context`에 대한 data race를 제거합니다.

`context`에 접근하는 다른 경로(`currentContext`, `resolve`, `handle`, `setUser` 계열 등)는 모두 lock으로 보호되어 있었으나, `toHackleUser(user:)`만 lock 없이 `context`를 읽고 있었습니다.

백그라운드 sync 완료 시 `handle()`이 lock을 잡고 `context`를 write하는 동안, 이벤트 트래킹 경로(`SessionEventTracker.track` → `toHackleUser(user:)`)가 lock 없이 같은 `context`를 read하면서 발생하는 race입니다. `UserContext` 내부에 Dictionary/Array storage가 있어 torn read가 가능합니다.

## 변경 사항

- `toHackleUser(user:)`의 `context` read를 lock으로 보호 (실제 race fix 지점)
- `ReadWriteLock` → `RecursiveLock`(NSRecursiveLock 기반) 교체
  - `setUser` → `changeUser` → `SessionManager.onUserUpdated` → `SessionEventTracker.onSessionStarted` → `toHackleUser(user:)` 재진입 체인에서 **같은 스레드가 lock을 재획득**합니다.
  - `toHackleUser`의 read를 lock으로 감싸는 순간 이 체인은 비재진입 lock이면 deadlock하므로, 재진입 가능한 lock으로 교체했습니다.

## 테스트

- ThreadSanitizer로 race를 재현/검증하는 `UserManagerRaceSpecs` 추가 및 CI(test.yml) TSan 잡에 등록
- 재진입 체인에서 deadlock이 없음을 검증하는 테스트(`DefaultUserManagerSpecs`의 re-entrant lock) 추가
