### PR TITLE
Fix/loadimage retain cycle

### DIFF
--- a/Sources/Hackle/UI/InAppMessageUI/Views/Banner/InAppMessageUIBannerImageView.swift
+++ b/Sources/Hackle/UI/InAppMessageUI/Views/Banner/InAppMessageUIBannerImageView.swift
@@ -52,8 +52,8 @@ extension HackleInAppMessageUI {
             guard let imageView = imageView, let image = context.message.image(orientation: attributes.orientation) else {
                 return
             }
-            imageView.loadImage(url: image.imagePath) {
-                self.layoutContent()
+            imageView.loadImage(url: image.imagePath) { [weak self] in
+                self?.layoutContent()
             }
         }
 

--- a/Sources/Hackle/UI/InAppMessageUI/Views/Banner/InAppMessageUIBannerView.swift
+++ b/Sources/Hackle/UI/InAppMessageUI/Views/Banner/InAppMessageUIBannerView.swift
@@ -57,8 +57,8 @@ extension HackleInAppMessageUI {
             guard let imageView = imageView, let image = context.message.image(orientation: attributes.orientation) else {
                 return
             }
-            imageView.loadImage(url: image.imagePath) {
-                self.layoutContent()
+            imageView.loadImage(url: image.imagePath) { [weak self] in
+                self?.layoutContent()
             }
         }
 

--- a/Sources/Hackle/UI/InAppMessageUI/Views/InAppMessageUIScrollImageView.swift
+++ b/Sources/Hackle/UI/InAppMessageUI/Views/InAppMessageUIScrollImageView.swift
@@ -208,8 +208,8 @@ extension HackleInAppMessageUI {
             }
 
             func configure(image: InAppMessage.Message.Image) {
-                imageView.loadImage(url: image.imagePath) {
-                    self.layout()
+                imageView.loadImage(url: image.imagePath) { [weak self] in
+                    self?.layout()
                 }
             }
 

--- a/Sources/Hackle/UI/Internal/UIKitExt.swift
+++ b/Sources/Hackle/UI/Internal/UIKitExt.swift
@@ -66,13 +66,16 @@ extension UIImageView {
             return
         }
 
-        URLSession.shared.dataTask(with: url) { data, response, error in
+        URLSession.shared.dataTask(with: url) { [weak self] data, response, error in
                 if let error = error {
                     Log.error("Failed to load image [\(url)]: \(error)")
                     return
                 }
 
                 DispatchQueue.main.async {
+                    guard let self = self else {
+                        return
+                    }
                     if let data = data, let image = UIImage(data: data) {
                         ImageCacheManager.shared.setObject(image, forKey: cacheKey)
                         self.image = image

--- a/Sources/Hackle/UI/Internal/UIKitExt.swift
+++ b/Sources/Hackle/UI/Internal/UIKitExt.swift
@@ -73,11 +73,11 @@ extension UIImageView {
                 }
 
                 DispatchQueue.main.async {
-                    guard let self = self else {
-                        return
-                    }
                     if let data = data, let image = UIImage(data: data) {
                         ImageCacheManager.shared.setObject(image, forKey: cacheKey)
+                        guard let self = self else {
+                            return
+                        }
                         self.image = image
                         completion?()
                     }


### PR DESCRIPTION
## 개요
InAppMessage 이미지 로딩 완료 클로저에서 owner view를 강하게 캡처하지 않도록 수정합니다.
`UIImageView.loadImage` 내부에서도 `self`를 weak capture 하되, 다운로드한 이미지는 view 생존 여부와 관계없이 캐시에 저장되도록 유지했습니다.

## 작업 내용
- 배너/스크롤 InAppMessage 이미지 로딩 completion에서 `[weak self]` 적용
- `UIImageView.loadImage`의 URLSession completion에서 `[weak self]` 적용
- image cache 저장 후 view가 해제된 경우 UI 업데이트만 건너뛰도록 변경