### PR TITLE
feat: add load timeout for HTML in-app message view

### DIFF
--- a/Hackle.xcodeproj/project.pbxproj
+++ b/Hackle.xcodeproj/project.pbxproj
@@ -603,6 +603,7 @@
 		EE7BC0222F71812E0017BE4E /* hackle-javascript-sdk-11.56.0.min.js in Resources */ = {isa = PBXBuildFile; fileRef = EE7BC0212F71812E0017BE4E /* hackle-javascript-sdk-11.56.0.min.js */; };
 		EE7BC0242F7226370017BE4E /* WebViewResourceLoaderSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE7BC0232F7226370017BE4E /* WebViewResourceLoaderSpecs.swift */; };
 		EE7BC0262F7228A20017BE4E /* HtmlViewBridgeScriptSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE7BC0252F7228A20017BE4E /* HtmlViewBridgeScriptSpecs.swift */; };
+		AA0001112F9000AA0017BE4E /* InAppMessageUIHtmlViewSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0000002F9000AA0017BE4E /* InAppMessageUIHtmlViewSpecs.swift */; };
 		EE80378829D3DB04000DC77E /* HackleAbTestItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE80378729D3DB04000DC77E /* HackleAbTestItem.swift */; };
 		EE80DF852A27836600FB12CC /* InAppMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE80DF842A27836600FB12CC /* InAppMessage.swift */; };
 		EE80DF902A285B2600FB12CC /* EvaluationContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE80DF8F2A285B2600FB12CC /* EvaluationContext.swift */; };
@@ -1343,6 +1344,7 @@
 		EE7BC0212F71812E0017BE4E /* hackle-javascript-sdk-11.56.0.min.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = "hackle-javascript-sdk-11.56.0.min.js"; sourceTree = "<group>"; };
 		EE7BC0232F7226370017BE4E /* WebViewResourceLoaderSpecs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewResourceLoaderSpecs.swift; sourceTree = "<group>"; };
 		EE7BC0252F7228A20017BE4E /* HtmlViewBridgeScriptSpecs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HtmlViewBridgeScriptSpecs.swift; sourceTree = "<group>"; };
+		AA0000002F9000AA0017BE4E /* InAppMessageUIHtmlViewSpecs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppMessageUIHtmlViewSpecs.swift; sourceTree = "<group>"; };
 		EE80378729D3DB04000DC77E /* HackleAbTestItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HackleAbTestItem.swift; sourceTree = "<group>"; };
 		EE80DF842A27836600FB12CC /* InAppMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppMessage.swift; sourceTree = "<group>"; };
 		EE80DF8F2A285B2600FB12CC /* EvaluationContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EvaluationContext.swift; sourceTree = "<group>"; };
@@ -1885,6 +1887,7 @@
 			children = (
 				EE0202412F6A96D9002A8D4F /* MockInAppMessageHtmlContentResolverFactory.swift */,
 				EE7BC0252F7228A20017BE4E /* HtmlViewBridgeScriptSpecs.swift */,
+				AA0000002F9000AA0017BE4E /* InAppMessageUIHtmlViewSpecs.swift */,
 			);
 			path = Html;
 			sourceTree = "<group>";
@@ -4441,6 +4444,7 @@
 				EE55B4982F63C7F000A36359 /* MockInvocationHandler.swift in Sources */,
 				EE4D04742E5DCB96007BE61A /* MockInAppMessageTriggerProcessor.swift in Sources */,
 				EE7BC0262F7228A20017BE4E /* HtmlViewBridgeScriptSpecs.swift in Sources */,
+				AA0001112F9000AA0017BE4E /* InAppMessageUIHtmlViewSpecs.swift in Sources */,
 				EE4D03C22E5D57F7007BE61A /* MockInAppMessageIdentifierChecker.swift in Sources */,
 				EE5A78E32ADCCD06005A0F9E /* DefaultUserCohortFetcherSpecs.swift in Sources */,
 				B29C535A2DCB2621001724B2 /* NotificationHandlerSpecs.swift in Sources */,

--- a/Sources/Hackle/UI/InAppMessageUI/InAppMessageUIExt.swift
+++ b/Sources/Hackle/UI/InAppMessageUI/InAppMessageUIExt.swift
@@ -28,7 +28,8 @@ extension HackleInAppMessageUI {
                 return nil
             }
             let bridgeScript = HtmlViewBridgeScript.create(config: app.config)
-            return HtmlView(context: context, app: app, contentResolverFactory: htmlContentResolverFactory, bridgeScript: bridgeScript)
+            let scheduler = Schedulers.dispatch(queue: DispatchQueue(label: "io.hackle.scheduler.InAppMessageHtmlView"))
+            return HtmlView(context: context, app: app, contentResolverFactory: htmlContentResolverFactory, bridgeScript: bridgeScript, scheduler: scheduler)
         default:
             Log.error("Failed to create InAppMessageView [\(context.message.layout.displayType), \(context.message.layout.layoutType)]")
             return nil

--- a/Sources/Hackle/UI/InAppMessageUI/Views/Html/InAppMessageUIHtmlView.swift
+++ b/Sources/Hackle/UI/InAppMessageUI/Views/Html/InAppMessageUIHtmlView.swift
@@ -164,6 +164,7 @@ extension HackleInAppMessageUI {
         }
 
         func scheduleLoadTimeout() {
+            cancelLoadTimeout()
             loadTimeoutJob = scheduler.schedule(delay: Self.loadTimeout) { [weak self] in
                 Task { @MainActor in
                     self?.onLoadTimeout()

--- a/Sources/Hackle/UI/InAppMessageUI/Views/Html/InAppMessageUIHtmlView.swift
+++ b/Sources/Hackle/UI/InAppMessageUI/Views/Html/InAppMessageUIHtmlView.swift
@@ -9,17 +9,24 @@ extension HackleInAppMessageUI {
         private let app: HackleApp
         private let contentResolverFactory: InAppMessageHtmlContentResolverFactory
         private let bridgeScript: HtmlViewBridgeScript
+        private let scheduler: Scheduler
+
+        static let loadTimeout: TimeInterval = 30
+        private var loadTimeoutJob: ScheduledJob?
+        private(set) var isDismissed = false
 
         init(
             context: InAppMessagePresentationContext,
             app: HackleApp,
             contentResolverFactory: InAppMessageHtmlContentResolverFactory,
-            bridgeScript: HtmlViewBridgeScript
+            bridgeScript: HtmlViewBridgeScript,
+            scheduler: Scheduler
         ) {
             self.context = context
             self.app = app
             self.contentResolverFactory = contentResolverFactory
             self.bridgeScript = bridgeScript
+            self.scheduler = scheduler
             super.init(frame: .zero)
 
             alpha = 0
@@ -82,6 +89,12 @@ extension HackleInAppMessageUI {
         }
 
         func dismiss() {
+            guard !isDismissed else {
+                return
+            }
+            isDismissed = true
+            cancelLoadTimeout()
+
             webView.stopLoading()
             webView.navigationDelegate = nil
 
@@ -131,7 +144,10 @@ extension HackleInAppMessageUI {
             }
         }
 
-        private func showContent() {
+        func showContent() {
+            guard !isDismissed else {
+                return
+            }
             window?.makeKey()
             UIView.animate(
                 withDuration: 0.1,
@@ -144,6 +160,27 @@ extension HackleInAppMessageUI {
                     self.didPresent()
                 }
             )
+        }
+
+        func scheduleLoadTimeout() {
+            loadTimeoutJob = scheduler.schedule(delay: Self.loadTimeout) { [weak self] in
+                Task { @MainActor in
+                    self?.onLoadTimeout()
+                }
+            }
+        }
+
+        private func cancelLoadTimeout() {
+            loadTimeoutJob?.cancel()
+            loadTimeoutJob = nil
+        }
+
+        func onLoadTimeout() {
+            guard !isDismissed, !presented else {
+                return
+            }
+            Log.error("InAppMessage HTML did not become ready within \(Self.loadTimeout)s; closing [\(inAppMessage.id)]")
+            dismiss()
         }
 
         // MARK: - Views

--- a/Sources/Hackle/UI/InAppMessageUI/Views/Html/InAppMessageUIHtmlView.swift
+++ b/Sources/Hackle/UI/InAppMessageUI/Views/Html/InAppMessageUIHtmlView.swift
@@ -131,6 +131,7 @@ extension HackleInAppMessageUI {
                     Task { @MainActor in
                         switch result {
                         case .success(let content):
+                            self?.scheduleLoadTimeout()
                             self?.webView.load(html: content)
                         case .failure(let error):
                             Log.error("Failed to resolve Html content: \(error)")
@@ -228,6 +229,7 @@ extension HackleInAppMessageUI.HtmlView: WKNavigationDelegate {
         webView.disableDragAndDrop()
         webView.evaluate(script: DisableSelectionScript())
         webView.evaluate(script: bridgeScript) { [weak self] _, _ in
+            self?.cancelLoadTimeout()
             self?.showContent()
         }
     }

--- a/Sources/Hackle/UI/InAppMessageUI/Views/Html/InAppMessageUIHtmlView.swift
+++ b/Sources/Hackle/UI/InAppMessageUI/Views/Html/InAppMessageUIHtmlView.swift
@@ -129,13 +129,16 @@ extension HackleInAppMessageUI {
                 let resolver = try contentResolverFactory.get(resourceType: html.resourceType)
                 resolver.resolve(html: html) { [weak self] result in
                     Task { @MainActor in
+                        guard let self, !self.isDismissed else {
+                            return
+                        }
                         switch result {
                         case .success(let content):
-                            self?.scheduleLoadTimeout()
-                            self?.webView.load(html: content)
+                            self.scheduleLoadTimeout()
+                            self.webView.load(html: content)
                         case .failure(let error):
                             Log.error("Failed to resolve Html content: \(error)")
-                            self?.dismiss()
+                            self.dismiss()
                         }
                     }
                 }

--- a/Tests/HackleTests/UI/InAppMessageUI/Views/Html/InAppMessageUIHtmlViewSpecs.swift
+++ b/Tests/HackleTests/UI/InAppMessageUI/Views/Html/InAppMessageUIHtmlViewSpecs.swift
@@ -1,0 +1,97 @@
+import Foundation
+import Quick
+import Nimble
+import MockingKit
+@testable import Hackle
+
+class InAppMessageUIHtmlViewSpecs: QuickSpec {
+    override class func spec() {
+        typealias HtmlView = HackleInAppMessageUI.HtmlView
+        typealias BridgeScript = HackleInAppMessageUI.HtmlViewBridgeScript
+
+        let sdkKey = "test_sdk_key"
+
+        @MainActor
+        func makeView(scheduler: Scheduler) -> HtmlView {
+            let app = HackleApp(
+                hackleAppCore: MockHackleAppCore(sdkKey: sdkKey),
+                sdk: Sdk.of(sdkKey: sdkKey, config: HackleConfig.DEFAULT),
+                config: HackleConfig.DEFAULT,
+                hackleInvocator: DefaultHackleInvocator(processor: MockInvocationProcessor())
+            )
+            return HtmlView(
+                context: InAppMessage.context(),
+                app: app,
+                contentResolverFactory: DefaultInAppMessageHtmlContentResolverFactory(
+                    resolvers: [TextInAppMessageHtmlContentResolver()]
+                ),
+                bridgeScript: BridgeScript.create(config: HackleConfig.DEFAULT),
+                scheduler: scheduler
+            )
+        }
+
+        it("schedules a load timeout with the configured 30s delay") {
+            MainActor.assumeIsolated {
+                let scheduler = MockScheduler()
+                every(scheduler.scheduleMock).returns(MockScheduledJob())
+                let view = makeView(scheduler: scheduler)
+
+                view.scheduleLoadTimeout()
+
+                verify(exactly: 1) { scheduler.scheduleMock }
+                let (delay, _) = scheduler.scheduleMock.firstInvokation().arguments
+                expect(delay) == HtmlView.loadTimeout
+                expect(HtmlView.loadTimeout) == 30
+            }
+        }
+
+        it("dismisses the view when load times out before ready") {
+            MainActor.assumeIsolated {
+                let view = makeView(scheduler: MockScheduler())
+
+                view.onLoadTimeout()
+
+                expect(view.isDismissed).to(beTrue())
+                expect(view.presented).to(beFalse())
+            }
+        }
+
+        it("does not dismiss on timeout if already presented") {
+            MainActor.assumeIsolated {
+                let view = makeView(scheduler: MockScheduler())
+                view.presented = true
+
+                view.onLoadTimeout()
+
+                expect(view.isDismissed).to(beFalse())
+            }
+        }
+
+        it("does not present content after dismiss (no false impression)") {
+            MainActor.assumeIsolated {
+                let view = makeView(scheduler: MockScheduler())
+
+                view.dismiss()
+                view.showContent()
+
+                expect(view.presented).to(beFalse())
+            }
+        }
+
+        it("cancels the load timeout on dismiss and is idempotent") {
+            MainActor.assumeIsolated {
+                let scheduler = MockScheduler()
+                let job = MockScheduledJob()
+                every(scheduler.scheduleMock).returns(job)
+                let view = makeView(scheduler: scheduler)
+                view.scheduleLoadTimeout()
+
+                view.dismiss()
+                view.dismiss()
+
+                verify(exactly: 1) { job.cancelMock }
+                expect(view.isDismissed).to(beTrue())
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 개요
HTML 인앱 메시지 콘텐츠가 로드되지 않는 상황을 대비해 30초 타임아웃을 추가합니다.
타임아웃 내에 WebView 콘텐츠가 준비되지 않으면 메시지를 자동으로 닫아 impression이 잘못 기록되는 것을 방지합니다.

## 작업 내용
- `InAppMessageUIHtmlView`에 `Scheduler` 의존성 주입
- 콘텐츠 로드 시작 시 30초 타임아웃 스케줄 등록, 성공 시 자동 취소
- 타임아웃 도달 시 아직 표시 전인 경우에만 자동 dismiss
- `dismiss()`를 idempotent하게 개선 (`isDismissed` 플래그 추가)
- 타임아웃 시나리오 커버하는 단위 테스트 추가 (`InAppMessageUIHtmlViewSpecs`)