### PR TITLE
feature: add async/await APIs and evaluation processor

### DIFF
--- a/Sources/Hackle/Core/HackleAppCore.swift
+++ b/Sources/Hackle/Core/HackleAppCore.swift
@@ -21,13 +21,16 @@ protocol HackleAppCore: AnyObject {
 
     func hideUserExplorer()
 
-    func setUser(user: User, hackleAppContext: HackleAppContext, completion: @escaping () -> ())
+    @discardableResult
+    func setUser(user: User, hackleAppContext: HackleAppContext) -> Task<Void, Never>
 
-    func setUserId(userId: String?, hackleAppContext: HackleAppContext, completion: @escaping () -> ())
+    @discardableResult
+    func setUserId(userId: String?, hackleAppContext: HackleAppContext) -> Task<Void, Never>
 
-    func setDeviceId(deviceId: String, hackleAppContext: HackleAppContext, completion: @escaping () -> ())
+    @discardableResult
+    func setDeviceId(deviceId: String, hackleAppContext: HackleAppContext) -> Task<Void, Never>
 
-    func updateUserProperties(operations: PropertyOperations, hackleAppContext: HackleAppContext, completion: @escaping () -> ())
+    func updateUserProperties(operations: PropertyOperations, hackleAppContext: HackleAppContext)
 
     func updatePushSubscriptions(operations: HackleSubscriptionOperations, hackleAppContext: HackleAppContext)
 
@@ -35,11 +38,12 @@ protocol HackleAppCore: AnyObject {
 
     func updateKakaoSubscriptions(operations: HackleSubscriptionOperations, hackleAppContext: HackleAppContext)
 
-    func resetUser(hackleAppContext: HackleAppContext, completion: @escaping () -> ())
+    @discardableResult
+    func resetUser(hackleAppContext: HackleAppContext) -> Task<Void, Never>
 
-    func setPhoneNumber(phoneNumber: String, hackleAppContext: HackleAppContext, completion: @escaping () -> ())
+    func setPhoneNumber(phoneNumber: String, hackleAppContext: HackleAppContext)
 
-    func unsetPhoneNumber(hackleAppContext: HackleAppContext, completion: @escaping () -> ())
+    func unsetPhoneNumber(hackleAppContext: HackleAppContext)
 
     func variationDetail(experimentKey: Int, user: User?, defaultVariation: String, hackleAppContext: HackleAppContext) -> Decision
 
@@ -56,7 +60,8 @@ protocol HackleAppCore: AnyObject {
     var isOptOutTracking: Bool { get }
     func setOptOutTracking(optOut: Bool)
 
-    func fetch(completion: @escaping () -> ())
+    @discardableResult
+    func fetch() -> Task<Void, Never>
 
     func setPushToken(deviceToken: Data)
 
@@ -168,11 +173,12 @@ class DefaultHackleAppCore: HackleAppCore, @unchecked Sendable {
         sessionManager.initialize()
         eventProcessor.initialize()
         applicationInstallStateManager.initialize()
-        synchronizer.sync { [weak self] in
+        Task { [weak self] in
             guard let self = self else {
                 completion()
                 return
             }
+            await self.synchronizer.safeSync()
             self.pushTokenRegistry.flush()
             self.notificationManager.flush()
             self.applicationInstallStateManager.checkApplicationInstall()
@@ -205,26 +211,28 @@ class DefaultHackleAppCore: HackleAppCore, @unchecked Sendable {
         }
     }
 
-    func setUser(user: User, hackleAppContext: HackleAppContext, completion: @escaping () -> ()) {
+    @discardableResult
+    func setUser(user: User, hackleAppContext: HackleAppContext) -> Task<Void, Never> {
         let updated = userManager.setUser(user: user)
-        userManager.syncIfNeeded(updated: updated, completion: completion)
+        return Task { await self.userManager.syncIfNeeded(updated: updated) }
     }
 
-    func setUserId(userId: String?, hackleAppContext: HackleAppContext, completion: @escaping () -> ()) {
+    @discardableResult
+    func setUserId(userId: String?, hackleAppContext: HackleAppContext) -> Task<Void, Never> {
         let updated = userManager.setUserId(userId: userId)
-        userManager.syncIfNeeded(updated: updated, completion: completion)
+        return Task { await self.userManager.syncIfNeeded(updated: updated) }
     }
 
-    func setDeviceId(deviceId: String, hackleAppContext: HackleAppContext, completion: @escaping () -> ()) {
+    @discardableResult
+    func setDeviceId(deviceId: String, hackleAppContext: HackleAppContext) -> Task<Void, Never> {
         let updated = userManager.setDeviceId(deviceId: deviceId)
-        userManager.syncIfNeeded(updated: updated, completion: completion)
+        return Task { await self.userManager.syncIfNeeded(updated: updated) }
     }
 
-    func updateUserProperties(operations: PropertyOperations, hackleAppContext: HackleAppContext, completion: @escaping () -> ()) {
+    func updateUserProperties(operations: PropertyOperations, hackleAppContext: HackleAppContext) {
         track(event: operations.toEvent(), user: nil, hackleAppContext: hackleAppContext)
         eventProcessor.flush()
         userManager.updateProperties(operations: operations)
-        completion()
     }
 
     func updatePushSubscriptions(operations: HackleSubscriptionOperations, hackleAppContext: HackleAppContext) {
@@ -242,30 +250,29 @@ class DefaultHackleAppCore: HackleAppCore, @unchecked Sendable {
         eventProcessor.flush()
     }
 
-    func resetUser(hackleAppContext: HackleAppContext, completion: @escaping () -> ()) {
+    @discardableResult
+    func resetUser(hackleAppContext: HackleAppContext) -> Task<Void, Never> {
         let updated = userManager.resetUser()
         track(event: PropertyOperations.clearAll().toEvent(), user: nil, hackleAppContext: hackleAppContext)
-        userManager.syncIfNeeded(updated: updated, completion: completion)
+        return Task { await self.userManager.syncIfNeeded(updated: updated) }
     }
 
-    func setPhoneNumber(phoneNumber: String, hackleAppContext: HackleAppContext, completion: @escaping () -> ()) {
+    func setPhoneNumber(phoneNumber: String, hackleAppContext: HackleAppContext) {
         let event = PropertyOperationsBuilder()
             .set(PIIProperty.phoneNumber.rawValue, phoneNumber)
             .build()
             .toSecuredEvent()
         track(event: event, user: nil, hackleAppContext: hackleAppContext)
         eventProcessor.flush()
-        completion()
     }
 
-    func unsetPhoneNumber(hackleAppContext: HackleAppContext, completion: @escaping () -> ()) {
+    func unsetPhoneNumber(hackleAppContext: HackleAppContext) {
         let event = PropertyOperationsBuilder()
             .unset(PIIProperty.phoneNumber.rawValue)
             .build()
             .toSecuredEvent()
         track(event: event, user: nil, hackleAppContext: hackleAppContext)
         eventProcessor.flush()
-        completion()
     }
 
     func variationDetail(experimentKey: Int, user: User?, defaultVariation: String, hackleAppContext: HackleAppContext) -> Decision {
@@ -342,16 +349,24 @@ class DefaultHackleAppCore: HackleAppCore, @unchecked Sendable {
         optOutManager.setOptOutTracking(optOut: optOut)
     }
 
-    func fetch(completion: @escaping () -> ()) {
+    @discardableResult
+    func fetch() -> Task<Void, Never> {
+        // Throttler.execute는 반환 전에 accept/reject 중 하나를 동기적으로 호출하는 계약이다.
+        // 계약 위반(둘 다 미호출)은 디버그에서 즉시 드러내되, 릴리스에서는 크래시 대신 무해한 no-op Task를 반환한다.
+        var task: Task<Void, Never>? = nil
         fetchThrottler.execute(
             accept: {
-                self.synchronizer.sync(completion: completion)
+                task = Task { await self.synchronizer.safeSync() }
             },
             reject: {
                 Log.debug("Too many quick fetch requests")
-                completion()
+                task = Task {}
             }
         )
+        if task == nil {
+            assertionFailure("Throttler.execute must synchronously call accept or reject before returning")
+        }
+        return task ?? Task {}
     }
 
     func setPushToken(deviceToken: Data) {

--- a/Sources/Hackle/Core/HackleAppCore.swift
+++ b/Sources/Hackle/Core/HackleAppCore.swift
@@ -13,7 +13,7 @@ protocol HackleAppCore: AnyObject {
     var user: User { get }
     @MainActor var currentInAppMessageView: InAppMessageView? { get }
 
-    func initialize(user: User?, completion: @escaping () -> ())
+    func initialize(user: User?, completion: @escaping @Sendable () -> ())
 
     @MainActor func getInAppMessageView(viewId: String) -> InAppMessageView?
 
@@ -87,7 +87,7 @@ class DefaultHackleAppCore: HackleAppCore, @unchecked Sendable {
     private let applicationInstallStateManager: ApplicationInstallStateManager
     private let userExplorer: HackleUserExplorer
     private let optOutManager: OptOutManager
-    private let onInitializedRef = AtomicReference<(() -> ())?>(value: nil)
+    private let onInitializedRef = AtomicReference<(@Sendable () -> ())?>(value: nil)
 
     @MainActor private var userExplorerView: HackleUserExplorerView? = nil
 
@@ -151,7 +151,7 @@ class DefaultHackleAppCore: HackleAppCore, @unchecked Sendable {
         self.optOutManager = optOutManager
     }
 
-    func initialize(user: User?, completion: @escaping () -> ()) {
+    func initialize(user: User?, completion: @escaping @Sendable () -> ()) {
         userManager.initialize(user: user)
         onInitializedRef.set(newValue: completion)
         Task {
@@ -168,7 +168,7 @@ class DefaultHackleAppCore: HackleAppCore, @unchecked Sendable {
         }
     }
 
-    private func initialize(completion: @escaping () -> ()) {
+    private func initialize(completion: @escaping @Sendable () -> ()) {
         workspaceManager.initialize()
         sessionManager.initialize()
         eventProcessor.initialize()

--- a/Sources/Hackle/Core/Http/HttpClient.swift
+++ b/Sources/Hackle/Core/Http/HttpClient.swift
@@ -9,6 +9,27 @@ protocol HttpClient {
     func execute(request: HttpRequest, timeout: TimeInterval, completion: @escaping (HttpResponse) -> Void)
 }
 
+extension HttpClient {
+    /// 콜백 기반 execute를 async로 감싸는 유일한 continuation 브리지.
+    ///
+    /// - Important: conformer는 completion을 **정확히 1회** 호출해야 한다. 0회 호출 시
+    ///   continuation이 resume되지 않아 호출 Task가 영구 정지한다. `DefaultHttpClient`는
+    ///   URLSession dataTask 계약으로 이를 보장하며, 테스트 더블(`MockHttpClient`)은 등록한
+    ///   answer가 반드시 completion을 1회 호출해야 한다.
+    func execute(request: HttpRequest, timeout: TimeInterval? = nil) async -> HttpResponse {
+        await withCheckedContinuation { continuation in
+            let completion: (HttpResponse) -> Void = { response in
+                continuation.resume(returning: response)
+            }
+            if let timeout {
+                execute(request: request, timeout: timeout, completion: completion)
+            } else {
+                execute(request: request, completion: completion)
+            }
+        }
+    }
+}
+
 class DefaultHttpClient: HttpClient {
 
     private let sdk: Sdk

--- a/Sources/Hackle/Core/Sync/CompositeSynchronizer.swift
+++ b/Sources/Hackle/Core/Sync/CompositeSynchronizer.swift
@@ -2,33 +2,20 @@ import Foundation
 
 class CompositeSynchronizer: Synchronizer {
 
-    private let dispatchQueue: DispatchQueue
     private var synchronizers: [Synchronizer] = []
-
-    init(dispatchQueue: DispatchQueue) {
-        self.dispatchQueue = dispatchQueue
-    }
 
     func add(synchronizer: Synchronizer) {
         self.synchronizers.append(synchronizer)
         Log.debug("Synchronizer added [\(synchronizer)]")
     }
 
-    func sync(completion: @escaping (Result<(), Error>) -> ()) {
-        let dispatchGroup = DispatchGroup()
-        for synchronizer in synchronizers {
-            dispatchGroup.enter()
-            dispatchQueue.async {
-                synchronizer.sync { result in
-                    dispatchGroup.leave()
-                    if case .failure(let error) = result {
-                        Log.error("Failed to sync: \(error)")
-                    }
+    func sync() async throws {
+        await withTaskGroup(of: Void.self) { group in
+            for synchronizer in synchronizers {
+                group.addTask {
+                    await synchronizer.safeSync()
                 }
             }
-        }
-        dispatchGroup.notify(queue: dispatchQueue) {
-            completion(.success(()))
         }
     }
 }

--- a/Sources/Hackle/Core/Sync/CompositeSynchronizer.swift
+++ b/Sources/Hackle/Core/Sync/CompositeSynchronizer.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-class CompositeSynchronizer: Synchronizer {
+class CompositeSynchronizer: Synchronizer, @unchecked Sendable {
 
     private var synchronizers: [Synchronizer] = []
 

--- a/Sources/Hackle/Core/Sync/PollingSynchronizer.swift
+++ b/Sources/Hackle/Core/Sync/PollingSynchronizer.swift
@@ -17,12 +17,13 @@ class PollingSynchronizer: Synchronizer, @unchecked Sendable {
         self.interval = interval
     }
 
-    func sync(completion: @escaping (Result<(), Error>) -> ()) {
-        delegate.sync(completion: completion)
+    func sync() async throws {
+        try await delegate.sync()
     }
 
     private func poll() {
-        sync {
+        Task {
+            await self.safeSync()
             Log.debug("PollingSynchronizer.poll")
         }
     }

--- a/Sources/Hackle/Core/Sync/Synchronizer.swift
+++ b/Sources/Hackle/Core/Sync/Synchronizer.swift
@@ -2,23 +2,20 @@
 //  Synchronizer.swift
 //  Hackle
 //
-//  Created by yong on 2023/10/02.
-//
 
 import Foundation
 
 
 protocol Synchronizer {
-    func sync(completion: @escaping (Result<Void, Error>) -> ())
+    func sync() async throws
 }
 
 extension Synchronizer {
-    func sync(completion: @escaping () -> ()) {
-        sync { result in
-            if case .failure(let error) = result {
-                Log.error("Failed to sync: \(error)")
-            }
-            completion()
+    func safeSync() async {
+        do {
+            try await sync()
+        } catch {
+            Log.error("Failed to sync: \(error)")
         }
     }
 }

--- a/Sources/Hackle/Core/Sync/Synchronizer.swift
+++ b/Sources/Hackle/Core/Sync/Synchronizer.swift
@@ -6,7 +6,7 @@
 import Foundation
 
 
-protocol Synchronizer {
+protocol Synchronizer: Sendable {
     func sync() async throws
 }
 

--- a/Sources/Hackle/Core/User/UserCohortFetcher.swift
+++ b/Sources/Hackle/Core/User/UserCohortFetcher.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 protocol UserCohortFetcher {
-    func fetch(user: User, completion: @escaping (Result<UserCohorts, Error>) -> ())
+    func fetch(user: User) async throws -> UserCohorts
 }
 
 class DefaultUserCohortFetcher: UserCohortFetcher {
@@ -26,26 +26,12 @@ class DefaultUserCohortFetcher: UserCohortFetcher {
         "\(config.sdkUrl)/api/v1/cohorts"
     }
 
-    func fetch(user: User, completion: @escaping (Result<UserCohorts, Error>) -> ()) {
-        do {
-            let request = try createRequest(user: user)
-            let sample = TimerSample.start()
-            httpClient.execute(request: request, timeout: timeout) { [weak self] response in
-                guard let self = self else {
-                    completion(.failure(HackleError.error("Failed to fetch cohorts: instance deallocated")))
-                    return
-                }
-                ApiCallMetrics.record(operation: "get.cohorts", sample: sample, response: response)
-                do {
-                    let userCohorts = try self.handleResponse(response: response)
-                    completion(.success(userCohorts))
-                } catch let error {
-                    completion(.failure(error))
-                }
-            }
-        } catch let error {
-            completion(.failure(error))
-        }
+    func fetch(user: User) async throws -> UserCohorts {
+        let request = try createRequest(user: user)
+        let sample = TimerSample.start()
+        let response = await httpClient.execute(request: request, timeout: timeout)
+        ApiCallMetrics.record(operation: "get.cohorts", sample: sample, response: response)
+        return try handleResponse(response: response)
     }
 
     private func createRequest(user: User) throws -> HttpRequest {

--- a/Sources/Hackle/Core/User/UserManager.swift
+++ b/Sources/Hackle/Core/User/UserManager.swift
@@ -27,14 +27,13 @@ protocol UserManager: Synchronizer {
     @discardableResult
     func resetUser() -> Updated<User>
 
-    func syncIfNeeded(updated: Updated<User>, completion: @escaping () -> ())
+    func syncIfNeeded(updated: Updated<User>) async
 }
 
 class DefaultUserManager: UserManager {
 
     private static let USER_KEY = "user"
     private let recursiveLock = RecursiveLock(label: "io.hackle.DefaultUserManager")
-    private let dispatchQueue: DispatchQueue = DispatchQueue(label: "io.hackle.DefaultUserManager.dispatchQueue")
 
     private var userListeners: [UserListener]
     private let repository: KeyValueRepository
@@ -133,117 +132,57 @@ class DefaultUserManager: UserManager {
 
     // Sync
 
-    func sync(completion: @escaping (Result<(), Error>) -> ()) {
-        sync(
-            user: currentUser,
-            shouldSyncCohort: true,
-            shouldSyncTargetEvent: true,
-            completion: {
-                completion(.success(()))
-            }
-        )
+    func sync() async throws {
+        await sync(user: currentUser, shouldSyncCohort: true, shouldSyncTargetEvent: true)
     }
-    
-    func syncIfNeeded(updated: Updated<User>, completion: @escaping () -> ()) {
-        sync(
+
+    func syncIfNeeded(updated: Updated<User>) async {
+        await sync(
             user: updated.current,
             shouldSyncCohort: hasNewIdentifiers(previousUser: updated.previous, currentUser: updated.current),
-            shouldSyncTargetEvent: !updated.previous.identifierEquals(other: updated.current),
-            completion: completion
+            shouldSyncTargetEvent: !updated.previous.identifierEquals(other: updated.current)
         )
     }
 
-    private func sync(
-        user: User,
-        shouldSyncCohort: Bool,
-        shouldSyncTargetEvent: Bool,
-        completion: @escaping () -> Void
-    ) {
-        let dispatchGroup = DispatchGroup()
-        
-        if shouldSyncCohort {
-            dispatchGroup.enter()
-            dispatchQueue.async { [weak self] in
-                self?.syncCohort(user: user) { result in
-                    defer { dispatchGroup.leave() }
-                    if case .failure(let error) = result {
-                        Log.error("Cohort sync failed: \(error)")
-                    }
-                }
+    private func sync(user: User, shouldSyncCohort: Bool, shouldSyncTargetEvent: Bool) async {
+        await withTaskGroup(of: Void.self) { group in
+            if shouldSyncCohort {
+                group.addTask { await self.syncCohort(user: user) }
             }
-        }
-        
-        if shouldSyncTargetEvent {
-            dispatchGroup.enter()
-            dispatchQueue.async { [weak self] in
-                self?.syncTargetEvent(user: user) { result in
-                    defer { dispatchGroup.leave() }
-                    if case .failure(let error) = result {
-                        Log.error("Target event sync failed: \(error)")
-                    }
-                }
+            if shouldSyncTargetEvent {
+                group.addTask { await self.syncTargetEvent(user: user) }
             }
-        }
-        
-        dispatchGroup.notify(queue: dispatchQueue) {
-            completion()
         }
     }
-    
-    private func syncCohort(user: User, completion: @escaping (Result<(), Error>) -> ()) {
-        cohortFetcher.fetch(user: user) { [weak self] result in
-            guard let self = self else {
-                completion(.failure(HackleError.error("Failed to user cohort sync: instance deallocated")))
-                return
+
+    private func syncCohort(user: User) async {
+        do {
+            let cohorts = try await cohortFetcher.fetch(user: user)
+            recursiveLock.lock {
+                context = context.update(cohorts: cohorts)
             }
-            self.handle(result: result, completion: completion)
+        } catch {
+            Log.error("Cohort sync failed: \(error)")
         }
     }
-    
-    private func syncTargetEvent(user: User, completion: @escaping (Result<(), Error>) -> ()) {
-        targetFetcher.fetch(user: user) { [weak self] result in
-            guard let self = self else {
-                completion(.failure(HackleError.error("Failed to user target event sync: instance deallocated")))
-                return
+
+    private func syncTargetEvent(user: User) async {
+        do {
+            let targetEvents = try await targetFetcher.fetch(user: user)
+            recursiveLock.lock {
+                context = context.update(targetEvents: targetEvents)
             }
-            self.handle(result: result, completion: completion)
+        } catch {
+            Log.error("Target event sync failed: \(error)")
         }
     }
-    
+
     private func hasNewIdentifiers(previousUser: User, currentUser: User) -> Bool {
         let previousIdentifiers = previousUser.resolvedIdentifiers
         let currentIdentifiers = currentUser.resolvedIdentifiers
 
         return currentIdentifiers.contains { type, value in
             !previousIdentifiers.contains(type: type, value: value)
-        }
-    }
-    
-    private func handle(result: Result<UserCohorts, Error>, completion: @escaping (Result<(), Error>) -> ()) {
-        switch result {
-        case .success(let cohorts):
-            recursiveLock.lock {
-                context = context.update(cohorts: cohorts)
-            }
-            completion(.success(()))
-            return
-        case .failure(let error):
-            completion(.failure(error))
-            return
-        }
-    }
-
-    private func handle(result: Result<UserTargetEvents, Error>, completion: @escaping (Result<(), Error>) -> ()) {
-        switch result {
-        case .success(let target):
-            recursiveLock.lock {
-                context = context.update(targetEvents: target)
-            }
-            completion(.success(()))
-            return
-        case .failure(let error):
-            completion(.failure(error))
-            return
         }
     }
 

--- a/Sources/Hackle/Core/User/UserManager.swift
+++ b/Sources/Hackle/Core/User/UserManager.swift
@@ -30,7 +30,7 @@ protocol UserManager: Synchronizer {
     func syncIfNeeded(updated: Updated<User>) async
 }
 
-class DefaultUserManager: UserManager {
+class DefaultUserManager: UserManager, @unchecked Sendable {
 
     private static let USER_KEY = "user"
     private let recursiveLock = RecursiveLock(label: "io.hackle.DefaultUserManager")

--- a/Sources/Hackle/Core/User/UserTargetEventFetcher.swift
+++ b/Sources/Hackle/Core/User/UserTargetEventFetcher.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 protocol UserTargetEventsFetcher {
-    func fetch(user: User, completion: @escaping (Result<UserTargetEvents, Error>) -> ())
+    func fetch(user: User) async throws -> UserTargetEvents
 }
 
 class DefaultUserTargetEventsFetcher: UserTargetEventsFetcher {
@@ -26,26 +26,12 @@ class DefaultUserTargetEventsFetcher: UserTargetEventsFetcher {
         "\(config.sdkUrl)/api/v1/user-targets"
     }
 
-    func fetch(user: User, completion: @escaping (Result<UserTargetEvents, Error>) -> ()) {
-        do {
-            let request = try createRequest(user: user)
-            let sample = TimerSample.start()
-            httpClient.execute(request: request, timeout: timeout) { [weak self] response in
-                guard let self = self else {
-                    completion(.failure(HackleError.error("Failed to fetch user target: instance deallocated")))
-                    return
-                }
-                ApiCallMetrics.record(operation: "get.user-targets", sample: sample, response: response)
-                do {
-                    let userTargets = try self.handleResponse(response: response)
-                    completion(.success(userTargets))
-                } catch let error {
-                    completion(.failure(error))
-                }
-            }
-        } catch let error {
-            completion(.failure(error))
-        }
+    func fetch(user: User) async throws -> UserTargetEvents {
+        let request = try createRequest(user: user)
+        let sample = TimerSample.start()
+        let response = await httpClient.execute(request: request, timeout: timeout)
+        ApiCallMetrics.record(operation: "get.user-targets", sample: sample, response: response)
+        return try handleResponse(response: response)
     }
 
     private func createRequest(user: User) throws -> HttpRequest {

--- a/Sources/Hackle/Core/Utilities/Concurrency/TaskExtensions.swift
+++ b/Sources/Hackle/Core/Utilities/Concurrency/TaskExtensions.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+extension Task where Success == Void, Failure == Never {
+    /// 비동기 파트 완료 후 지정 큐에서 completion을 호출한다.
+    /// public completion API가 async 코어를 감쌀 때 사용하는 유일한 콜백 브리지.
+    func onComplete(queue: DispatchQueue, _ completion: @escaping () -> Void) {
+        Task<Void, Never> {
+            await self.value
+            queue.async {
+                completion()
+            }
+        }
+    }
+}

--- a/Sources/Hackle/Core/Utilities/Concurrency/TaskExtensions.swift
+++ b/Sources/Hackle/Core/Utilities/Concurrency/TaskExtensions.swift
@@ -3,7 +3,7 @@ import Foundation
 extension Task where Success == Void, Failure == Never {
     /// 비동기 파트 완료 후 지정 큐에서 completion을 호출한다.
     /// public completion API가 async 코어를 감쌀 때 사용하는 유일한 콜백 브리지.
-    func onComplete(queue: DispatchQueue, _ completion: @escaping () -> Void) {
+    func onComplete(queue: DispatchQueue, _ completion: @escaping @Sendable () -> Void) {
         Task<Void, Never> {
             await self.value
             queue.async {

--- a/Sources/Hackle/Core/Utilities/Concurrency/Throttler.swift
+++ b/Sources/Hackle/Core/Utilities/Concurrency/Throttler.swift
@@ -2,6 +2,8 @@ import Foundation
 
 
 protocol Throttler {
+    /// accept 또는 reject 중 정확히 하나를 execute 반환 전에 동기적으로 호출해야 한다.
+    /// (HackleAppCore.fetch가 이 동기 호출 계약에 의존한다)
     func execute(accept: @escaping () -> (), reject: @escaping () -> ())
 }
 

--- a/Sources/Hackle/Core/Workspace/HttpWorkspaceFetcher.swift
+++ b/Sources/Hackle/Core/Workspace/HttpWorkspaceFetcher.swift
@@ -7,7 +7,7 @@ import Foundation
 
 
 protocol HttpWorkspaceFetcher {
-    func fetchIfModified(lastModified: String?, completion: @escaping (Result<WorkspaceConfigResponse?, Error>) -> ())
+    func fetchIfModified(lastModified: String?) async throws -> WorkspaceConfigResponse?
 }
 
 class DefaultHttpWorkspaceFetcher: HttpWorkspaceFetcher {
@@ -24,9 +24,9 @@ class DefaultHttpWorkspaceFetcher: HttpWorkspaceFetcher {
         "\(config.sdkUrl)/api/v2/workspaces/\(sdk.key)/config"
     }
 
-    func fetchIfModified(lastModified: String? = nil, completion: @escaping (Result<WorkspaceConfigResponse?, Error>) -> ()) {
+    func fetchIfModified(lastModified: String? = nil) async throws -> WorkspaceConfigResponse? {
         let request = createRequest(lastModified: lastModified)
-        execute(request: request, completion: completion)
+        return try await execute(request: request)
     }
 
     private func createRequest(lastModified: String?) -> HttpRequest {
@@ -37,21 +37,11 @@ class DefaultHttpWorkspaceFetcher: HttpWorkspaceFetcher {
         }
     }
 
-    private func execute(request: HttpRequest, completion: @escaping (Result<WorkspaceConfigResponse?, Error>) -> ()) {
+    private func execute(request: HttpRequest) async throws -> WorkspaceConfigResponse? {
         let sample = TimerSample.start()
-        httpClient.execute(request: request) { [weak self] response in
-            guard let self = self else {
-                completion(.failure(HackleError.error("Failed to fetch workspace: instance deallocated")))
-                return
-            }
-            ApiCallMetrics.record(operation: "get.workspace", sample: sample, response: response)
-            do {
-                let workspace = try self.handleResponse(response: response)
-                completion(.success(workspace))
-            } catch let error {
-                completion(.failure(error))
-            }
-        }
+        let response = await httpClient.execute(request: request)
+        ApiCallMetrics.record(operation: "get.workspace", sample: sample, response: response)
+        return try handleResponse(response: response)
     }
 
     private func handleResponse(response: HttpResponse) throws -> WorkspaceConfigResponse? {

--- a/Sources/Hackle/Core/Workspace/WorkspaceManager.swift
+++ b/Sources/Hackle/Core/Workspace/WorkspaceManager.swift
@@ -30,13 +30,15 @@ class WorkspaceManager: WorkspaceFetcher, WorkspaceConfigFetcher, Synchronizer {
         workspace
     }
 
-    func sync(completion: @escaping (Result<(), Error>) -> ()) {
-        httpWorkspaceFetcher.fetchIfModified(lastModified: lastModified) { [weak self] result in
-            guard let self = self else {
-                completion(.failure(HackleError.error("Failed to workspace sync: instance deallocated")))
-                return
-            }
-            self.handle(result: result, completion: completion)
+    func sync() async throws {
+        let response = try await httpWorkspaceFetcher.fetchIfModified(lastModified: lastModified)
+        handle(response: response)
+    }
+
+    private func handle(response: WorkspaceConfigResponse?) {
+        if let response {
+            setWorkspaceConfig(response)
+            repository.set(value: response)
         }
     }
 
@@ -52,18 +54,4 @@ class WorkspaceManager: WorkspaceFetcher, WorkspaceConfigFetcher, Synchronizer {
         }
     }
 
-    private func handle(result: Result<WorkspaceConfigResponse?, Error>, completion: @escaping (Result<(), Error>) -> ()) {
-        switch result {
-        case .success(let config):
-            if let config {
-                setWorkspaceConfig(config)
-                repository.set(value: config)
-            }
-            completion(.success(()))
-            return
-        case .failure(let error):
-            completion(.failure(error))
-            return
-        }
-    }
 }

--- a/Sources/Hackle/Core/Workspace/WorkspaceManager.swift
+++ b/Sources/Hackle/Core/Workspace/WorkspaceManager.swift
@@ -6,7 +6,7 @@
 import Foundation
 
 
-class WorkspaceManager: WorkspaceFetcher, WorkspaceConfigFetcher, Synchronizer {
+class WorkspaceManager: WorkspaceFetcher, WorkspaceConfigFetcher, Synchronizer, @unchecked Sendable {
     private let httpWorkspaceFetcher: HttpWorkspaceFetcher
     private let repository: WorkspaceConfigRepository
 

--- a/Sources/Hackle/Hackle+Notification.swift
+++ b/Sources/Hackle/Hackle+Notification.swift
@@ -1,0 +1,169 @@
+//
+//  Hackle+Notification.swift
+//  Hackle
+//
+//  Created by sungwoo.yeo on 7/6/26.
+//
+
+import Foundation
+import UserNotifications
+
+extension Hackle {
+    /// Sets the push notification device token.
+    ///
+    /// - Parameter deviceToken: The device token for push notifications
+    @objc static public func setPushToken(_ deviceToken: Data) {
+        DefaultPushTokenRegistry.shared.register(token: PushToken.of(value: deviceToken), timestamp: Date())
+    }
+}
+
+extension Hackle {
+    /// Handles notification presentation in foreground.
+    ///
+    /// - Parameters:
+    ///   - center: The notification center
+    ///   - notification: The notification to be presented
+    ///   - completionHandler: Handler to determine presentation options
+    /// - Returns: True if the notification was handled by Hackle, false otherwise
+    @objc static public func userNotificationCenter(
+        center: UNUserNotificationCenter,
+        willPresent notification: UNNotification,
+        withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
+    ) -> Bool {
+        if let notificationData = NotificationData.from(data: notification.request.content.userInfo) {
+            Log.info("Notification data received in foreground: \(notificationData.showForeground)")
+            if (notificationData.showForeground) {
+                if #available(iOS 14.0, *) {
+                    completionHandler([.list, .banner])
+                } else {
+                    completionHandler([.alert])
+                }
+            }
+            return true
+        } else {
+            return false
+        }
+    }
+
+    /// Handles notification tap responses.
+    ///
+    /// - Parameters:
+    ///   - response: The notification response
+    ///   - handleAction: Whether to automatically handle notification actions. Defaults to true
+    /// - Returns: ``HackleNotification`` if the notification was from Hackle, nil otherwise
+    @objc static public func handleNotification(
+        response: UNNotificationResponse,
+        handleAction: Bool = true
+    ) -> HackleNotification? {
+        guard let notificationData = NotificationData.from(data: response.notification.request.content.userInfo) else {
+            return nil
+        }
+        
+        NotificationHandler.shared.trackPushClickEvent(notificationData: notificationData)
+
+        if handleAction {
+            NotificationHandler.shared.handlePushClickAction(notificationData: notificationData)
+        }
+        
+        return notificationData
+    }
+    
+    /// Handles rich notifications with media attachments.
+    ///
+    /// - Parameters:
+    ///   - request: The notification request
+    ///   - contentHandler: Handler to process the notification content
+    /// - Returns: True if the notification was handled by Hackle, false otherwise
+    @objc static public func handleRichNotification(
+        request: UNNotificationRequest,
+        contentHandler: @escaping (UNNotificationContent) -> Void
+    ) -> Bool {
+        guard let baseNotificationContent: UNMutableNotificationContent = (request.content.mutableCopy() as? UNMutableNotificationContent) else {
+            return false
+        }
+        
+        return handleRichNotification(notificationContent: baseNotificationContent, contentHandler: contentHandler)
+    }
+    
+    /// Handles rich notifications with mutable content.
+    ///
+    /// - Parameters:
+    ///   - notificationContent: The mutable notification content
+    ///   - contentHandler: Handler to process the notification content
+    /// - Returns: True if the notification was handled by Hackle, false otherwise
+    @objc static public func handleRichNotification(
+        notificationContent: UNMutableNotificationContent,
+        contentHandler: @escaping (UNNotificationContent) -> Void
+    ) -> Bool {
+        guard let notificationData = NotificationData.from(data: notificationContent.userInfo) else {
+            return false
+        }
+        
+        return resolveRichNotificationContent(notificationContent: notificationContent, completion: { hackleNotificationContent in
+            contentHandler(hackleNotificationContent)
+        })
+    }
+    
+    /// Resolves rich notification content from a notification request.
+    ///
+    /// - Parameters:
+    ///   - request: The notification request
+    ///   - completion: Completion handler with resolved content
+    /// - Returns: True if the notification was handled by Hackle, false otherwise
+    @objc static public func resolveRichNotificationContent(
+        request: UNNotificationRequest,
+        completion: @escaping (UNMutableNotificationContent) -> Void
+    ) -> Bool {
+        guard let baseNotificationContent: UNMutableNotificationContent = (request.content.mutableCopy() as? UNMutableNotificationContent) else {
+            return false
+        }
+        
+        return resolveRichNotificationContent(notificationContent: baseNotificationContent, completion: completion)
+    }
+    
+    /// Resolves rich notification content from mutable content.
+    ///
+    /// - Parameters:
+    ///   - notificationContent: The mutable notification content
+    ///   - completion: Completion handler with resolved content
+    /// - Returns: True if the notification was handled by Hackle, false otherwise
+    @objc static public func resolveRichNotificationContent(
+        notificationContent: UNMutableNotificationContent,
+        completion: @escaping (UNMutableNotificationContent) -> Void
+    ) -> Bool {
+        guard let notificationData = NotificationData.from(data: notificationContent.userInfo) else {
+            return false
+        }
+        
+        // NOTE: use dispatch group when add another attachment, and etc...
+        NotificationHandler.shared.handlePushImage(notificationData: notificationData) { attachment in
+            if let attachment = attachment {
+                notificationContent.attachments = [attachment]
+            }
+            
+            completion(notificationContent)
+        }
+        
+        return true
+    }
+
+    /// Handles notification responses
+    ///
+    /// - Parameters:
+    ///   - center: The notification center
+    ///   - response: The notification response
+    ///   - completionHandler: Completion handler
+    /// - Returns: True if the notification was handled by Hackle, false otherwise
+    @available(*, deprecated, message: "Use handleClickNotification(UNNotificationResponse, Bool) instead.")
+    @objc static public func userNotificationCenter(
+        center: UNUserNotificationCenter,
+        didReceive response: UNNotificationResponse,
+        withCompletionHandler completionHandler: @escaping () -> Void
+    ) -> Bool {
+        if handleNotification(response: response) == nil {
+            return false
+        }
+        completionHandler()
+        return true
+    }
+}

--- a/Sources/Hackle/Hackle.swift
+++ b/Sources/Hackle/Hackle.swift
@@ -34,7 +34,7 @@ import Foundation
     ///   - sdkKey: Your Hackle SDK key
     ///   - config: SDK configuration options. Defaults to ``HackleConfig/DEFAULT``
     ///   - completion: Completion handler called when initialization is complete
-    @objc public static func initialize(sdkKey: String, config: HackleConfig = HackleConfig.DEFAULT, completion: @escaping () -> ()) {
+    @preconcurrency @objc public static func initialize(sdkKey: String, config: HackleConfig = HackleConfig.DEFAULT, completion: @escaping @Sendable () -> ()) {
         initialize(sdkKey: sdkKey, user: nil, config: config, completion: completion)
     }
 
@@ -55,7 +55,7 @@ import Foundation
     ///   - user: Initial user to set for the SDK. Can be nil
     ///   - config: SDK configuration options. Defaults to ``HackleConfig/DEFAULT``
     ///   - completion: Completion handler called when initialization is complete
-    @objc public static func initialize(sdkKey: String, user: User?, config: HackleConfig = HackleConfig.DEFAULT, completion: @escaping () -> ()) {
+    @preconcurrency @objc public static func initialize(sdkKey: String, user: User?, config: HackleConfig = HackleConfig.DEFAULT, completion: @escaping @Sendable () -> ()) {
         lock.write {
             if container.app != nil {
                 readyToUse(completion: completion)
@@ -69,7 +69,7 @@ import Foundation
         }
     }
 
-    private static func readyToUse(completion: @escaping () -> ()) {
+    private static func readyToUse(completion: @escaping @Sendable () -> ()) {
         queue.async {
             completion()
         }

--- a/Sources/Hackle/Hackle.swift
+++ b/Sources/Hackle/Hackle.swift
@@ -3,7 +3,6 @@
 //
 
 import Foundation
-import UserNotifications
 
 /// The main entry point for the Hackle SDK.
 /// 
@@ -89,6 +88,69 @@ import UserNotifications
     }
 }
 
+// MARK: async initialization
+extension Hackle {
+
+    // NOTE: async initialize는 기존 sync initialize와 동명 오버로드다.
+    // async 컨텍스트에서 `Hackle.initialize(sdkKey:)`를 await 없이 호출하면 async 오버로드가
+    // 우선 선택되어 컴파일 에러가 나는데, 이는 R1 정책([async-await 전환])에 따른 의도된 동작이며
+    // Firebase/Optimizely/Braze/Apple(SE-0297)과 동일한 "Async 접미사 없는" Swift 관례를 따른다.
+
+    /// Initializes the Hackle SDK and suspends until initialization completes.
+    ///
+    /// - Parameter sdkKey: Your Hackle SDK key
+    public static func initialize(sdkKey: String) async {
+        await withCheckedContinuation { continuation in
+            initialize(sdkKey: sdkKey, user: nil, config: HackleConfig.DEFAULT) {
+                continuation.resume()
+            }
+        }
+    }
+    
+    /// Initializes the Hackle SDK and suspends until initialization completes.
+    ///
+    /// - Parameters:
+    ///   - sdkKey: Your Hackle SDK key
+    ///   - user: Initial user to set for the SDK. Can be nil
+    ///   - config: SDK configuration options. Defaults to ``HackleConfig/DEFAULT``
+    public static func initialize(sdkKey: String, user: User?) async {
+        await withCheckedContinuation { continuation in
+            initialize(sdkKey: sdkKey, user: user, config: HackleConfig.DEFAULT) {
+                continuation.resume()
+            }
+        }
+    }
+    
+    /// Initializes the Hackle SDK and suspends until initialization completes.
+    ///
+    /// - Parameters:
+    ///   - sdkKey: Your Hackle SDK key
+    ///   - user: Initial user to set for the SDK. Can be nil
+    ///   - config: SDK configuration options. Defaults to ``HackleConfig/DEFAULT``
+    public static func initialize(sdkKey: String, config: HackleConfig) async {
+        await withCheckedContinuation { continuation in
+            initialize(sdkKey: sdkKey, user: nil, config: config) {
+                continuation.resume()
+            }
+        }
+    }
+    
+    /// Initializes the Hackle SDK and suspends until initialization completes.
+    ///
+    /// - Parameters:
+    ///   - sdkKey: Your Hackle SDK key
+    ///   - user: Initial user to set for the SDK. Can be nil
+    ///   - config: SDK configuration options. Defaults to ``HackleConfig/DEFAULT``
+    public static func initialize(sdkKey: String, user: User?, config: HackleConfig) async {
+        await withCheckedContinuation { continuation in
+            initialize(sdkKey: sdkKey, user: user, config: config) {
+                continuation.resume()
+            }
+        }
+    }
+}
+
+// MARK: convenience
 extension Hackle {
 
     /// Creates a new ``User`` instance with the specified parameters.
@@ -140,165 +202,5 @@ extension Hackle {
             .value(value)
             .properties(properties ?? [:])
             .build()
-    }
-}
-
-extension Hackle {
-    /// Sets the push notification device token.
-    ///
-    /// - Parameter deviceToken: The device token for push notifications
-    @objc static public func setPushToken(_ deviceToken: Data) {
-        DefaultPushTokenRegistry.shared.register(token: PushToken.of(value: deviceToken), timestamp: Date())
-    }
-}
-
-extension Hackle {
-    /// Handles notification presentation in foreground.
-    ///
-    /// - Parameters:
-    ///   - center: The notification center
-    ///   - notification: The notification to be presented
-    ///   - completionHandler: Handler to determine presentation options
-    /// - Returns: True if the notification was handled by Hackle, false otherwise
-    @objc static public func userNotificationCenter(
-        center: UNUserNotificationCenter,
-        willPresent notification: UNNotification,
-        withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
-    ) -> Bool {
-        if let notificationData = NotificationData.from(data: notification.request.content.userInfo) {
-            Log.info("Notification data received in foreground: \(notificationData.showForeground)")
-            if (notificationData.showForeground) {
-                if #available(iOS 14.0, *) {
-                    completionHandler([.list, .banner])
-                } else {
-                    completionHandler([.alert])
-                }
-            }
-            return true
-        } else {
-            return false
-        }
-    }
-
-    /// Handles notification tap responses.
-    ///
-    /// - Parameters:
-    ///   - response: The notification response
-    ///   - handleAction: Whether to automatically handle notification actions. Defaults to true
-    /// - Returns: ``HackleNotification`` if the notification was from Hackle, nil otherwise
-    @objc static public func handleNotification(
-        response: UNNotificationResponse,
-        handleAction: Bool = true
-    ) -> HackleNotification? {
-        guard let notificationData = NotificationData.from(data: response.notification.request.content.userInfo) else {
-            return nil
-        }
-        
-        NotificationHandler.shared.trackPushClickEvent(notificationData: notificationData)
-
-        if handleAction {
-            NotificationHandler.shared.handlePushClickAction(notificationData: notificationData)
-        }
-        
-        return notificationData
-    }
-    
-    /// Handles rich notifications with media attachments.
-    ///
-    /// - Parameters:
-    ///   - request: The notification request
-    ///   - contentHandler: Handler to process the notification content
-    /// - Returns: True if the notification was handled by Hackle, false otherwise
-    @objc static public func handleRichNotification(
-        request: UNNotificationRequest,
-        contentHandler: @escaping (UNNotificationContent) -> Void
-    ) -> Bool {
-        guard let baseNotificationContent: UNMutableNotificationContent = (request.content.mutableCopy() as? UNMutableNotificationContent) else {
-            return false
-        }
-        
-        return handleRichNotification(notificationContent: baseNotificationContent, contentHandler: contentHandler)
-    }
-    
-    /// Handles rich notifications with mutable content.
-    ///
-    /// - Parameters:
-    ///   - notificationContent: The mutable notification content
-    ///   - contentHandler: Handler to process the notification content
-    /// - Returns: True if the notification was handled by Hackle, false otherwise
-    @objc static public func handleRichNotification(
-        notificationContent: UNMutableNotificationContent,
-        contentHandler: @escaping (UNNotificationContent) -> Void
-    ) -> Bool {
-        guard let notificationData = NotificationData.from(data: notificationContent.userInfo) else {
-            return false
-        }
-        
-        return resolveRichNotificationContent(notificationContent: notificationContent, completion: { hackleNotificationContent in
-            contentHandler(hackleNotificationContent)
-        })
-    }
-    
-    /// Resolves rich notification content from a notification request.
-    ///
-    /// - Parameters:
-    ///   - request: The notification request
-    ///   - completion: Completion handler with resolved content
-    /// - Returns: True if the notification was handled by Hackle, false otherwise
-    @objc static public func resolveRichNotificationContent(
-        request: UNNotificationRequest,
-        completion: @escaping (UNMutableNotificationContent) -> Void
-    ) -> Bool {
-        guard let baseNotificationContent: UNMutableNotificationContent = (request.content.mutableCopy() as? UNMutableNotificationContent) else {
-            return false
-        }
-        
-        return resolveRichNotificationContent(notificationContent: baseNotificationContent, completion: completion)
-    }
-    
-    /// Resolves rich notification content from mutable content.
-    ///
-    /// - Parameters:
-    ///   - notificationContent: The mutable notification content
-    ///   - completion: Completion handler with resolved content
-    /// - Returns: True if the notification was handled by Hackle, false otherwise
-    @objc static public func resolveRichNotificationContent(
-        notificationContent: UNMutableNotificationContent,
-        completion: @escaping (UNMutableNotificationContent) -> Void
-    ) -> Bool {
-        guard let notificationData = NotificationData.from(data: notificationContent.userInfo) else {
-            return false
-        }
-        
-        // NOTE: use dispatch group when add another attachment, and etc...
-        NotificationHandler.shared.handlePushImage(notificationData: notificationData) { attachment in
-            if let attachment = attachment {
-                notificationContent.attachments = [attachment]
-            }
-            
-            completion(notificationContent)
-        }
-        
-        return true
-    }
-
-    /// Handles notification responses
-    ///
-    /// - Parameters:
-    ///   - center: The notification center
-    ///   - response: The notification response
-    ///   - completionHandler: Completion handler
-    /// - Returns: True if the notification was handled by Hackle, false otherwise
-    @available(*, deprecated, message: "Use handleClickNotification(UNNotificationResponse, Bool) instead.")
-    @objc static public func userNotificationCenter(
-        center: UNUserNotificationCenter,
-        didReceive response: UNNotificationResponse,
-        withCompletionHandler completionHandler: @escaping () -> Void
-    ) -> Bool {
-        if handleNotification(response: response) == nil {
-            return false
-        }
-        completionHandler()
-        return true
     }
 }

--- a/Sources/Hackle/Hackle.swift
+++ b/Sources/Hackle/Hackle.swift
@@ -90,12 +90,6 @@ import Foundation
 
 // MARK: async initialization
 extension Hackle {
-
-    // NOTE: async initialize는 기존 sync initialize와 동명 오버로드다.
-    // async 컨텍스트에서 `Hackle.initialize(sdkKey:)`를 await 없이 호출하면 async 오버로드가
-    // 우선 선택되어 컴파일 에러가 나는데, 이는 R1 정책([async-await 전환])에 따른 의도된 동작이며
-    // Firebase/Optimizely/Braze/Apple(SE-0297)과 동일한 "Async 접미사 없는" Swift 관례를 따른다.
-
     /// Initializes the Hackle SDK and suspends until initialization completes.
     ///
     /// - Parameter sdkKey: Your Hackle SDK key

--- a/Sources/Hackle/HackleApp+Deprecate.swift
+++ b/Sources/Hackle/HackleApp+Deprecate.swift
@@ -8,86 +8,246 @@
 import Foundation
 
 extension HackleApp {
+    /// Sets or replaces the current user.
+    ///
+    /// - Parameter user: the ``User`` to set
+    @available(*, deprecated, message: "Use async setUser(user:) or setUser(user:completion:) instead.")
+    @objc public func setUser(user: User) {
+        setUser(user: user, completion: {})
+    }
+
+    /// Sets the userId for the current user.
+    ///
+    /// - Parameter userId: the userId to set for the user. Can be null to identify an anonymous user
+    @available(*, deprecated, message: "Use async setUserId(userId:) or setUserId(userId:completion:) instead.")
+    @objc public func setUserId(userId: String?) {
+        setUserId(userId: userId, completion: {})
+    }
+
+    /// Sets a custom device ID.
+    ///
+    /// - Parameter deviceId: the custom device ID to set
+    @available(*, deprecated, message: "Use async setDeviceId(deviceId:) or setDeviceId(deviceId:completion:) instead.")
+    @objc public func setDeviceId(deviceId: String) {
+        setDeviceId(deviceId: deviceId, completion: {})
+    }
+
+    /// Sets a single user property.
+    ///
+    /// - Parameters:
+    ///   - key: the key of the property
+    ///   - value: the value of the property
+    @available(*, deprecated, message: "Use async setUserProperty(key:value:) or setUserProperty(key:value:completion:) instead.")
+    @objc public func setUserProperty(key: String, value: Any?) {
+        let operations = PropertyOperations.builder()
+            .set(key, value)
+            .build()
+        updateUserProperties(operations: operations, completion: {})
+    }
+
+    /// Updates user properties with a set of operations.
+    ///
+    /// - Parameter operations: a set of ``PropertyOperations`` to apply to user properties
+    @available(*, deprecated, message: "Use async updateUserProperties(operations:) or updateUserProperties(operations:completion:) instead.")
+    @objc public func updateUserProperties(operations: PropertyOperations) {
+        updateUserProperties(operations: operations, completion: {})
+    }
+
+    /// Resets the current user.
+    @available(*, deprecated, message: "Use async resetUser() or resetUser(completion:) instead.")
+    @objc public func resetUser() {
+        resetUser(completion: {})
+    }
+
+    /// Sets the phone number for the current user.
+    ///
+    /// - Parameter phoneNumber: the phone number to set
+    @available(*, deprecated, message: "Use async setPhoneNumber(phoneNumber:) or setPhoneNumber(phoneNumber:completion:) instead.")
+    @objc public func setPhoneNumber(phoneNumber: String) {
+        setPhoneNumber(phoneNumber: phoneNumber, completion: {})
+    }
+
+    /// Removes the phone number from the current user.
+    @available(*, deprecated, message: "Use async unsetPhoneNumber() or unsetPhoneNumber(completion:) instead.")
+    @objc public func unsetPhoneNumber() {
+        unsetPhoneNumber(completion: {})
+    }
+
+    /// Decide the variation to expose to the user for experiment.
+    ///
+    /// - Parameters:
+    ///   - experimentKey: the unique key of the experiment
+    ///   - defaultVariation: the default variation to return if the experiment cannot be decided
+    /// - Returns: the decided variation for the user, or defaultVariation
     @available(*, deprecated, message: "Use variation(experimentKey) without defaultVariation instead.")
     @objc public func variation(experimentKey: Int, defaultVariation: String) -> String {
         variationDetail(experimentKey: experimentKey, defaultVariation: defaultVariation).variation
     }
 
+    /// Decide the variation to expose to the user for experiment and returns an object that describes the way the variation was decided.
+    ///
+    /// - Parameters:
+    ///   - experimentKey: the unique key for the experiment
+    ///   - defaultVariation: the default variation to return if the experiment cannot be decided
+    /// - Returns: a ``Decision`` object
     @available(*, deprecated, message: "Use variationDetail(experimentKey) without defaultVariation instead.")
     @objc public func variationDetail(experimentKey: Int, defaultVariation: String) -> Decision {
         hackleAppCore.variationDetail(experimentKey: experimentKey, user: nil, defaultVariation: defaultVariation, hackleAppContext: .default)
     }
-    
+
+    /// Decide the variation to expose to the user for experiment.
+    ///
+    /// - Parameters:
+    ///   - experimentKey: the unique key of the experiment
+    ///   - userId: the identifier of the user to decide the variation for
+    ///   - defaultVariation: the default variation to return if the experiment cannot be decided
+    /// - Returns: the decided variation for the user, or defaultVariation
     @available(*, deprecated, message: "Use variation(experimentKey) with setUser(user) instead.")
     @objc public func variation(experimentKey: Int, userId: String, defaultVariation: String = "A") -> String {
         hackleAppCore.variationDetail(experimentKey: experimentKey, user: Hackle.user(id: userId), defaultVariation: defaultVariation, hackleAppContext: .default).variation
     }
 
+    /// Decide the variation to expose to the user for experiment.
+    ///
+    /// - Parameters:
+    ///   - experimentKey: the unique key of the experiment
+    ///   - user: the ``User`` to decide the variation for
+    ///   - defaultVariation: the default variation to return if the experiment cannot be decided
+    /// - Returns: the decided variation for the user, or defaultVariation
     @available(*, deprecated, message: "Use variation(experimentKey) with setUser(user) instead.")
     @objc public func variation(experimentKey: Int, user: User, defaultVariation: String = "A") -> String {
         hackleAppCore.variationDetail(experimentKey: experimentKey, user: user, defaultVariation: defaultVariation, hackleAppContext: .default).variation
     }
 
+    /// Decide the variation to expose to the user for experiment and returns an object that describes the way the variation was decided.
+    ///
+    /// - Parameters:
+    ///   - experimentKey: the unique key for the experiment
+    ///   - userId: the identifier of the user to decide the variation for
+    ///   - defaultVariation: the default variation to return if the experiment cannot be decided
+    /// - Returns: a ``Decision`` object
     @available(*, deprecated, message: "Use variationDetail(experimentKey) with setUser(user) instead,")
     @objc public func variationDetail(experimentKey: Int, userId: String, defaultVariation: String = "A") -> Decision {
         hackleAppCore.variationDetail(experimentKey: experimentKey, user: Hackle.user(id: userId), defaultVariation: defaultVariation, hackleAppContext: .default)
     }
 
+    /// Decide the variation to expose to the user for experiment and returns an object that describes the way the variation was decided.
+    ///
+    /// - Parameters:
+    ///   - experimentKey: the unique key for the experiment
+    ///   - user: the ``User`` to decide the variation for
+    ///   - defaultVariation: the default variation to return if the experiment cannot be decided
+    /// - Returns: a ``Decision`` object
     @available(*, deprecated, message: "Use variationDetail(experimentKey) with setUser(user) instead,")
     @objc public func variationDetail(experimentKey: Int, user: User, defaultVariation: String = "A") -> Decision {
         hackleAppCore.variationDetail(experimentKey: experimentKey, user: user, defaultVariation: defaultVariation, hackleAppContext: .default)
     }
 
+    /// Decide the variations for all experiments and returns a map of decision results.
+    ///
+    /// - Parameter user: the ``User`` to decide the variations for
+    /// - Returns: a dictionary where key is experimentKey and value is ``Decision`` result
     @available(*, deprecated, message: "Use allVariationDetails() with setUser(user) instead.")
     @objc public func allVariationDetails(user: User) -> [Int: Decision] {
         hackleAppCore.allVariationDetails(user: user, hackleAppContext: .default)
     }
 
+    /// Decide whether the feature is turned on to the user.
+    ///
+    /// - Parameters:
+    ///   - featureKey: the unique key for the feature
+    ///   - userId: the identifier of the user to decide the feature flag for
+    /// - Returns: True if the feature is on, False if the feature is off
     @available(*, deprecated, message: "Use isFeatureOn(featureKey) with setUser(user) instead.")
     @objc public func isFeatureOn(featureKey: Int, userId: String) -> Bool {
         hackleAppCore.featureFlagDetail(featureKey: featureKey, user: Hackle.user(id: userId), hackleAppContext: .default).isOn
     }
 
+    /// Decide whether the feature is turned on to the user.
+    ///
+    /// - Parameters:
+    ///   - featureKey: the unique key for the feature
+    ///   - user: the ``User`` to decide the feature flag for
+    /// - Returns: True if the feature is on, False if the feature is off
     @available(*, deprecated, message: "Use isFeatureOn(featureKey) with setUser(user) instead.")
     @objc public func isFeatureOn(featureKey: Int, user: User) -> Bool {
         hackleAppCore.featureFlagDetail(featureKey: featureKey, user: user, hackleAppContext: .default).isOn
     }
 
+    /// Decide whether the feature is turned on to the user and returns an object that describes the way the flag was decided.
+    ///
+    /// - Parameters:
+    ///   - featureKey: the unique key for the feature
+    ///   - userId: the identifier of the user to decide the feature flag for
+    /// - Returns: a ``FeatureFlagDecision`` object
     @available(*, deprecated, message: "Use featureFlagDetail(featureKey) with setUser(user) instead.")
     @objc public func featureFlagDetail(featureKey: Int, userId: String) -> FeatureFlagDecision {
         hackleAppCore.featureFlagDetail(featureKey: featureKey, user: Hackle.user(id: userId), hackleAppContext: .default)
     }
 
+    /// Decide whether the feature is turned on to the user and returns an object that describes the way the flag was decided.
+    ///
+    /// - Parameters:
+    ///   - featureKey: the unique key for the feature
+    ///   - user: the ``User`` to decide the feature flag for
+    /// - Returns: a ``FeatureFlagDecision`` object
     @available(*, deprecated, message: "Use featureFlagDetail(featureKey) with setUser(user) instead.")
     @objc public func featureFlagDetail(featureKey: Int, user: User) -> FeatureFlagDecision {
         hackleAppCore.featureFlagDetail(featureKey: featureKey, user: user, hackleAppContext: .default)
     }
 
+    /// Records the event that occurred by the user.
+    ///
+    /// - Parameters:
+    ///   - eventKey: the unique key of the event that occurred
+    ///   - userId: the identifier of the user who triggered the event
     @available(*, deprecated, message: "Use track(eventKey) with setUser(user) instead.")
     @objc public func track(eventKey: String, userId: String) {
         hackleAppCore.track(event: Hackle.event(key: eventKey), user: Hackle.user(id: userId), hackleAppContext: .default)
     }
 
+    /// Records the event that occurred by the user.
+    ///
+    /// - Parameters:
+    ///   - eventKey: the unique key of the event that occurred
+    ///   - user: the ``User`` who triggered the event
     @available(*, deprecated, message: "Use track(eventKey) with setUser(user) instead.")
     @objc public func track(eventKey: String, user: User) {
         hackleAppCore.track(event: Hackle.event(key: eventKey), user: user, hackleAppContext: .default)
     }
 
+    /// Records the event that occurred by the user.
+    ///
+    /// - Parameters:
+    ///   - event: the ``Event`` that occurred
+    ///   - userId: the identifier of the user who triggered the event
     @available(*, deprecated, message: "Use track(event) with setUser(user) instead.")
     @objc public func track(event: Event, userId: String) {
         hackleAppCore.track(event: event, user: Hackle.user(id: userId), hackleAppContext: .default)
     }
 
+    /// Records the event that occurred by the user.
+    ///
+    /// - Parameters:
+    ///   - event: the ``Event`` that occurred
+    ///   - user: the ``User`` who triggered the event
     @available(*, deprecated, message: "Use track(event) with setUser(user) instead.")
     @objc public func track(event: Event, user: User) {
         hackleAppCore.track(event: event, user: user, hackleAppContext: .default)
     }
 
+    /// Returns an instance of Hackle Remote Config.
+    ///
+    /// - Parameter user: the ``User`` to evaluate the remote config for
+    /// - Returns: a ``HackleRemoteConfig`` instance
     @available(*, deprecated, message: "Use remoteConfig() with setUser(user) instead.")
     @objc public func remoteConfig(user: User) -> HackleRemoteConfig {
         DefaultRemoteConfig(hackleAppCore: hackleAppCore, user: user)
     }
 
+    /// Updates push notification subscription status.
+    ///
+    /// - Parameter status: the ``HacklePushSubscriptionStatus`` to apply
     @available(*, deprecated, message: "Do not use this method because it does nothing. Use `updatePushSubscriptions(operations)` instead.")
     @objc public func updatePushSubscriptionStatus(status: HacklePushSubscriptionStatus) {
         Log.error("updatePushSubscriptionStatus does nothing. Use updatePushSubscriptions(operations) instead.")

--- a/Sources/Hackle/HackleApp+Deprecate.swift
+++ b/Sources/Hackle/HackleApp+Deprecate.swift
@@ -1,0 +1,95 @@
+//
+//  HackleApp+Deprecate.swift
+//  Hackle
+//
+//  Created by sungwoo.yeo on 7/6/26.
+//
+
+import Foundation
+
+extension HackleApp {
+    @available(*, deprecated, message: "Use variation(experimentKey) without defaultVariation instead.")
+    @objc public func variation(experimentKey: Int, defaultVariation: String) -> String {
+        variationDetail(experimentKey: experimentKey, defaultVariation: defaultVariation).variation
+    }
+
+    @available(*, deprecated, message: "Use variationDetail(experimentKey) without defaultVariation instead.")
+    @objc public func variationDetail(experimentKey: Int, defaultVariation: String) -> Decision {
+        hackleAppCore.variationDetail(experimentKey: experimentKey, user: nil, defaultVariation: defaultVariation, hackleAppContext: .default)
+    }
+    
+    @available(*, deprecated, message: "Use variation(experimentKey) with setUser(user) instead.")
+    @objc public func variation(experimentKey: Int, userId: String, defaultVariation: String = "A") -> String {
+        hackleAppCore.variationDetail(experimentKey: experimentKey, user: Hackle.user(id: userId), defaultVariation: defaultVariation, hackleAppContext: .default).variation
+    }
+
+    @available(*, deprecated, message: "Use variation(experimentKey) with setUser(user) instead.")
+    @objc public func variation(experimentKey: Int, user: User, defaultVariation: String = "A") -> String {
+        hackleAppCore.variationDetail(experimentKey: experimentKey, user: user, defaultVariation: defaultVariation, hackleAppContext: .default).variation
+    }
+
+    @available(*, deprecated, message: "Use variationDetail(experimentKey) with setUser(user) instead,")
+    @objc public func variationDetail(experimentKey: Int, userId: String, defaultVariation: String = "A") -> Decision {
+        hackleAppCore.variationDetail(experimentKey: experimentKey, user: Hackle.user(id: userId), defaultVariation: defaultVariation, hackleAppContext: .default)
+    }
+
+    @available(*, deprecated, message: "Use variationDetail(experimentKey) with setUser(user) instead,")
+    @objc public func variationDetail(experimentKey: Int, user: User, defaultVariation: String = "A") -> Decision {
+        hackleAppCore.variationDetail(experimentKey: experimentKey, user: user, defaultVariation: defaultVariation, hackleAppContext: .default)
+    }
+
+    @available(*, deprecated, message: "Use allVariationDetails() with setUser(user) instead.")
+    @objc public func allVariationDetails(user: User) -> [Int: Decision] {
+        hackleAppCore.allVariationDetails(user: user, hackleAppContext: .default)
+    }
+
+    @available(*, deprecated, message: "Use isFeatureOn(featureKey) with setUser(user) instead.")
+    @objc public func isFeatureOn(featureKey: Int, userId: String) -> Bool {
+        hackleAppCore.featureFlagDetail(featureKey: featureKey, user: Hackle.user(id: userId), hackleAppContext: .default).isOn
+    }
+
+    @available(*, deprecated, message: "Use isFeatureOn(featureKey) with setUser(user) instead.")
+    @objc public func isFeatureOn(featureKey: Int, user: User) -> Bool {
+        hackleAppCore.featureFlagDetail(featureKey: featureKey, user: user, hackleAppContext: .default).isOn
+    }
+
+    @available(*, deprecated, message: "Use featureFlagDetail(featureKey) with setUser(user) instead.")
+    @objc public func featureFlagDetail(featureKey: Int, userId: String) -> FeatureFlagDecision {
+        hackleAppCore.featureFlagDetail(featureKey: featureKey, user: Hackle.user(id: userId), hackleAppContext: .default)
+    }
+
+    @available(*, deprecated, message: "Use featureFlagDetail(featureKey) with setUser(user) instead.")
+    @objc public func featureFlagDetail(featureKey: Int, user: User) -> FeatureFlagDecision {
+        hackleAppCore.featureFlagDetail(featureKey: featureKey, user: user, hackleAppContext: .default)
+    }
+
+    @available(*, deprecated, message: "Use track(eventKey) with setUser(user) instead.")
+    @objc public func track(eventKey: String, userId: String) {
+        hackleAppCore.track(event: Hackle.event(key: eventKey), user: Hackle.user(id: userId), hackleAppContext: .default)
+    }
+
+    @available(*, deprecated, message: "Use track(eventKey) with setUser(user) instead.")
+    @objc public func track(eventKey: String, user: User) {
+        hackleAppCore.track(event: Hackle.event(key: eventKey), user: user, hackleAppContext: .default)
+    }
+
+    @available(*, deprecated, message: "Use track(event) with setUser(user) instead.")
+    @objc public func track(event: Event, userId: String) {
+        hackleAppCore.track(event: event, user: Hackle.user(id: userId), hackleAppContext: .default)
+    }
+
+    @available(*, deprecated, message: "Use track(event) with setUser(user) instead.")
+    @objc public func track(event: Event, user: User) {
+        hackleAppCore.track(event: event, user: user, hackleAppContext: .default)
+    }
+
+    @available(*, deprecated, message: "Use remoteConfig() with setUser(user) instead.")
+    @objc public func remoteConfig(user: User) -> HackleRemoteConfig {
+        DefaultRemoteConfig(hackleAppCore: hackleAppCore, user: user)
+    }
+
+    @available(*, deprecated, message: "Do not use this method because it does nothing. Use `updatePushSubscriptions(operations)` instead.")
+    @objc public func updatePushSubscriptionStatus(status: HacklePushSubscriptionStatus) {
+        Log.error("updatePushSubscriptionStatus does nothing. Use updatePushSubscriptions(operations) instead.")
+    }
+}

--- a/Sources/Hackle/HackleApp.swift
+++ b/Sources/Hackle/HackleApp.swift
@@ -6,10 +6,11 @@ import WebKit
 
 /// Entry point of Hackle SDK.
 @objc public final class HackleApp: NSObject {
-    private let hackleAppCore: HackleAppCore
+    let hackleAppCore: HackleAppCore
     let sdk: Sdk
     let config: HackleConfig
     let hackleInvocator: HackleInvocator
+    private let completionQueue = DispatchQueue(label: "io.hackle.HackleApp.CompletionQueue")
 
     init(
         hackleAppCore: HackleAppCore,
@@ -90,6 +91,7 @@ import WebKit
     /// Sets or replaces the current user.
     ///
     /// - Parameter user: the ``User`` to set
+    @available(*, deprecated, message: "Use async setUser(user:) or setUser(user:completion:) instead.")
     @objc public func setUser(user: User) {
         setUser(user: user, completion: {})
     }
@@ -100,12 +102,14 @@ import WebKit
     ///   - user: the ``User`` to set
     ///   - completion: callback to be executed when the operation is complete
     @objc public func setUser(user: User, completion: @escaping () -> ()) {
-        hackleAppCore.setUser(user: user, hackleAppContext: .default, completion: completion)
+        hackleAppCore.setUser(user: user, hackleAppContext: .default)
+            .onComplete(queue: completionQueue, completion)
     }
 
     /// Sets the userId for the current user.
     ///
     /// - Parameter userId: the userId to set for the user. Can be null to identify an anonymous user
+    @available(*, deprecated, message: "Use async setUserId(userId:) or setUserId(userId:completion:) instead.")
     @objc public func setUserId(userId: String?) {
         setUserId(userId: userId, completion: {})
     }
@@ -116,12 +120,14 @@ import WebKit
     ///   - userId: the userId to set for the user. Can be null to identify an anonymous user
     ///   - completion: callback to be executed when the operation is complete
     @objc public func setUserId(userId: String?, completion: @escaping () -> ()) {
-        hackleAppCore.setUserId(userId: userId, hackleAppContext: .default, completion: completion)
+        hackleAppCore.setUserId(userId: userId, hackleAppContext: .default)
+            .onComplete(queue: completionQueue, completion)
     }
 
     /// Sets a custom device ID.
     ///
     /// - Parameter deviceId: the custom device ID to set
+    @available(*, deprecated, message: "Use async setDeviceId(deviceId:) or setDeviceId(deviceId:completion:) instead.")
     @objc public func setDeviceId(deviceId: String) {
         setDeviceId(deviceId: deviceId, completion: {})
     }
@@ -132,7 +138,8 @@ import WebKit
     ///   - deviceId: the custom device ID to set
     ///   - completion: callback to be executed when the operation is complete
     @objc public func setDeviceId(deviceId: String, completion: @escaping () -> ()) {
-        hackleAppCore.setDeviceId(deviceId: deviceId, hackleAppContext: .default, completion: completion)
+        hackleAppCore.setDeviceId(deviceId: deviceId, hackleAppContext: .default)
+            .onComplete(queue: completionQueue, completion)
     }
 
     /// Sets a single user property.
@@ -140,11 +147,12 @@ import WebKit
     /// - Parameters:
     ///   - key: the key of the property
     ///   - value: the value of the property
+    @available(*, deprecated, message: "Use async setUserProperty(key:value:) or setUserProperty(key:value:completion:) instead.")
     @objc public func setUserProperty(key: String, value: Any?) {
         let operations = PropertyOperations.builder()
             .set(key, value)
             .build()
-        updateUserProperties(operations: operations)
+        updateUserProperties(operations: operations, completion: {})
     }
 
     /// Sets a single user property with completion.
@@ -163,6 +171,7 @@ import WebKit
     /// Updates user properties with a set of operations.
     ///
     /// - Parameter operations: a set of ``PropertyOperations`` to apply to user properties
+    @available(*, deprecated, message: "Use async updateUserProperties(operations:) or updateUserProperties(operations:completion:) instead.")
     @objc public func updateUserProperties(operations: PropertyOperations) {
         updateUserProperties(operations: operations, completion: {})
     }
@@ -173,7 +182,8 @@ import WebKit
     ///   - operations: a set of ``PropertyOperations`` to apply to user properties
     ///   - completion: callback to be executed when the operation is complete
     @objc public func updateUserProperties(operations: PropertyOperations, completion: @escaping () -> ()) {
-        hackleAppCore.updateUserProperties(operations: operations, hackleAppContext: .default, completion: completion)
+        hackleAppCore.updateUserProperties(operations: operations, hackleAppContext: .default)
+        completion()
     }
 
     /// Updates push notification subscription status.
@@ -198,6 +208,7 @@ import WebKit
     }
 
     /// Resets the current user.
+    @available(*, deprecated, message: "Use async resetUser() or resetUser(completion:) instead.")
     @objc public func resetUser() {
         resetUser(completion: {})
     }
@@ -206,12 +217,14 @@ import WebKit
     ///
     /// - Parameter completion: callback to be executed when the operation is complete
     @objc public func resetUser(completion: @escaping () -> ()) {
-        hackleAppCore.resetUser(hackleAppContext: .default, completion: completion)
+        hackleAppCore.resetUser(hackleAppContext: .default)
+            .onComplete(queue: completionQueue, completion)
     }
 
     /// Sets the phone number for the current user.
     ///
     /// - Parameter phoneNumber: the phone number to set
+    @available(*, deprecated, message: "Use async setPhoneNumber(phoneNumber:) or setPhoneNumber(phoneNumber:completion:) instead.")
     @objc public func setPhoneNumber(phoneNumber: String) {
         setPhoneNumber(phoneNumber: phoneNumber, completion: {})
     }
@@ -222,10 +235,12 @@ import WebKit
     ///   - phoneNumber: the phone number to set
     ///   - completion: callback to be executed when the operation is complete
     @objc public func setPhoneNumber(phoneNumber: String, completion: @escaping () -> ()) {
-        hackleAppCore.setPhoneNumber(phoneNumber: phoneNumber, hackleAppContext: .default, completion: completion)
+        hackleAppCore.setPhoneNumber(phoneNumber: phoneNumber, hackleAppContext: .default)
+        completion()
     }
 
     /// Removes the phone number from the current user.
+    @available(*, deprecated, message: "Use async unsetPhoneNumber() or unsetPhoneNumber(completion:) instead.")
     @objc public func unsetPhoneNumber() {
         unsetPhoneNumber(completion: {})
     }
@@ -234,29 +249,28 @@ import WebKit
     ///
     /// - Parameter completion: callback to be executed when the operation is complete
     @objc public func unsetPhoneNumber(completion: @escaping () -> ()) {
-        hackleAppCore.unsetPhoneNumber(hackleAppContext: .default, completion: completion)
+        hackleAppCore.unsetPhoneNumber(hackleAppContext: .default)
+        completion()
     }
-
+    
     /// Decide the variation to expose to the user for experiment.
     ///
     /// - Parameters:
     ///   - experimentKey: the unique key of the experiment
-    ///   - defaultVariation: the default variation of the experiment
     /// - Returns: the decided variation for the user, or defaultVariation
-    @objc public func variation(experimentKey: Int, defaultVariation: String = "A") -> String {
-        variationDetail(experimentKey: experimentKey, defaultVariation: defaultVariation).variation
+    @objc public func variation(experimentKey: Int) -> String {
+        variationDetail(experimentKey: experimentKey).variation
     }
 
     /// Decide the variation to expose to the user for experiment and returns an object that describes the way the variation was decided.
     ///
     /// - Parameters:
     ///   - experimentKey: the unique key for the experiment
-    ///   - defaultVariation: the default variation of the experiment
     /// - Returns: a ``Decision`` object
-    @objc public func variationDetail(experimentKey: Int, defaultVariation: String = "A") -> Decision {
-        hackleAppCore.variationDetail(experimentKey: experimentKey, user: nil, defaultVariation: defaultVariation, hackleAppContext: .default)
+    @objc public func variationDetail(experimentKey: Int) -> Decision {
+        hackleAppCore.variationDetail(experimentKey: experimentKey, user: nil, defaultVariation: "A", hackleAppContext: .default)
     }
-
+    
     /// Decide the variations for all experiments and returns a map of decision results.
     ///
     /// - Returns: a dictionary where key is experimentKey and value is ``Decision`` result
@@ -330,7 +344,8 @@ import WebKit
     ///
     /// - Parameter completion: callback to be executed when the fetch is complete
     @objc public func fetch(_ completion: @escaping () -> ()) {
-        hackleAppCore.fetch(completion: completion)
+        hackleAppCore.fetch()
+            .onComplete(queue: completionQueue, completion)
     }
 
     /// Sets the current screen for screen tracking.
@@ -339,80 +354,79 @@ import WebKit
     @objc public func setCurrentScreen(screen: Screen) {
         hackleAppCore.setCurrentScreen(screen: screen, hackleAppContext: .default)
     }
+}
 
-    @available(*, deprecated, message: "Use variation(experimentKey) with setUser(user) instead.")
-    @objc public func variation(experimentKey: Int, userId: String, defaultVariation: String = "A") -> String {
-        hackleAppCore.variationDetail(experimentKey: experimentKey, user: Hackle.user(id: userId), defaultVariation: defaultVariation, hackleAppContext: .default).variation
+// MARK: async interaction
+extension HackleApp {
+    
+    /// Sets or replaces the current user, and suspends until the user synchronization completes.
+    ///
+    /// The user is updated synchronously before the first suspension point.
+    ///
+    /// - Parameter user: the ``User`` to set
+    public func setUser(user: User) async {
+        await hackleAppCore.setUser(user: user, hackleAppContext: .default).value
     }
 
-    @available(*, deprecated, message: "Use variation(experimentKey) with setUser(user) instead.")
-    @objc public func variation(experimentKey: Int, user: User, defaultVariation: String = "A") -> String {
-        hackleAppCore.variationDetail(experimentKey: experimentKey, user: user, defaultVariation: defaultVariation, hackleAppContext: .default).variation
+    /// Sets the userId for the current user, and suspends until the user synchronization completes.
+    ///
+    /// The user is updated synchronously before the first suspension point.
+    ///
+    /// - Parameter userId: the userId to set for the user. Can be null to identify an anonymous user
+    public func setUserId(userId: String?) async {
+        await hackleAppCore.setUserId(userId: userId, hackleAppContext: .default).value
     }
 
-    @available(*, deprecated, message: "Use variationDetail(experimentKey) with setUser(user) instead,")
-    @objc public func variationDetail(experimentKey: Int, userId: String, defaultVariation: String = "A") -> Decision {
-        hackleAppCore.variationDetail(experimentKey: experimentKey, user: Hackle.user(id: userId), defaultVariation: defaultVariation, hackleAppContext: .default)
+    /// Sets a custom device ID, and suspends until the user synchronization completes.
+    ///
+    /// The user is updated synchronously before the first suspension point.
+    ///
+    /// - Parameter deviceId: the custom device ID to set
+    public func setDeviceId(deviceId: String) async {
+        await hackleAppCore.setDeviceId(deviceId: deviceId, hackleAppContext: .default).value
     }
 
-    @available(*, deprecated, message: "Use variationDetail(experimentKey) with setUser(user) instead,")
-    @objc public func variationDetail(experimentKey: Int, user: User, defaultVariation: String = "A") -> Decision {
-        hackleAppCore.variationDetail(experimentKey: experimentKey, user: user, defaultVariation: defaultVariation, hackleAppContext: .default)
+    /// Sets a single user property.
+    ///
+    /// - Parameters:
+    ///   - key: the key of the property
+    ///   - value: the value of the property
+    public func setUserProperty(key: String, value: Any?) async {
+        let operations = PropertyOperations.builder()
+            .set(key, value)
+            .build()
+        await updateUserProperties(operations: operations)
     }
 
-    @available(*, deprecated, message: "Use allVariationDetails() with setUser(user) instead.")
-    @objc public func allVariationDetails(user: User) -> [Int: Decision] {
-        hackleAppCore.allVariationDetails(user: user, hackleAppContext: .default)
+    /// Updates user properties with a set of operations.
+    ///
+    /// - Parameter operations: a set of ``PropertyOperations`` to apply to user properties
+    public func updateUserProperties(operations: PropertyOperations) async {
+        hackleAppCore.updateUserProperties(operations: operations, hackleAppContext: .default)
     }
 
-    @available(*, deprecated, message: "Use isFeatureOn(featureKey) with setUser(user) instead.")
-    @objc public func isFeatureOn(featureKey: Int, userId: String) -> Bool {
-        hackleAppCore.featureFlagDetail(featureKey: featureKey, user: Hackle.user(id: userId), hackleAppContext: .default).isOn
+    /// Resets the current user, and suspends until the user synchronization completes.
+    ///
+    /// The user is updated synchronously before the first suspension point.
+    public func resetUser() async {
+        await hackleAppCore.resetUser(hackleAppContext: .default).value
     }
 
-    @available(*, deprecated, message: "Use isFeatureOn(featureKey) with setUser(user) instead.")
-    @objc public func isFeatureOn(featureKey: Int, user: User) -> Bool {
-        hackleAppCore.featureFlagDetail(featureKey: featureKey, user: user, hackleAppContext: .default).isOn
+    /// Sets the phone number for the current user.
+    ///
+    /// - Parameter phoneNumber: the phone number to set
+    public func setPhoneNumber(phoneNumber: String) async {
+        hackleAppCore.setPhoneNumber(phoneNumber: phoneNumber, hackleAppContext: .default)
     }
 
-    @available(*, deprecated, message: "Use featureFlagDetail(featureKey) with setUser(user) instead.")
-    @objc public func featureFlagDetail(featureKey: Int, userId: String) -> FeatureFlagDecision {
-        hackleAppCore.featureFlagDetail(featureKey: featureKey, user: Hackle.user(id: userId), hackleAppContext: .default)
+    /// Removes the phone number from the current user.
+    public func unsetPhoneNumber() async {
+        hackleAppCore.unsetPhoneNumber(hackleAppContext: .default)
     }
 
-    @available(*, deprecated, message: "Use featureFlagDetail(featureKey) with setUser(user) instead.")
-    @objc public func featureFlagDetail(featureKey: Int, user: User) -> FeatureFlagDecision {
-        hackleAppCore.featureFlagDetail(featureKey: featureKey, user: user, hackleAppContext: .default)
-    }
-
-    @available(*, deprecated, message: "Use track(eventKey) with setUser(user) instead.")
-    @objc public func track(eventKey: String, userId: String) {
-        hackleAppCore.track(event: Hackle.event(key: eventKey), user: Hackle.user(id: userId), hackleAppContext: .default)
-    }
-
-    @available(*, deprecated, message: "Use track(eventKey) with setUser(user) instead.")
-    @objc public func track(eventKey: String, user: User) {
-        hackleAppCore.track(event: Hackle.event(key: eventKey), user: user, hackleAppContext: .default)
-    }
-
-    @available(*, deprecated, message: "Use track(event) with setUser(user) instead.")
-    @objc public func track(event: Event, userId: String) {
-        hackleAppCore.track(event: event, user: Hackle.user(id: userId), hackleAppContext: .default)
-    }
-
-    @available(*, deprecated, message: "Use track(event) with setUser(user) instead.")
-    @objc public func track(event: Event, user: User) {
-        hackleAppCore.track(event: event, user: user, hackleAppContext: .default)
-    }
-
-    @available(*, deprecated, message: "Use remoteConfig() with setUser(user) instead.")
-    @objc public func remoteConfig(user: User) -> HackleRemoteConfig {
-        DefaultRemoteConfig(hackleAppCore: hackleAppCore, user: user)
-    }
-
-    @available(*, deprecated, message: "Do not use this method because it does nothing. Use `updatePushSubscriptions(operations)` instead.")
-    @objc public func updatePushSubscriptionStatus(status: HacklePushSubscriptionStatus) {
-        Log.error("updatePushSubscriptionStatus does nothing. Use updatePushSubscriptions(operations) instead.")
+    /// Fetches the latest configuration from the Hackle servers, and suspends until the fetch completes.
+    public func fetch() async {
+        await hackleAppCore.fetch().value
     }
 }
 
@@ -435,9 +449,7 @@ extension HackleApp {
 
         // - Synchronizer
 
-        let compositeSynchronizer = CompositeSynchronizer(
-            dispatchQueue: DispatchQueue(label: "io.hackle.DelegatingSynchronizer", attributes: .concurrent)
-        )
+        let compositeSynchronizer = CompositeSynchronizer()
         let pollingSynchronizer = PollingSynchronizer(
             delegate: compositeSynchronizer,
             scheduler: Schedulers.dispatch(queue: DispatchQueue(label: "io.hackle.scheduler.PollingSynchronizer")),

--- a/Sources/Hackle/HackleApp.swift
+++ b/Sources/Hackle/HackleApp.swift
@@ -93,7 +93,7 @@ import WebKit
     /// - Parameters:
     ///   - user: the ``User`` to set
     ///   - completion: callback to be executed when the operation is complete
-    @objc public func setUser(user: User, completion: @escaping () -> ()) {
+    @preconcurrency @objc public func setUser(user: User, completion: @escaping @Sendable () -> ()) {
         hackleAppCore.setUser(user: user, hackleAppContext: .default)
             .onComplete(queue: completionQueue, completion)
     }
@@ -103,7 +103,7 @@ import WebKit
     /// - Parameters:
     ///   - userId: the userId to set for the user. Can be null to identify an anonymous user
     ///   - completion: callback to be executed when the operation is complete
-    @objc public func setUserId(userId: String?, completion: @escaping () -> ()) {
+    @preconcurrency @objc public func setUserId(userId: String?, completion: @escaping @Sendable () -> ()) {
         hackleAppCore.setUserId(userId: userId, hackleAppContext: .default)
             .onComplete(queue: completionQueue, completion)
     }
@@ -113,7 +113,7 @@ import WebKit
     /// - Parameters:
     ///   - deviceId: the custom device ID to set
     ///   - completion: callback to be executed when the operation is complete
-    @objc public func setDeviceId(deviceId: String, completion: @escaping () -> ()) {
+    @preconcurrency @objc public func setDeviceId(deviceId: String, completion: @escaping @Sendable () -> ()) {
         hackleAppCore.setDeviceId(deviceId: deviceId, hackleAppContext: .default)
             .onComplete(queue: completionQueue, completion)
     }
@@ -124,7 +124,7 @@ import WebKit
     ///   - key: the key of the property
     ///   - value: the value of the property
     ///   - completion: callback to be executed when the operation is complete
-    @objc public func setUserProperty(key: String, value: Any?, completion: @escaping () -> ()) {
+    @preconcurrency @objc public func setUserProperty(key: String, value: Any?, completion: @escaping @Sendable () -> ()) {
         let operations = PropertyOperations.builder()
             .set(key, value)
             .build()
@@ -136,7 +136,7 @@ import WebKit
     /// - Parameters:
     ///   - operations: a set of ``PropertyOperations`` to apply to user properties
     ///   - completion: callback to be executed when the operation is complete
-    @objc public func updateUserProperties(operations: PropertyOperations, completion: @escaping () -> ()) {
+    @preconcurrency @objc public func updateUserProperties(operations: PropertyOperations, completion: @escaping @Sendable () -> ()) {
         hackleAppCore.updateUserProperties(operations: operations, hackleAppContext: .default)
         completion()
     }
@@ -165,7 +165,7 @@ import WebKit
     /// Resets the current user with completion.
     ///
     /// - Parameter completion: callback to be executed when the operation is complete
-    @objc public func resetUser(completion: @escaping () -> ()) {
+    @preconcurrency @objc public func resetUser(completion: @escaping @Sendable () -> ()) {
         hackleAppCore.resetUser(hackleAppContext: .default)
             .onComplete(queue: completionQueue, completion)
     }
@@ -175,7 +175,7 @@ import WebKit
     /// - Parameters:
     ///   - phoneNumber: the phone number to set
     ///   - completion: callback to be executed when the operation is complete
-    @objc public func setPhoneNumber(phoneNumber: String, completion: @escaping () -> ()) {
+    @preconcurrency @objc public func setPhoneNumber(phoneNumber: String, completion: @escaping @Sendable () -> ()) {
         hackleAppCore.setPhoneNumber(phoneNumber: phoneNumber, hackleAppContext: .default)
         completion()
     }
@@ -183,7 +183,7 @@ import WebKit
     /// Removes the phone number from the current user with completion.
     ///
     /// - Parameter completion: callback to be executed when the operation is complete
-    @objc public func unsetPhoneNumber(completion: @escaping () -> ()) {
+    @preconcurrency @objc public func unsetPhoneNumber(completion: @escaping @Sendable () -> ()) {
         hackleAppCore.unsetPhoneNumber(hackleAppContext: .default)
         completion()
     }
@@ -278,7 +278,7 @@ import WebKit
     /// Fetches the latest configuration from the Hackle servers with completion.
     ///
     /// - Parameter completion: callback to be executed when the fetch is complete
-    @objc public func fetch(_ completion: @escaping () -> ()) {
+    @preconcurrency @objc public func fetch(_ completion: @escaping @Sendable () -> ()) {
         hackleAppCore.fetch()
             .onComplete(queue: completionQueue, completion)
     }
@@ -366,7 +366,7 @@ extension HackleApp {
 }
 
 extension HackleApp {
-    func initialize(user: User? = nil, completion: @escaping () -> ()) {
+    func initialize(user: User? = nil, completion: @escaping @Sendable () -> ()) {
         hackleAppCore.initialize(user: user, completion: completion)
     }
 

--- a/Sources/Hackle/HackleApp.swift
+++ b/Sources/Hackle/HackleApp.swift
@@ -88,14 +88,6 @@ import WebKit
         hackleAppCore.hideUserExplorer()
     }
 
-    /// Sets or replaces the current user.
-    ///
-    /// - Parameter user: the ``User`` to set
-    @available(*, deprecated, message: "Use async setUser(user:) or setUser(user:completion:) instead.")
-    @objc public func setUser(user: User) {
-        setUser(user: user, completion: {})
-    }
-
     /// Sets or replaces the current user with completion.
     ///
     /// - Parameters:
@@ -104,14 +96,6 @@ import WebKit
     @objc public func setUser(user: User, completion: @escaping () -> ()) {
         hackleAppCore.setUser(user: user, hackleAppContext: .default)
             .onComplete(queue: completionQueue, completion)
-    }
-
-    /// Sets the userId for the current user.
-    ///
-    /// - Parameter userId: the userId to set for the user. Can be null to identify an anonymous user
-    @available(*, deprecated, message: "Use async setUserId(userId:) or setUserId(userId:completion:) instead.")
-    @objc public func setUserId(userId: String?) {
-        setUserId(userId: userId, completion: {})
     }
 
     /// Sets the userId for the current user with completion.
@@ -124,14 +108,6 @@ import WebKit
             .onComplete(queue: completionQueue, completion)
     }
 
-    /// Sets a custom device ID.
-    ///
-    /// - Parameter deviceId: the custom device ID to set
-    @available(*, deprecated, message: "Use async setDeviceId(deviceId:) or setDeviceId(deviceId:completion:) instead.")
-    @objc public func setDeviceId(deviceId: String) {
-        setDeviceId(deviceId: deviceId, completion: {})
-    }
-
     /// Sets a custom device ID with completion.
     ///
     /// - Parameters:
@@ -140,19 +116,6 @@ import WebKit
     @objc public func setDeviceId(deviceId: String, completion: @escaping () -> ()) {
         hackleAppCore.setDeviceId(deviceId: deviceId, hackleAppContext: .default)
             .onComplete(queue: completionQueue, completion)
-    }
-
-    /// Sets a single user property.
-    ///
-    /// - Parameters:
-    ///   - key: the key of the property
-    ///   - value: the value of the property
-    @available(*, deprecated, message: "Use async setUserProperty(key:value:) or setUserProperty(key:value:completion:) instead.")
-    @objc public func setUserProperty(key: String, value: Any?) {
-        let operations = PropertyOperations.builder()
-            .set(key, value)
-            .build()
-        updateUserProperties(operations: operations, completion: {})
     }
 
     /// Sets a single user property with completion.
@@ -166,14 +129,6 @@ import WebKit
             .set(key, value)
             .build()
         updateUserProperties(operations: operations, completion: completion)
-    }
-
-    /// Updates user properties with a set of operations.
-    ///
-    /// - Parameter operations: a set of ``PropertyOperations`` to apply to user properties
-    @available(*, deprecated, message: "Use async updateUserProperties(operations:) or updateUserProperties(operations:completion:) instead.")
-    @objc public func updateUserProperties(operations: PropertyOperations) {
-        updateUserProperties(operations: operations, completion: {})
     }
 
     /// Updates user properties with a set of operations with completion.
@@ -207,26 +162,12 @@ import WebKit
         hackleAppCore.updateKakaoSubscriptions(operations: operations, hackleAppContext: .default)
     }
 
-    /// Resets the current user.
-    @available(*, deprecated, message: "Use async resetUser() or resetUser(completion:) instead.")
-    @objc public func resetUser() {
-        resetUser(completion: {})
-    }
-
     /// Resets the current user with completion.
     ///
     /// - Parameter completion: callback to be executed when the operation is complete
     @objc public func resetUser(completion: @escaping () -> ()) {
         hackleAppCore.resetUser(hackleAppContext: .default)
             .onComplete(queue: completionQueue, completion)
-    }
-
-    /// Sets the phone number for the current user.
-    ///
-    /// - Parameter phoneNumber: the phone number to set
-    @available(*, deprecated, message: "Use async setPhoneNumber(phoneNumber:) or setPhoneNumber(phoneNumber:completion:) instead.")
-    @objc public func setPhoneNumber(phoneNumber: String) {
-        setPhoneNumber(phoneNumber: phoneNumber, completion: {})
     }
 
     /// Sets the phone number for the current user with completion.
@@ -237,12 +178,6 @@ import WebKit
     @objc public func setPhoneNumber(phoneNumber: String, completion: @escaping () -> ()) {
         hackleAppCore.setPhoneNumber(phoneNumber: phoneNumber, hackleAppContext: .default)
         completion()
-    }
-
-    /// Removes the phone number from the current user.
-    @available(*, deprecated, message: "Use async unsetPhoneNumber() or unsetPhoneNumber(completion:) instead.")
-    @objc public func unsetPhoneNumber() {
-        unsetPhoneNumber(completion: {})
     }
 
     /// Removes the phone number from the current user with completion.

--- a/Sources/Hackle/Invocator/Invocation/InvocationHandlers.swift
+++ b/Sources/Hackle/Invocator/Invocation/InvocationHandlers.swift
@@ -43,7 +43,7 @@ class SetUserInvocationHandler: InvocationHandler {
             throw HackleError.error("parameters.user must be provided.")
         }
         let user = User.from(dto: data)
-        core.setUser(user: user, hackleAppContext: request.appContext, completion: {})
+        core.setUser(user: user, hackleAppContext: request.appContext)
         return .success()
     }
 }
@@ -57,7 +57,7 @@ class ResetUserInvocationHandler: InvocationHandler {
     }
 
     func invoke(request: InvocationRequest) throws -> InvocationResponse<Void> {
-        core.resetUser(hackleAppContext: request.appContext, completion: {})
+        core.resetUser(hackleAppContext: request.appContext)
         return .success()
     }
 }
@@ -76,7 +76,7 @@ class SetUserIdInvocationHandler: InvocationHandler {
         guard let userId = request.parameters.userId() else {
             throw HackleError.error("parameters.userId must be provided.")
         }
-        core.setUserId(userId: userId, hackleAppContext: request.appContext, completion: {})
+        core.setUserId(userId: userId, hackleAppContext: request.appContext)
         return .success()
     }
 }
@@ -93,7 +93,7 @@ class SetDeviceIdInvocationHandler: InvocationHandler {
         guard let deviceId = request.parameters.deviceId() else {
             throw HackleError.error("parameters.deviceId must be provided.")
         }
-        core.setDeviceId(deviceId: deviceId, hackleAppContext: request.appContext, completion: {})
+        core.setDeviceId(deviceId: deviceId, hackleAppContext: request.appContext)
         return .success()
     }
 }
@@ -119,7 +119,7 @@ class SetUserPropertyInvocationHandler: InvocationHandler {
             .set(key, value)
             .build()
 
-        core.updateUserProperties(operations: operations, hackleAppContext: request.appContext, completion: {})
+        core.updateUserProperties(operations: operations, hackleAppContext: request.appContext)
         return .success()
     }
 }
@@ -137,7 +137,7 @@ class UpdateUserPropertiesInvocationHandler: InvocationHandler {
             throw HackleError.error("parameters.operations must be provided.")
         }
         let operations = PropertyOperations.from(dto: dto)
-        core.updateUserProperties(operations: operations, hackleAppContext: request.appContext, completion: {})
+        core.updateUserProperties(operations: operations, hackleAppContext: request.appContext)
         return .success()
     }
 }
@@ -157,7 +157,7 @@ class SetPhoneNumberInvocationHandler: InvocationHandler {
             throw HackleError.error("parameters.phoneNumber must be provided.")
         }
 
-        core.setPhoneNumber(phoneNumber: phoneNumber, hackleAppContext: request.appContext, completion: {})
+        core.setPhoneNumber(phoneNumber: phoneNumber, hackleAppContext: request.appContext)
         return .success()
     }
 }
@@ -171,7 +171,7 @@ class UnsetPhoneNumberInvocationHandler: InvocationHandler {
     }
 
     func invoke(request: InvocationRequest) throws -> InvocationResponse<Void> {
-        core.unsetPhoneNumber(hackleAppContext: request.appContext, completion: {})
+        core.unsetPhoneNumber(hackleAppContext: request.appContext)
         return .success()
     }
 }

--- a/Tests/HackleTests/Core/Sync/CompositeSynchronizerSpecs.swift
+++ b/Tests/HackleTests/Core/Sync/CompositeSynchronizerSpecs.swift
@@ -13,7 +13,7 @@ class CompositeSynchronizerSpecs: QuickSpec {
         beforeEach {
             workspaceSynchronizer = MockSynchronizer()
             cohortSynchronizer = MockSynchronizer()
-            sut = CompositeSynchronizer(dispatchQueue: DispatchQueue(label: "test", attributes: .concurrent))
+            sut = CompositeSynchronizer()
             sut.add(synchronizer: workspaceSynchronizer)
             sut.add(synchronizer: cohortSynchronizer)
         }
@@ -22,10 +22,10 @@ class CompositeSynchronizerSpecs: QuickSpec {
             // given
             var count = 0
             // when
-            sut.sync { _ in
+            awaitCompletion {
+                try? await sut.sync()
                 count += 1
             }
-            Thread.sleep(forTimeInterval: 0.1)
 
             // then
             expect(count) == 1
@@ -37,26 +37,27 @@ class CompositeSynchronizerSpecs: QuickSpec {
             }
         }
 
-        it("async") {
-            // given
-            every(workspaceSynchronizer.syncMock).answers { completion in
-                Thread.sleep(forTimeInterval: 0.1)
-                completion(.success(()))
-            }
-            every(cohortSynchronizer.syncMock).answers { completion in
-                Thread.sleep(forTimeInterval: 0.1)
-                completion(.success(()))
-            }
-            var count = 0
+        it("child들을 동시에 dispatch한다 (결정적 병렬성 증명)") {
+            // given: 두 child가 모두 sync()에 진입해야만 통과하는 배리어(count 2)
+            let barrier = Barrier(count: 2)
+            let parallelSut = CompositeSynchronizer()
+            let a = BarrierSynchronizer(barrier: barrier)
+            let b = BarrierSynchronizer(barrier: barrier)
+            parallelSut.add(synchronizer: a)
+            parallelSut.add(synchronizer: b)
 
-            // when
-            sut.sync {
-                count += 1
+            // when: 순차 await로 dispatch하면 첫 child가 배리어에서 영구 대기 → 타임아웃 실패.
+            //       TaskGroup 팬아웃이면 둘 다 진입 → 배리어 통과 → 완료.
+            var completed = false
+            awaitCompletion(timeout: .seconds(2)) {
+                try await parallelSut.sync()
+                completed = true
             }
-            Thread.sleep(forTimeInterval: 0.15)
 
             // then
-            expect(count) == 1
+            expect(completed) == true
+            expect(a.synced) == true
+            expect(b.synced) == true
         }
 
         it("safe") {
@@ -64,26 +65,28 @@ class CompositeSynchronizerSpecs: QuickSpec {
             let registry = CumulativeMetricRegistry()
             let counter = registry.counter(name: "workspace")
 
-            every(workspaceSynchronizer.syncMock).answers { completion in
+            every(workspaceSynchronizer.syncMock).answers { _ in
                 Thread.sleep(forTimeInterval: 0.1)
                 counter.increment()
-                completion(.success(()))
             }
 
-            every(cohortSynchronizer.syncMock).answers { completion in
+            every(cohortSynchronizer.syncMock).answers { _ in
                 Thread.sleep(forTimeInterval: 0.05)
-                completion(.failure(HackleError.error("fail")))
+                throw HackleError.error("fail")
             }
 
             // when
-            var actual: Result<Void, Error>!
-            sut.sync { result in
-                actual = result
+            var thrown: Error?
+            awaitCompletion {
+                do {
+                    try await sut.sync()
+                } catch {
+                    thrown = error
+                }
             }
-            Thread.sleep(forTimeInterval: 0.15)
 
             // then
-            try actual.get()
+            expect(thrown).to(beNil())
             expect(counter.count()) == 1
         }
     }

--- a/Tests/HackleTests/Core/Sync/MockSynchronizer.swift
+++ b/Tests/HackleTests/Core/Sync/MockSynchronizer.swift
@@ -2,8 +2,6 @@
 //  MockSynchronizer.swift
 //  HackleTests
 //
-//  Created by yong on 2023/10/02.
-//
 
 import Foundation
 import MockingKit
@@ -12,14 +10,15 @@ import MockingKit
 class MockSynchronizer: Mock, Synchronizer {
     override init() {
         super.init()
-        every(syncMock).answers { completion in
-            completion(.success(()))
-        }
+        every(syncMock).answers { _ in }
     }
 
-    lazy var syncMock = MockFunction(self, sync)
+    lazy var syncMock = MockFunction.throwable(self, syncStub)
 
-    func sync(completion: @escaping (Result<(), Error>) -> ()) {
-        call(syncMock, args: completion)
+    private func syncStub() throws {
+    }
+
+    func sync() async throws {
+        try call(syncMock, args: ())
     }
 }

--- a/Tests/HackleTests/Core/Sync/PollingSynchronizerSpecs.swift
+++ b/Tests/HackleTests/Core/Sync/PollingSynchronizerSpecs.swift
@@ -13,8 +13,7 @@ class PollingSynchronizerSpecs: QuickSpec {
                 let sut = PollingSynchronizer(delegate: delegate, scheduler: Schedulers.dispatch(), interval: 10)
 
                 // when
-                sut.sync {
-                }
+                awaitCompletion { try await sut.sync() }
 
                 // then
                 verify(exactly: 1) {
@@ -27,7 +26,6 @@ class PollingSynchronizerSpecs: QuickSpec {
             it("no polling") {
                 // given
                 let delegate = MockSynchronizer()
-                every(delegate.syncMock).answers({ $0(.success(())) })
                 let sut = PollingSynchronizer(delegate: delegate, scheduler: Schedulers.dispatch(), interval: -1)
 
                 // when
@@ -43,7 +41,6 @@ class PollingSynchronizerSpecs: QuickSpec {
             it("start scheduling") {
                 // given
                 let delegate = MockSynchronizer()
-                every(delegate.syncMock).answers({ $0(.success(())) })
                 let sut = PollingSynchronizer(delegate: delegate, scheduler: Schedulers.dispatch(), interval: 0.1)
 
                 // when
@@ -59,7 +56,6 @@ class PollingSynchronizerSpecs: QuickSpec {
             it("start once") {
                 // given
                 let delegate = MockSynchronizer()
-                every(delegate.syncMock).answers({ $0(.success(())) })
                 let sut = PollingSynchronizer(delegate: delegate, scheduler: Schedulers.dispatch(), interval: 0.1)
 
                 // when
@@ -82,7 +78,6 @@ class PollingSynchronizerSpecs: QuickSpec {
             it("no polling") {
                 // given
                 let delegate = MockSynchronizer()
-                every(delegate.syncMock).answers({ $0(.success(())) })
                 let sut = PollingSynchronizer(delegate: delegate, scheduler: Schedulers.dispatch(), interval: -1)
 
                 // when
@@ -93,7 +88,6 @@ class PollingSynchronizerSpecs: QuickSpec {
             it("cancel polling job") {
                 // given
                 let delegate = MockSynchronizer()
-                every(delegate.syncMock).answers({ $0(.success(())) })
                 let sut = PollingSynchronizer(delegate: delegate, scheduler: Schedulers.dispatch(), interval: 0.1)
 
                 // when
@@ -111,7 +105,6 @@ class PollingSynchronizerSpecs: QuickSpec {
 
         it("onChanged") {
             let delegate = MockSynchronizer()
-            every(delegate.syncMock).answers({ $0(.success(())) })
             let sut = PollingSynchronizer(delegate: delegate, scheduler: Schedulers.dispatch(), interval: 0.5)
 
             sut.onForeground(nil, timestamp: Date(), isFromBackground: true)

--- a/Tests/HackleTests/Core/Sync/SynchronizerSpecs.swift
+++ b/Tests/HackleTests/Core/Sync/SynchronizerSpecs.swift
@@ -5,25 +5,25 @@ import Quick
 
 class SynchronizerSpecs: QuickSpec {
     override class func spec() {
-        describe("SynchronizerExtensions") {
-            describe("Synchronizer.sync(() -> ())") {
-                it("success") {
-                    let counter = CumulativeMetricRegistry().counter(name: "counter")
-                    let sut = SynchronizerStub(.success(()))
-                    sut.sync {
-                        counter.increment()
-                    }
-                    expect(counter.count()) == 1
+        describe("Synchronizer.safeSync") {
+            it("success") {
+                let counter = CumulativeMetricRegistry().counter(name: "counter")
+                let sut = SynchronizerStub(.success(()))
+                awaitCompletion {
+                    await sut.safeSync()
+                    counter.increment()
                 }
+                expect(counter.count()) == 1
+            }
 
-                it("failure") {
-                    let counter = CumulativeMetricRegistry().counter(name: "counter")
-                    let sut = SynchronizerStub(.failure(HackleError.error("fail")))
-                    sut.sync {
-                        counter.increment()
-                    }
-                    expect(counter.count()) == 1
+            it("failure - 에러를 삼키고 완료된다") {
+                let counter = CumulativeMetricRegistry().counter(name: "counter")
+                let sut = SynchronizerStub(.failure(HackleError.error("fail")))
+                awaitCompletion {
+                    await sut.safeSync()
+                    counter.increment()
                 }
+                expect(counter.count()) == 1
             }
         }
     }
@@ -37,7 +37,7 @@ class SynchronizerStub: Synchronizer {
         self.result = result
     }
 
-    func sync(completion: @escaping (Result<(), Error>) -> ()) {
-        completion(result)
+    func sync() async throws {
+        try result.get()
     }
 }

--- a/Tests/HackleTests/Core/User/DefaultUserCohortFetcherSpecs.swift
+++ b/Tests/HackleTests/Core/User/DefaultUserCohortFetcherSpecs.swift
@@ -22,10 +22,7 @@ class DefaultUserCohortFetcherSpecs: QuickSpec {
             }
 
             // when
-            var actual: Result<UserCohorts, Error>!
-            sut.fetch(user: User.builder().id("42").build()) { result in
-                actual = result
-            }
+            let actual = awaitResult { try await sut.fetch(user: User.builder().id("42").build()) }
 
             // then
             expect(try actual.get()).to(throwError(HackleError.error("fail")))
@@ -38,10 +35,7 @@ class DefaultUserCohortFetcherSpecs: QuickSpec {
             }
 
             // when
-            var actual: Result<UserCohorts, Error>!
-            sut.fetch(user: User.builder().id("42").build()) { result in
-                actual = result
-            }
+            let actual = awaitResult { try await sut.fetch(user: User.builder().id("42").build()) }
 
             // then
             expect(try actual.get()).to(throwError(HackleError.error("Response is empty")))
@@ -54,10 +48,7 @@ class DefaultUserCohortFetcherSpecs: QuickSpec {
             }
 
             // when
-            var actual: Result<UserCohorts, Error>!
-            sut.fetch(user: User.builder().id("42").build()) { result in
-                actual = result
-            }
+            let actual = awaitResult { try await sut.fetch(user: User.builder().id("42").build()) }
 
             // then
             expect(try actual.get()).to(throwError(HackleError.error("Http status code: 500")))
@@ -70,10 +61,7 @@ class DefaultUserCohortFetcherSpecs: QuickSpec {
             }
 
             // when
-            var actual: Result<UserCohorts, Error>!
-            sut.fetch(user: User.builder().id("42").build()) { result in
-                actual = result
-            }
+            let actual = awaitResult { try await sut.fetch(user: User.builder().id("42").build()) }
 
             // then
             expect(try actual.get()).to(throwError(HackleError.error("Response body is empty")))
@@ -86,10 +74,7 @@ class DefaultUserCohortFetcherSpecs: QuickSpec {
             }
 
             // when
-            var actual: Result<UserCohorts, Error>!
-            sut.fetch(user: User.builder().id("42").build()) { result in
-                actual = result
-            }
+            let actual = awaitResult { try await sut.fetch(user: User.builder().id("42").build()) }
 
             // then
             expect(try actual.get()).to(throwError(HackleError.error("Invalid format")))
@@ -103,10 +88,7 @@ class DefaultUserCohortFetcherSpecs: QuickSpec {
             }
 
             // when
-            var actual: Result<UserCohorts, Error>!
-            sut.fetch(user: User.builder().id("42").build()) { result in
-                actual = result
-            }
+            let actual = awaitResult { try await sut.fetch(user: User.builder().id("42").build()) }
 
             // then
             let cohorts = try actual.get()
@@ -124,8 +106,7 @@ class DefaultUserCohortFetcherSpecs: QuickSpec {
             }
 
             // when
-            sut.fetch(user: User.builder().id("42").build()) { result in
-            }
+            awaitCompletion { _ = try await sut.fetch(user: User.builder().id("42").build()) }
 
             // then
             let request = httpClient.executeMock.firstInvokation().arguments.0

--- a/Tests/HackleTests/Core/User/DefaultUserManagerSpecs.swift
+++ b/Tests/HackleTests/Core/User/DefaultUserManagerSpecs.swift
@@ -26,12 +26,8 @@ class DefaultUserManagerSpecs: QuickSpec {
             device = deviceImpl
             bundleInfo = BundleInfoImpl()
             sut = DefaultUserManager(device: device, bundleInfo: bundleInfo, repository: repository, cohortFetcher: cohortFetcher, targetFetcher: targetFetcher, clock: clock)
-            every(cohortFetcher.fetchMock).answers({ _, completion in
-                completion(.success(UserCohorts()))
-            })
-            every(targetFetcher.fetchMock).answers { _, completion in
-                completion(.success(UserTargetEvents()))
-            }
+            every(cohortFetcher.fetchMock).answers { _ in UserCohorts() }
+            every(targetFetcher.fetchMock).answers { _ in UserTargetEvents() }
             listener = MockUserListener()
             sut.addListener(listener: listener)
         }
@@ -121,30 +117,24 @@ class DefaultUserManagerSpecs: QuickSpec {
                         )
                     ))
                     .build()
-                every(cohortFetcher.fetchMock).answers { _, completion in
-                    completion(.success(UserCohorts.Builder(cohorts: userCohorts).build()))
-                }
-                every(targetFetcher.fetchMock).answers { _, completion in
-                    completion(.success(UserTargetEvents.Builder(targetEvents: userTargetEvents).build()))
-                }
+                every(cohortFetcher.fetchMock).answers { _ in UserCohorts.Builder(cohorts: userCohorts).build() }
+                every(targetFetcher.fetchMock).answers { _ in UserTargetEvents.Builder(targetEvents: userTargetEvents).build() }
 
                 // when
                 sut.initialize(user: User.builder().id("id").property("a", "a").build())
-                Nimble.waitUntil(timeout: .seconds(2)) { done in
-                    sut.sync {
-                        let hackleUser = sut.toHackleUser(user: User.builder().id("id").userId("user_id").property("b", "b").build())
-                        
-                        // then
-                        expect(hackleUser.identifiers) == [
-                            "$id": "id",
-                            "$deviceId": "hackle_device_id",
-                            "$userId": "user_id",
-                            "$hackleDeviceId": "hackle_device_id"
-                        ]
-                        expect(hackleUser.properties as? [String: String]) == ["b": "b"]
-                        expect(hackleUser.cohorts) == [Cohort(id: 42)]
-                        done()
-                    }
+                awaitCompletion(timeout: .seconds(2)) {
+                    try? await sut.sync()
+                    let hackleUser = sut.toHackleUser(user: User.builder().id("id").userId("user_id").property("b", "b").build())
+                    
+                    // then
+                    expect(hackleUser.identifiers) == [
+                        "$id": "id",
+                        "$deviceId": "hackle_device_id",
+                        "$userId": "user_id",
+                        "$hackleDeviceId": "hackle_device_id"
+                    ]
+                    expect(hackleUser.properties as? [String: String]) == ["b": "b"]
+                    expect(hackleUser.cohorts) == [Cohort(id: 42)]
                 }
             }
 
@@ -243,20 +233,14 @@ class DefaultUserManagerSpecs: QuickSpec {
                         )
                     ))
                     .build()
-                every(cohortFetcher.fetchMock).answers { _, completion in
-                    completion(.success(UserCohorts.Builder(cohorts: userCohorts).build()))
-                }
-                every(targetFetcher.fetchMock).answers { _, completion in
-                    completion(.success(UserTargetEvents.Builder(targetEvents: userTargetEvents).build()))
-                }
+                every(cohortFetcher.fetchMock).answers { _ in UserCohorts.Builder(cohorts: userCohorts).build() }
+                every(targetFetcher.fetchMock).answers { _ in UserTargetEvents.Builder(targetEvents: userTargetEvents).build() }
 
                 sut.initialize(user: nil)
                 expect(sut.resolve(user: nil, hackleAppContext: .default).cohorts) == []
-                Nimble.waitUntil(timeout: .seconds(2)) { done in
-                    sut.sync {
-                        expect(sut.resolve(user: nil, hackleAppContext: .default).cohorts) == [Cohort(id: 42)]
-                        done()
-                    }
+                awaitCompletion(timeout: .seconds(2)) {
+                    try? await sut.sync()
+                    expect(sut.resolve(user: nil, hackleAppContext: .default).cohorts) == [Cohort(id: 42)]
                 }
             }
         }
@@ -289,28 +273,20 @@ class DefaultUserManagerSpecs: QuickSpec {
                 
                 
                 // given
-                every(targetFetcher.fetchMock).answers { _, completion in
-                    completion(.success(UserTargetEvents.Builder(targetEvents: UserTargetEvents.builder().putAll(targetEvents: targetEvents).build()).build()))
-                }
+                every(targetFetcher.fetchMock).answers { _ in UserTargetEvents.Builder(targetEvents: UserTargetEvents.builder().putAll(targetEvents: targetEvents).build()).build() }
                 sut.initialize(user: nil)
-                Nimble.waitUntil(timeout: .seconds(2)) { done in
-                    sut.sync {
-                        expect(sut.resolve(user: nil, hackleAppContext: .default).targetEvents) == targetEvents
-                        expect(sut.resolve(user: nil, hackleAppContext: .default).targetEvents.count) == 2
-                        done()
-                    }
+                awaitCompletion(timeout: .seconds(2)) {
+                    try? await sut.sync()
+                    expect(sut.resolve(user: nil, hackleAppContext: .default).targetEvents) == targetEvents
+                    expect(sut.resolve(user: nil, hackleAppContext: .default).targetEvents.count) == 2
                 }
                 
                 let newTargetEvents = [targetEvent]
-                every(targetFetcher.fetchMock).answers { _, completion in
-                    completion(.success(UserTargetEvents.Builder(targetEvents: UserTargetEvents.builder().putAll(targetEvents: newTargetEvents).build()).build()))
-                }
-                Nimble.waitUntil(timeout: .seconds(2)) { done in
-                    sut.sync {
-                        expect(sut.resolve(user: nil, hackleAppContext: .default).targetEvents) == newTargetEvents
-                        expect(sut.resolve(user: nil, hackleAppContext: .default).targetEvents.count) == 1
-                        done()
-                    }
+                every(targetFetcher.fetchMock).answers { _ in UserTargetEvents.Builder(targetEvents: UserTargetEvents.builder().putAll(targetEvents: newTargetEvents).build()).build() }
+                awaitCompletion(timeout: .seconds(2)) {
+                    try? await sut.sync()
+                    expect(sut.resolve(user: nil, hackleAppContext: .default).targetEvents) == newTargetEvents
+                    expect(sut.resolve(user: nil, hackleAppContext: .default).targetEvents.count) == 1
                 }
             }
         }
@@ -318,68 +294,62 @@ class DefaultUserManagerSpecs: QuickSpec {
         describe("syncIfNeeded") {
             it("no new identifiers") {
                 // cohort not sync and target event not sync
-                Nimble.waitUntil(timeout: .seconds(2)) { done in
-                    sut.syncIfNeeded(
+                awaitCompletion(timeout: .seconds(2)) {
+                    await sut.syncIfNeeded(
                         updated: Updated(
                             previous: User.builder().id("id").build(),
                             current: User.builder().build()
-                        ),
-                        completion: { done() }
-                    )
-                }
-                
-                // cohort not sync and target event not sync
-                Nimble.waitUntil(timeout: .seconds(2)) { done in
-                    sut.syncIfNeeded(
-                        updated: Updated(
-                            previous: User.builder().id("id").build(),
-                            current: User.builder().id("id").build()
-                        ),
-                        completion: { done() }
-                    )
-                }
-               
-                // cohort not sync and target event sync
-                Nimble.waitUntil(timeout: .seconds(2)) { done in
-                    sut.syncIfNeeded(
-                        updated: Updated(
-                            previous: User.builder().id("id").deviceId("device_id").build(),
-                            current: User.builder().id("id").build()
-                        ),
-                        completion: { done() }
-                    )
-                }
-                
-                // cohort not sync and target event not sync
-                Nimble.waitUntil(timeout: .seconds(2)) { done in
-                    sut.syncIfNeeded(
-                        updated: Updated(
-                            previous: User.builder().id("id").deviceId("device_id").build(),
-                            current: User.builder().id("id").deviceId("device_id").build()
-                        ),
-                        completion: { done() }
-                    )
-                }
-                
-                // cohort not sync and target event not sync
-                Nimble.waitUntil(timeout: .seconds(2)) { done in
-                    sut.syncIfNeeded(
-                        updated: Updated(
-                            previous: User.builder().id("id").deviceId("device_id").identifier("custom", "custom_id").build(),
-                            current: User.builder().id("id").deviceId("device_id").build()
-                        ),
-                        completion: { done() }
+                        )
                     )
                 }
 
                 // cohort not sync and target event not sync
-                Nimble.waitUntil(timeout: .seconds(2)) { done in
-                    sut.syncIfNeeded(
+                awaitCompletion(timeout: .seconds(2)) {
+                    await sut.syncIfNeeded(
+                        updated: Updated(
+                            previous: User.builder().id("id").build(),
+                            current: User.builder().id("id").build()
+                        )
+                    )
+                }
+
+                // cohort not sync and target event sync
+                awaitCompletion(timeout: .seconds(2)) {
+                    await sut.syncIfNeeded(
+                        updated: Updated(
+                            previous: User.builder().id("id").deviceId("device_id").build(),
+                            current: User.builder().id("id").build()
+                        )
+                    )
+                }
+
+                // cohort not sync and target event not sync
+                awaitCompletion(timeout: .seconds(2)) {
+                    await sut.syncIfNeeded(
+                        updated: Updated(
+                            previous: User.builder().id("id").deviceId("device_id").build(),
+                            current: User.builder().id("id").deviceId("device_id").build()
+                        )
+                    )
+                }
+
+                // cohort not sync and target event not sync
+                awaitCompletion(timeout: .seconds(2)) {
+                    await sut.syncIfNeeded(
+                        updated: Updated(
+                            previous: User.builder().id("id").deviceId("device_id").identifier("custom", "custom_id").build(),
+                            current: User.builder().id("id").deviceId("device_id").build()
+                        )
+                    )
+                }
+
+                // cohort not sync and target event not sync
+                awaitCompletion(timeout: .seconds(2)) {
+                    await sut.syncIfNeeded(
                         updated: Updated(
                             previous: User.builder().id("id").deviceId("device_id").identifier("custom", "custom_id").build(),
                             current: User.builder().id("id").deviceId("device_id").identifier("custom", "custom_id").build()
-                        ),
-                        completion: { done() }
+                        )
                     )
                 }
                 verify(exactly: 0) {
@@ -391,63 +361,57 @@ class DefaultUserManagerSpecs: QuickSpec {
             }
             it("new identifiers") {
                 // cohort sync and target event not sync
-                Nimble.waitUntil(timeout: .seconds(2)) { done in
-                    sut.syncIfNeeded(
+                awaitCompletion(timeout: .seconds(2)) {
+                    await sut.syncIfNeeded(
                         updated: Updated(
                             previous: User.builder().build(),
                             current: User.builder().id("new_id").build()
-                        ),
-                        completion: { done() }
+                        )
                     )
                 }
                 // cohort sync and target event not sync
-                Nimble.waitUntil(timeout: .seconds(2)) { done in
-                    sut.syncIfNeeded(
+                awaitCompletion(timeout: .seconds(2)) {
+                    await sut.syncIfNeeded(
                         updated: Updated(
                             previous: User.builder().id("id").build(),
                             current: User.builder().id("new_id").build()
-                        ),
-                        completion: { done() }
+                        )
                     )
                 }
                 // cohort sync and target event sync
-                Nimble.waitUntil(timeout: .seconds(2)) { done in
-                    sut.syncIfNeeded(
+                awaitCompletion(timeout: .seconds(2)) {
+                    await sut.syncIfNeeded(
                         updated: Updated(
                             previous: User.builder().id("id").build(),
                             current: User.builder().id("id").deviceId("new_device_id").build()
-                        ),
-                        completion: { done() }
+                        )
                     )
                 }
                 // cohort sync and target event sync
-                Nimble.waitUntil(timeout: .seconds(2)) { done in
-                    sut.syncIfNeeded(
+                awaitCompletion(timeout: .seconds(2)) {
+                    await sut.syncIfNeeded(
                         updated: Updated(
                             previous: User.builder().id("id").deviceId("device_id").build(),
                             current: User.builder().id("id").deviceId("new_device_id").build()
-                        ),
-                        completion: { done() }
+                        )
                     )
                 }
                 // cohort sync and target event not sync
-                Nimble.waitUntil(timeout: .seconds(2)) { done in
-                    sut.syncIfNeeded(
+                awaitCompletion(timeout: .seconds(2)) {
+                    await sut.syncIfNeeded(
                         updated: Updated(
                             previous: User.builder().id("id").deviceId("device_id").build(),
                             current: User.builder().id("id").deviceId("device_id").identifier("custom", "new_custom_id").build()
-                        ),
-                        completion: { done() }
+                        )
                     )
                 }
                 // cohort sync and target event not sync
-                Nimble.waitUntil(timeout: .seconds(2)) { done in
-                    sut.syncIfNeeded(
+                awaitCompletion(timeout: .seconds(2)) {
+                    await sut.syncIfNeeded(
                         updated: Updated(
                             previous: User.builder().id("id").deviceId("device_id").identifier("custom", "custom_id").build(),
                             current: User.builder().id("id").deviceId("device_id").identifier("custom", "new_custom_id").build()
-                        ),
-                        completion: { done() }
+                        )
                     )
                 }
                 verify(exactly: 6) {
@@ -710,20 +674,16 @@ class DefaultUserManagerSpecs: QuickSpec {
                     .put(cohort: UserCohort(identifier: Identifier(type: "$id", value: "hackle_device_id"), cohorts: [Cohort(id: 42)]))
                     .put(cohort: UserCohort(identifier: Identifier(type: "$deviceId", value: "hackle_device_id"), cohorts: [Cohort(id: 43)]))
                     .build()
-                every(cohortFetcher.fetchMock).answers { user, completion in
-                    completion(.success(UserCohorts.Builder(cohorts: userCohorts).build()))
-                }
+                every(cohortFetcher.fetchMock).answers { user in UserCohorts.Builder(cohorts: userCohorts).build() }
 
                 sut.initialize(user: User.builder().deviceId("device_id").build())
-                Nimble.waitUntil(timeout: .seconds(2)) { done in
-                    sut.sync {
-                        expect(sut.currentUser.resolvedIdentifiers) == [
-                            "$id": "hackle_device_id",
-                            "$deviceId": "device_id",
-                        ]
-                        expect(sut.resolve(user: sut.currentUser, hackleAppContext: .default).cohorts) == [Cohort(id: 42)]
-                        done()
-                    }
+                awaitCompletion(timeout: .seconds(2)) {
+                    try? await sut.sync()
+                    expect(sut.currentUser.resolvedIdentifiers) == [
+                        "$id": "hackle_device_id",
+                        "$deviceId": "device_id",
+                    ]
+                    expect(sut.resolve(user: sut.currentUser, hackleAppContext: .default).cohorts) == [Cohort(id: 42)]
                 }
             }
             
@@ -743,18 +703,14 @@ class DefaultUserManagerSpecs: QuickSpec {
                         )
                     ))
                     .build()
-                every(targetFetcher.fetchMock).answers { user, completion in
-                    completion(.success(UserTargetEvents.Builder(targetEvents: userTargetEvents).build()))
-                }
+                every(targetFetcher.fetchMock).answers { user in UserTargetEvents.Builder(targetEvents: userTargetEvents).build() }
 
                 sut.initialize(user: nil)
-                Nimble.waitUntil(timeout: .seconds(2)) { done in
-                    sut.sync {
-                        expect(sut.resolve(user: nil, hackleAppContext: .default).targetEvents.count) == 1
-                        expect(sut.resolve(user: nil, hackleAppContext: .default).targetEvents[0].eventKey) == "purchase"
-                        expect(sut.resolve(user: nil, hackleAppContext: .default).targetEvents[0].property?.key) == "product_name"
-                        done()
-                    }
+                awaitCompletion(timeout: .seconds(2)) {
+                    try? await sut.sync()
+                    expect(sut.resolve(user: nil, hackleAppContext: .default).targetEvents.count) == 1
+                    expect(sut.resolve(user: nil, hackleAppContext: .default).targetEvents[0].eventKey) == "purchase"
+                    expect(sut.resolve(user: nil, hackleAppContext: .default).targetEvents[0].property?.key) == "product_name"
                 }
             }
         }

--- a/Tests/HackleTests/Core/User/DefaultUserTargetFetcherSpecs.swift
+++ b/Tests/HackleTests/Core/User/DefaultUserTargetFetcherSpecs.swift
@@ -25,10 +25,7 @@ class DefaultUserTargetFetcherSpecs: QuickSpec {
                 completion(response(statusCode: 500, error: HackleError.error("fail")))
             }
 
-            var actual: Result<UserTargetEvents, Error>!
-            sut.fetch(user: User.builder().id("42").build()) { result in
-                actual = result
-            }
+            let actual = awaitResult { try await sut.fetch(user: User.builder().id("42").build()) }
 
             expect(try actual.get()).to(throwError(HackleError.error("fail")))
         }
@@ -38,10 +35,7 @@ class DefaultUserTargetFetcherSpecs: QuickSpec {
                 completion(HttpResponse(request: request, data: nil, urlResponse: nil, error: nil))
             }
 
-            var actual: Result<UserTargetEvents, Error>!
-            sut.fetch(user: User.builder().id("42").build()) { result in
-                actual = result
-            }
+            let actual = awaitResult { try await sut.fetch(user: User.builder().id("42").build()) }
 
             expect(try actual.get()).to(throwError(HackleError.error("Response is empty")))
         }
@@ -51,10 +45,7 @@ class DefaultUserTargetFetcherSpecs: QuickSpec {
                 completion(response(statusCode: 500))
             }
 
-            var actual: Result<UserTargetEvents, Error>!
-            sut.fetch(user: User.builder().id("42").build()) { result in
-                actual = result
-            }
+            let actual = awaitResult { try await sut.fetch(user: User.builder().id("42").build()) }
 
             expect(try actual.get()).to(throwError(HackleError.error("Http status code: 500")))
         }
@@ -64,10 +55,7 @@ class DefaultUserTargetFetcherSpecs: QuickSpec {
                 completion(response(statusCode: 200))
             }
 
-            var actual: Result<UserTargetEvents, Error>!
-            sut.fetch(user: User.builder().id("42").build()) { result in
-                actual = result
-            }
+            let actual = awaitResult { try await sut.fetch(user: User.builder().id("42").build()) }
 
             expect(try actual.get()).to(throwError(HackleError.error("Response body is empty")))
         }
@@ -77,10 +65,7 @@ class DefaultUserTargetFetcherSpecs: QuickSpec {
                 completion(response(statusCode: 200, data: "INVALID".data(using: .utf8)))
             }
 
-            var actual: Result<UserTargetEvents, Error>!
-            sut.fetch(user: User.builder().id("42").build()) { result in
-                actual = result
-            }
+            let actual = awaitResult { try await sut.fetch(user: User.builder().id("42").build()) }
 
             expect(try actual.get()).to(throwError(HackleError.error("Invalid format")))
         }
@@ -91,10 +76,7 @@ class DefaultUserTargetFetcherSpecs: QuickSpec {
                 completion(response(statusCode: 200, data: json.data(using: .utf8)))
             }
 
-            var actual: Result<UserTargetEvents, Error>!
-            sut.fetch(user: User.builder().id("42").build()) { result in
-                actual = result
-            }
+            let actual = awaitResult { try await sut.fetch(user: User.builder().id("42").build()) }
 
             let target = try actual.get()
             expect(target.count) == 2
@@ -106,7 +88,7 @@ class DefaultUserTargetFetcherSpecs: QuickSpec {
                 completion(response(statusCode: 200, data: json.data(using: .utf8)))
             }
 
-            sut.fetch(user: User.builder().id("42").build()) { _ in }
+            awaitCompletion { _ = try await sut.fetch(user: User.builder().id("42").build()) }
 
             let request = httpClient.executeMock.firstInvokation().arguments.0
             expect(request.headers?["X-HACKLE-USER"]).toNot(beNil())

--- a/Tests/HackleTests/Core/User/MockUserCohortFetcher.swift
+++ b/Tests/HackleTests/Core/User/MockUserCohortFetcher.swift
@@ -8,15 +8,17 @@ class MockUserCohortFetcher: Mock, UserCohortFetcher {
     init(result: Result<UserCohorts, Error>? = nil) {
         super.init()
         if let result {
-            every(fetchMock).answers { user, completion in
-                completion(result)
-            }
+            every(fetchMock).answers { _ in try result.get() }
         }
     }
 
-    lazy var fetchMock = MockFunction(self, fetch)
+    lazy var fetchMock = MockFunction.throwable(self, fetchStub)
 
-    func fetch(user: User, completion: @escaping (Result<UserCohorts, Error>) -> ()) {
-        call(fetchMock, args: (user, completion))
+    private func fetchStub(user: User) throws -> UserCohorts {
+        UserCohorts.empty()
+    }
+
+    func fetch(user: User) async throws -> UserCohorts {
+        try call(fetchMock, args: user)
     }
 }

--- a/Tests/HackleTests/Core/User/MockUserManager.swift
+++ b/Tests/HackleTests/Core/User/MockUserManager.swift
@@ -52,9 +52,8 @@ class MockUserManager: Mock, UserManager {
                 .build()
         }
 
-        every(syncIfNeededMock).answers { updated, completion in
-            completion()
-        }
+        every(syncIfNeededMock).answers { _ in }
+        every(syncMock).answers { _ in }
     }
 
     lazy var initializeMock = MockFunction(self, initialize)
@@ -107,15 +106,21 @@ class MockUserManager: Mock, UserManager {
         call(resetUserMock, args: ())
     }
 
-    lazy var syncMock = MockFunction(self, sync)
+    lazy var syncMock = MockFunction.throwable(self, syncStub)
 
-    func sync(completion: @escaping (Result<(), Error>) -> ()) {
-        call(syncMock, args: completion)
+    private func syncStub() throws {
     }
 
-    lazy var syncIfNeededMock = MockFunction(self, syncIfNeeded)
+    func sync() async throws {
+        try call(syncMock, args: ())
+    }
 
-    func syncIfNeeded(updated: Updated<User>, completion: @escaping () -> ()) {
-        call(syncIfNeededMock, args: (updated, completion))
+    lazy var syncIfNeededMock = MockFunction(self, syncIfNeededStub)
+
+    private func syncIfNeededStub(updated: Updated<User>) {
+    }
+
+    func syncIfNeeded(updated: Updated<User>) async {
+        call(syncIfNeededMock, args: updated)
     }
 }

--- a/Tests/HackleTests/Core/User/MockUserTargetFetcher.swift
+++ b/Tests/HackleTests/Core/User/MockUserTargetFetcher.swift
@@ -2,8 +2,6 @@
 //  MockUserTargetFetcher.swift
 //  Hackle
 //
-//  Created by sungwoo.yeo on 2/7/25.
-//
 
 @testable import Hackle
 import MockingKit
@@ -13,15 +11,17 @@ class MockUserTargetFetcher: Mock, UserTargetEventsFetcher {
     init(result: Result<UserTargetEvents, Error>? = nil) {
         super.init()
         if let result {
-            every(fetchMock).answers { user, completion in
-                completion(result)
-            }
+            every(fetchMock).answers { _ in try result.get() }
         }
     }
 
-    lazy var fetchMock = MockFunction(self, fetch)
+    lazy var fetchMock = MockFunction.throwable(self, fetchStub)
 
-    func fetch(user: User, completion: @escaping (Result<UserTargetEvents, Error>) -> ()) {
-        call(fetchMock, args: (user, completion))
+    private func fetchStub(user: User) throws -> UserTargetEvents {
+        UserTargetEvents.empty()
+    }
+
+    func fetch(user: User) async throws -> UserTargetEvents {
+        try call(fetchMock, args: user)
     }
 }

--- a/Tests/HackleTests/Core/User/UserManagerRaceSpecs.swift
+++ b/Tests/HackleTests/Core/User/UserManagerRaceSpecs.swift
@@ -26,12 +26,8 @@ class UserManagerRaceSpecs: QuickSpec {
                 targetFetcher: targetFetcher,
                 clock: clock
             )
-            every(cohortFetcher.fetchMock).answers { _, completion in
-                completion(.success(UserCohorts()))
-            }
-            every(targetFetcher.fetchMock).answers { _, completion in
-                completion(.success(UserTargetEvents()))
-            }
+            every(cohortFetcher.fetchMock).answers { _ in UserCohorts() }
+            every(targetFetcher.fetchMock).answers { _ in UserTargetEvents() }
             sut.initialize(user: User.builder().id("id").build())
 
             let writerIterations = 2_000
@@ -42,7 +38,10 @@ class UserManagerRaceSpecs: QuickSpec {
             DispatchQueue.global(qos: .utility).async(group: group) {
                 for _ in 0..<writerIterations {
                     let sem = DispatchSemaphore(value: 0)
-                    sut.sync { sem.signal() }
+                    Task {
+                        try? await sut.sync()
+                        sem.signal()
+                    }
                     sem.wait()
                 }
             }

--- a/Tests/HackleTests/Core/Workspace/DefaultHttpWorkspaceFetcherSpecs.swift
+++ b/Tests/HackleTests/Core/Workspace/DefaultHttpWorkspaceFetcherSpecs.swift
@@ -36,10 +36,7 @@ class DefaultHttpWorkspaceFetcherSpecs: QuickSpec {
             }
             let sut = DefaultHttpWorkspaceFetcher(config: HackleConfig.DEFAULT, sdk: sdk(key: "test-key"), httpClient: httpClient)
 
-            var actual: Result<WorkspaceConfigResponse?, Error>!
-            sut.fetchIfModified { result in
-                actual = result
-            }
+            let actual = awaitResult { try await sut.fetchIfModified() }
             expect(try actual.get()).to(throwError(HackleError.error("fail")))
         }
 
@@ -49,10 +46,7 @@ class DefaultHttpWorkspaceFetcherSpecs: QuickSpec {
             }
             let sut = DefaultHttpWorkspaceFetcher(config: HackleConfig.DEFAULT, sdk: sdk(key: "test-key"), httpClient: httpClient)
 
-            var actual: Result<WorkspaceConfigResponse?, Error>!
-            sut.fetchIfModified { result in
-                actual = result
-            }
+            let actual = awaitResult { try await sut.fetchIfModified() }
             expect(try actual.get()).to(throwError(HackleError.error("Response is empty")))
         }
 
@@ -62,10 +56,7 @@ class DefaultHttpWorkspaceFetcherSpecs: QuickSpec {
             }
             let sut = DefaultHttpWorkspaceFetcher(config: HackleConfig.DEFAULT, sdk: sdk(key: "test-key"), httpClient: httpClient)
 
-            var actual: Result<WorkspaceConfigResponse?, Error>!
-            sut.fetchIfModified(lastModified: "LAST_MODIFIED_HEADER_VALUE") { result in
-                actual = result
-            }
+            let actual = awaitResult { try await sut.fetchIfModified(lastModified: "LAST_MODIFIED_HEADER_VALUE") }
             expect(try actual.get()).to(beNil())
         }
 
@@ -75,10 +66,7 @@ class DefaultHttpWorkspaceFetcherSpecs: QuickSpec {
             }
             let sut = DefaultHttpWorkspaceFetcher(config: HackleConfig.DEFAULT, sdk: sdk(key: "test-key"), httpClient: httpClient)
 
-            var actual: Result<WorkspaceConfigResponse?, Error>!
-            sut.fetchIfModified { result in
-                actual = result
-            }
+            let actual = awaitResult { try await sut.fetchIfModified() }
             expect(try actual.get()).to(throwError(HackleError.error("Http status code: 500")))
         }
 
@@ -88,10 +76,7 @@ class DefaultHttpWorkspaceFetcherSpecs: QuickSpec {
             }
             let sut = DefaultHttpWorkspaceFetcher(config: HackleConfig.DEFAULT, sdk: sdk(key: "test-key"), httpClient: httpClient)
 
-            var actual: Result<WorkspaceConfigResponse?, Error>!
-            sut.fetchIfModified { result in
-                actual = result
-            }
+            let actual = awaitResult { try await sut.fetchIfModified() }
             expect(try actual.get()).to(throwError(HackleError.error("Response body is empty")))
         }
 
@@ -101,10 +86,7 @@ class DefaultHttpWorkspaceFetcherSpecs: QuickSpec {
             }
             let sut = DefaultHttpWorkspaceFetcher(config: HackleConfig.DEFAULT, sdk: sdk(key: "test-key"), httpClient: httpClient)
 
-            var actual: Result<WorkspaceConfigResponse?, Error>!
-            sut.fetchIfModified { result in
-                actual = result
-            }
+            let actual = awaitResult { try await sut.fetchIfModified() }
             expect(try actual.get()).to(throwError(HackleError.error("Invalid format")))
         }
 
@@ -115,10 +97,7 @@ class DefaultHttpWorkspaceFetcherSpecs: QuickSpec {
             }
             let sut = DefaultHttpWorkspaceFetcher(config: HackleConfig.DEFAULT, sdk: sdk(key: "test-key"), httpClient: httpClient)
 
-            var actual: Result<WorkspaceConfigResponse?, Error>!
-            sut.fetchIfModified { result in
-                actual = result
-            }
+            let actual = awaitResult { try await sut.fetchIfModified() }
             expect(try actual.get()).toNot(beNil())
         }
 
@@ -132,10 +111,7 @@ class DefaultHttpWorkspaceFetcherSpecs: QuickSpec {
                 .build()
             let sut = DefaultHttpWorkspaceFetcher(config: config, sdk: sdk(key: "SDK_KEY"), httpClient: httpClient)
 
-            var actual: Result<WorkspaceConfigResponse?, Error>!
-            sut.fetchIfModified { result in
-                actual = result
-            }
+            let actual = awaitResult { try await sut.fetchIfModified() }
             expect(try actual.get()).toNot(beNil())
 
             expect(httpClient.executeMock.firstInvokation().arguments.0.url) == URL(string: "localhost/api/v2/workspaces/SDK_KEY/config")
@@ -154,16 +130,10 @@ class DefaultHttpWorkspaceFetcherSpecs: QuickSpec {
             }
 
             let sut = DefaultHttpWorkspaceFetcher(config: HackleConfig.DEFAULT, sdk: sdk(key: "SDK_KEY"), httpClient: httpClient)
-            var actual: Result<WorkspaceConfigResponse?, Error>!
-            sut.fetchIfModified { result in
-                actual = result
-            }
-            expect(try actual.get()).toNot(beNil())
-            sut.fetchIfModified(lastModified: "LAST_MODIFIED_HEADER_VALUE") { result in
-                actual = result
-            }
-            Thread.sleep(forTimeInterval: 0.1)
-            expect(try actual.get()).to(beNil())
+            let first = awaitResult { try await sut.fetchIfModified() }
+            expect(try first.get()).toNot(beNil())
+            let second = awaitResult { try await sut.fetchIfModified(lastModified: "LAST_MODIFIED_HEADER_VALUE") }
+            expect(try second.get()).to(beNil())
 
             let invokes = httpClient.executeMock.invokations()
             expect(invokes[0].arguments.0.headers).to(beNil())
@@ -179,11 +149,8 @@ class DefaultHttpWorkspaceFetcherSpecs: QuickSpec {
                 }
             
             let sut = DefaultHttpWorkspaceFetcher(config: HackleConfig.DEFAULT, sdk: sdk(key: "SDK_KEY"), httpClient: httpClient)
-            var actual: Result<WorkspaceConfigResponse?, Error>!
-            sut.fetchIfModified { result in
-                actual = result
-            }
-            
+            let actual = awaitResult { try await sut.fetchIfModified() }
+
             let config = try actual.get()
             expect(config).toNot(beNil())
             expect(config?.lastModified) == "LAST_MODIFIED_HEADER_VALUE"

--- a/Tests/HackleTests/Core/Workspace/WorkspaceManagerSpecs.swift
+++ b/Tests/HackleTests/Core/Workspace/WorkspaceManagerSpecs.swift
@@ -28,7 +28,7 @@ class WorkspaceManagerSpecs: QuickSpec {
             let sut = WorkspaceManager(httpWorkspaceFetcher: httpWorkspaceFetcher, repository: repository)
             sut.initialize()
             
-            sut.sync { }
+            awaitCompletion { try await sut.sync() }
             
             let actual: WorkspaceConfig? = sut.fetch()
             expect(actual?.id) == data.config.workspace.id
@@ -72,7 +72,7 @@ class WorkspaceManagerSpecs: QuickSpec {
             let sut = WorkspaceManager(httpWorkspaceFetcher: httpWorkspaceFetcher, repository: repository)
             sut.initialize()
             
-            sut.sync { }
+            awaitCompletion { try await sut.sync() }
             
             let actual: WorkspaceConfig? = sut.fetch()
             expect(actual?.id) == data.config.workspace.id
@@ -90,14 +90,14 @@ class WorkspaceManagerSpecs: QuickSpec {
             let sut = WorkspaceManager(httpWorkspaceFetcher: httpWorkspaceFetcher, repository: repository)
             sut.initialize()
             
-            sut.sync { }
+            awaitCompletion { try await sut.sync() }
             
-            expect(httpWorkspaceFetcher.fetchIfModifiedRef.lastInvokation().arguments.0).to(beNil())
+            expect(httpWorkspaceFetcher.fetchIfModifiedRef.lastInvokation().arguments).to(beNil())
             expect(repository.value?.lastModified) == first.lastModified
             
-            sut.sync { }
+            awaitCompletion { try await sut.sync() }
             
-            expect(httpWorkspaceFetcher.fetchIfModifiedRef.lastInvokation().arguments.0) == first.lastModified
+            expect(httpWorkspaceFetcher.fetchIfModifiedRef.lastInvokation().arguments) == first.lastModified
             expect(repository.value?.lastModified) == second.lastModified
         }
         
@@ -108,7 +108,7 @@ class WorkspaceManagerSpecs: QuickSpec {
             let sut = WorkspaceManager(httpWorkspaceFetcher: httpWorkspaceFetcher, repository: repository)
             sut.initialize()
             
-            sut.sync { }
+            awaitCompletion { try await sut.sync() }
             
             let actual: WorkspaceConfig? = sut.fetch()
             expect(actual?.id) == data.config.workspace.id
@@ -121,7 +121,7 @@ class WorkspaceManagerSpecs: QuickSpec {
             let sut = WorkspaceManager(httpWorkspaceFetcher: httpWorkspaceFetcher, repository: repository)
             sut.initialize()
             
-            sut.sync { }
+            awaitCompletion { try await sut.sync() }
             
             let actual: WorkspaceConfig? = sut.fetch()
             expect(actual).to(beNil())
@@ -135,7 +135,7 @@ class WorkspaceManagerSpecs: QuickSpec {
             let sut = WorkspaceManager(httpWorkspaceFetcher: httpWorkspaceFetcher, repository: repository)
             sut.initialize()
             
-            sut.sync { }
+            awaitCompletion { try await sut.sync() }
             
             let actual: WorkspaceConfig? = sut.fetch()
             expect(actual).toNot(beNil())

--- a/Tests/HackleTests/HackleAppAsyncApiSpecs.swift
+++ b/Tests/HackleTests/HackleAppAsyncApiSpecs.swift
@@ -1,0 +1,100 @@
+import Foundation
+import Nimble
+import Quick
+@testable import Hackle
+
+class HackleAppAsyncApiSpecs: QuickSpec {
+    override class func spec() {
+        var core: MockHackleCore!
+        var eventQueue: DispatchQueue!
+        var synchronizer: MockSynchronizer!
+        var platformManager: PlatformManager!
+        var userManager: MockUserManager!
+        var workspaceManager: WorkspaceManager!
+        var notificationManager: MockNotificationManager!
+        var sessionManager: MockSessionManager!
+        var screenManager: MockScreeManager!
+        var eventProcessor: MockUserEventProcessor!
+        var pushTokenRegistry = DefaultPushTokenRegistry()
+        var userExplorer: HackleUserExplorer!
+        var inAppMessageUI: HackleInAppMessageUI!
+
+        var sut: HackleApp!
+
+        beforeEach {
+            Metrics.clear()
+            core = MockHackleCore()
+            eventQueue = DispatchQueue(label: "io.hackle.EventQueue", qos: .utility)
+            synchronizer = MockSynchronizer()
+            userManager = MockUserManager()
+            workspaceManager = WorkspaceManager(
+                httpWorkspaceFetcher: MockHttpWorkspaceFetcher(returns: []),
+                repository: MockWorkspaceConfigRepository()
+            )
+            let globalRepository = MemoryKeyValueRepository()
+            globalRepository.putString(key: "hackle_device_id", value: "test_device_id")
+            platformManager = PlatformManager(keyValueRepository: globalRepository)
+            notificationManager = MockNotificationManager()
+            sessionManager = MockSessionManager()
+            screenManager = MockScreeManager()
+            eventProcessor = MockUserEventProcessor()
+            pushTokenRegistry = DefaultPushTokenRegistry()
+            userExplorer = DefaultHackleUserExplorer(
+                core: core,
+                userManager: userManager,
+                pushTokenManager: MockPushTokenManager(),
+                abTestOverrideStorage: HackleUserManualOverrideStorage(keyValueRepository: MemoryKeyValueRepository()),
+                featureFlagOverrideStorage: HackleUserManualOverrideStorage(keyValueRepository: MemoryKeyValueRepository()),
+                devToolsAPI: MockDevToolsAPI()
+            )
+            inAppMessageUI = makeInAppMessageUI(core: core)
+            let throttler = DefaultThrottler(limiter: ScopingThrottleLimiter(interval: 10, limit: 1, clock: SystemClock.shared))
+            let built = makeHackleApp(
+                core: core,
+                eventQueue: eventQueue,
+                synchronizer: synchronizer,
+                userManager: userManager,
+                workspaceManager: workspaceManager,
+                sessionManager: sessionManager,
+                screenManager: screenManager,
+                eventProcessor: eventProcessor,
+                pushTokenRegistry: pushTokenRegistry,
+                notificationManager: notificationManager,
+                platformManager: platformManager,
+                userExplorer: userExplorer,
+                inAppMessageUI: inAppMessageUI,
+                throttler: throttler
+            )
+            sut = built.sut
+        }
+
+        it("setUser async — 반환 시 유저 갱신과 sync가 모두 완료된다") {
+            let user = User.builder().id("async-user").build()
+            awaitCompletion {
+                await sut.setUser(user: user)
+                expect(userManager.currentUser.id) == "async-user"
+                verify(exactly: 1) {
+                    userManager.syncIfNeededMock
+                }
+            }
+        }
+
+        it("updateUserProperties async — non-suspending으로 완료된다") {
+            awaitCompletion {
+                await sut.updateUserProperties(operations: PropertyOperations.builder().set("k", "v").build())
+                verify(exactly: 1) {
+                    userManager.updatePropertiesMock
+                }
+            }
+        }
+
+        it("fetch async — sync 완료 후 반환된다") {
+            awaitCompletion {
+                await sut.fetch()
+                verify(exactly: 1) {
+                    synchronizer.syncMock
+                }
+            }
+        }
+    }
+}

--- a/Tests/HackleTests/HackleAppSpec.swift
+++ b/Tests/HackleTests/HackleAppSpec.swift
@@ -47,50 +47,12 @@ class HackleAppSpecs: QuickSpec {
                 featureFlagOverrideStorage: HackleUserManualOverrideStorage(keyValueRepository: MemoryKeyValueRepository()),
                 devToolsAPI: MockDevToolsAPI()
             )
-            let urlHandler = ApplicationUrlHandler()
-            let inAppMessageActionHandlerFactory = DefaultInAppMessageActionHandlerFactory(handlers: [])
-            let inAppMessageViewEventActorFactory = DefaultInAppMessageViewEventActorFactory(actors: [
-                InAppMessageViewImpressionEventActor(),
-                InAppMessageViewActionEventActor(actionHandlerFactory: inAppMessageActionHandlerFactory),
-                InAppMessageViewCloseEventActor()
-            ])
-            let inAppMessageViewEventActionHandler = InAppMessageViewEventActionHandler(
-                actorFactory: inAppMessageViewEventActorFactory
-            )
-            let inAppMessageEventTracker = DefaultInAppMessageEventTracker(
-                core: core
-            )
-            let inAppMessageViewEventTrackHandler = InAppMessageViewEventTrackHandler(
-                tracker: inAppMessageEventTracker
-            )
-            let inAppMessageViewEventHandlerFactory = DefaultInAppMessageViewEventHandlerFactory(handlers: [
-                inAppMessageViewEventActionHandler,
-                inAppMessageViewEventTrackHandler
-            ])
-            let inAppMessageViewEventProcessor = DefaultInAppMessageViewEventProcessor(
-                handlerFactory: inAppMessageViewEventHandlerFactory
-            )
-            inAppMessageUI = HackleInAppMessageUI(
-                clock: SystemClock.shared,
-                eventProcessor: inAppMessageViewEventProcessor,
-                htmlContentResolverFactory: MockInAppMessageHtmlContentResolverFactory()
-            )
-
-            let applicationInstallDeterminer = ApplicationInstallDeterminer()
-            let applicationInstallStateManager = ApplicationInstallStateManager(
-                platformManager: platformManager,
-                applicationInstallDeterminer: applicationInstallDeterminer,
-                clock: SystemClock.shared
-            )
-
+            inAppMessageUI = makeInAppMessageUI(core: core)
             let throttler = DefaultThrottler(limiter: ScopingThrottleLimiter(interval: 10, limit: 1, clock: SystemClock.shared))
-
-            let hackleAppCore = DefaultHackleAppCore(
+            let built = makeHackleApp(
                 core: core,
                 eventQueue: eventQueue,
                 synchronizer: synchronizer,
-                applicationLifecycleObserver: ApplicationLifecycleObserver.shared,
-                viewLifecycleObserver: ViewLifecycleObserver.shared,
                 userManager: userManager,
                 workspaceManager: workspaceManager,
                 sessionManager: sessionManager,
@@ -98,19 +60,12 @@ class HackleAppSpecs: QuickSpec {
                 eventProcessor: eventProcessor,
                 pushTokenRegistry: pushTokenRegistry,
                 notificationManager: notificationManager,
-                fetchThrottler: throttler,
                 platformManager: platformManager,
-                inAppMessageUI: inAppMessageUI,
-                applicationInstallStateManager: applicationInstallStateManager,
                 userExplorer: userExplorer,
-                optOutManager: OptOutManager(configOptOutTracking: false)
+                inAppMessageUI: inAppMessageUI,
+                throttler: throttler
             )
-            sut = HackleApp(
-                hackleAppCore: hackleAppCore,
-                sdk: Sdk.of(sdkKey: "abcd1234", config: HackleConfig.DEFAULT),
-                config: HackleConfig.builder().mode(.native).build(),
-                hackleInvocator: DefaultHackleInvocator(processor: DefaultInvocationProcessor(handlerFactory: DefaultInvocationHandlerFactory(core: hackleAppCore)))
-            )
+            sut = built.sut
         }
 
         it("deviceId") {
@@ -139,7 +94,11 @@ class HackleAppSpecs: QuickSpec {
         describe("setUser") {
             it("set and sync") {
                 let user = User.builder().id("42").build()
-                sut.setUser(user: user)
+                waitUntil { done in
+                    sut.setUser(user: user) {
+                        done()
+                    }
+                }
                 verify(exactly: 1) {
                     userManager.setUserMock
                 }
@@ -152,16 +111,30 @@ class HackleAppSpecs: QuickSpec {
             it("completion") {
                 var count = 0
                 let user = User.builder().id("42").build()
-                sut.setUser(user: user) {
-                    count += 1
+                waitUntil { done in
+                    sut.setUser(user: user) {
+                        count += 1
+                        done()
+                    }
                 }
                 expect(count) == 1
+            }
+
+            it("setUser 반환 시점에 유저 갱신이 이미 완료된다 (동기 프리픽스)") {
+                let user = User.builder().id("sync-prefix").build()
+                sut.setUser(user: user, completion: {})
+                // completion 대기 없이 즉시 확인 — mutation은 동기
+                expect(userManager.currentUser.id) == "sync-prefix"
             }
         }
 
         describe("setUserId") {
             it("set and sync") {
-                sut.setUserId(userId: "user_id")
+                waitUntil { done in
+                    sut.setUserId(userId: "user_id") {
+                        done()
+                    }
+                }
                 verify(exactly: 1) {
                     userManager.setUserIdMock
                 }
@@ -173,8 +146,11 @@ class HackleAppSpecs: QuickSpec {
 
             it("completion") {
                 var count = 0
-                sut.setUserId(userId: "user_id") {
-                    count += 1
+                waitUntil { done in
+                    sut.setUserId(userId: "user_id") {
+                        count += 1
+                        done()
+                    }
                 }
                 expect(count) == 1
             }
@@ -182,7 +158,11 @@ class HackleAppSpecs: QuickSpec {
 
         describe("setDeviceId") {
             it("set and sync") {
-                sut.setDeviceId(deviceId: "device_id")
+                waitUntil { done in
+                    sut.setDeviceId(deviceId: "device_id") {
+                        done()
+                    }
+                }
                 verify(exactly: 1) {
                     userManager.setDeviceIdMock
                 }
@@ -194,8 +174,11 @@ class HackleAppSpecs: QuickSpec {
 
             it("completion") {
                 var count = 0
-                sut.setDeviceId(deviceId: "device_id") {
-                    count += 1
+                waitUntil { done in
+                    sut.setDeviceId(deviceId: "device_id") {
+                        count += 1
+                        done()
+                    }
                 }
                 expect(count) == 1
             }
@@ -203,7 +186,11 @@ class HackleAppSpecs: QuickSpec {
 
         describe("resetUser") {
             it("reset") {
-                sut.resetUser()
+                waitUntil { done in
+                    sut.resetUser {
+                        done()
+                    }
+                }
                 verify(exactly: 1) {
                     userManager.resetUserMock
                 }
@@ -217,8 +204,11 @@ class HackleAppSpecs: QuickSpec {
             }
             it("completion") {
                 var count = 0
-                sut.resetUser {
-                    count += 1
+                waitUntil { done in
+                    sut.resetUser {
+                        count += 1
+                        done()
+                    }
                 }
                 expect(count) == 1
             }
@@ -226,7 +216,7 @@ class HackleAppSpecs: QuickSpec {
 
         describe("setUserProperty") {
             it("update properties") {
-                sut.setUserProperty(key: "age", value: 42)
+                sut.setUserProperty(key: "age", value: 42) {}
                 verify(exactly: 1) {
                     userManager.updatePropertiesMock
                 }
@@ -255,7 +245,7 @@ class HackleAppSpecs: QuickSpec {
 
         describe("updateUserProperties") {
             it("update properties") {
-                sut.updateUserProperties(operations: PropertyOperations.builder().set("age", 42).build())
+                sut.updateUserProperties(operations: PropertyOperations.builder().set("age", 42).build()) {}
                 verify(exactly: 1) {
                     userManager.updatePropertiesMock
                 }
@@ -278,6 +268,15 @@ class HackleAppSpecs: QuickSpec {
                     count += 1
                 }
                 expect(count) == 1
+            }
+
+            it("updateUserProperties completion은 동기 인라인으로 호출된다") {
+                var called = false
+                sut.updateUserProperties(operations: PropertyOperations.builder().set("k", "v").build()) {
+                    called = true
+                }
+                // 대기 없이 즉시 true — 현행 동기 인라인 계약 보존
+                expect(called) == true
             }
         }
 
@@ -495,6 +494,25 @@ class HackleAppSpecs: QuickSpec {
             expect(platformManager.device.properties.count) == 13
         }
 
+        it("initialize — sync 완료 후에 flush가 실행된다") {
+            var order: [String] = []
+            every(synchronizer.syncMock).answers { _ in
+                Thread.sleep(forTimeInterval: 0.1)
+                order.append("sync")
+            }
+            notificationManager.onFlush = {
+                order.append("flush")
+            }
+
+            waitUntil(timeout: .seconds(10)) { done in
+                sut.initialize(user: nil) {
+                    done()
+                }
+            }
+
+            expect(order) == ["sync", "flush"]
+        }
+
         it("create") {
             let config = HackleConfig.builder()
                 .sdkUrl(URL(string: "http://localhost")!)
@@ -582,6 +600,34 @@ class HackleAppSpecs: QuickSpec {
             }
         }
 
+        describe("fetch") {
+            it("fetch - 스로틀(reject) 시에도 completion이 호출된다") {
+                let rejectingBuilt = makeHackleApp(
+                    core: core,
+                    eventQueue: eventQueue,
+                    synchronizer: synchronizer,
+                    userManager: userManager,
+                    workspaceManager: workspaceManager,
+                    sessionManager: sessionManager,
+                    screenManager: screenManager,
+                    eventProcessor: eventProcessor,
+                    pushTokenRegistry: pushTokenRegistry,
+                    notificationManager: notificationManager,
+                    platformManager: platformManager,
+                    userExplorer: userExplorer,
+                    inAppMessageUI: inAppMessageUI,
+                    throttler: RejectingThrottler()
+                )
+                let rejectingSut = rejectingBuilt.sut
+
+                waitUntil { done in
+                    rejectingSut.fetch {
+                        done()
+                    }
+                }
+            }
+        }
+
         describe("DEPRECATED") {
             describe("experiment") {
                 beforeEach {
@@ -666,5 +712,11 @@ class HackleAppSpecs: QuickSpec {
                 expect(actual).to(beAnInstanceOf(DefaultRemoteConfig.self))
             }
         }
+    }
+}
+
+private class RejectingThrottler: Throttler {
+    func execute(accept: @escaping () -> (), reject: @escaping () -> ()) {
+        reject()
     }
 }

--- a/Tests/HackleTests/Mock/AsyncTestHelpers.swift
+++ b/Tests/HackleTests/Mock/AsyncTestHelpers.swift
@@ -1,0 +1,23 @@
+import Nimble
+@testable import Hackle
+
+/// async 작업을 waitUntil로 감싸 완료까지 대기하고 결과를 Result로 반환한다.
+func awaitResult<T>(timeout: NimbleTimeInterval = .seconds(1), _ operation: @escaping () async throws -> T) -> Result<T, Error> {
+    var result: Result<T, Error>?
+    waitUntil(timeout: timeout) { done in
+        Task {
+            do {
+                result = .success(try await operation())
+            } catch {
+                result = .failure(error)
+            }
+            done()
+        }
+    }
+    return result ?? .failure(HackleError.error("awaitResult timed out"))
+}
+
+/// async 작업을 waitUntil로 감싸 완료까지 대기한다. 발생한 에러는 무시한다.
+func awaitCompletion(timeout: NimbleTimeInterval = .seconds(1), _ operation: @escaping () async throws -> Void) {
+    _ = awaitResult(timeout: timeout, operation)
+}

--- a/Tests/HackleTests/Mock/BarrierSynchronizer.swift
+++ b/Tests/HackleTests/Mock/BarrierSynchronizer.swift
@@ -1,0 +1,52 @@
+@testable import Hackle
+
+/// N개의 async 호출자가 모두 도착할 때까지 비블로킹으로 대기시키는 배리어.
+/// cooperative pool 스레드 수와 무관하게 동작(await 기반, blocking 아님).
+///
+/// - Important: `wait()`을 호출하는 개수는 반드시 `count`와 정확히 일치해야 한다.
+///   호출 횟수가 `count`보다 적으면 이미 도착한 모든 호출자가 영구히 suspend된다.
+///   타임아웃/탈출 경로가 없으므로, 호출 수 불일치는 (의도적으로) 테스트 데드락으로 나타난다.
+actor Barrier {
+    private let count: Int
+    private var arrived = 0
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    init(count: Int) {
+        self.count = count
+    }
+
+    /// 도착 카운트를 1 증가시키고, `count`에 도달하면 대기 중이던 모든 호출자를 깨운다.
+    /// 그렇지 않으면 이 호출자 자신도 대기열에 등록되어 suspend된다.
+    ///
+    /// - Warning: `wait()` 호출 총 횟수가 `count`에 도달하지 못하면 이 함수는 영원히 반환하지 않는다.
+    func wait() async {
+        arrived += 1
+        if arrived >= count {
+            for waiter in waiters {
+                waiter.resume()
+            }
+            waiters.removeAll()
+        } else {
+            await withCheckedContinuation { continuation in
+                waiters.append(continuation)
+            }
+        }
+    }
+}
+
+/// sync() 진입 시 배리어에 도착·대기하는 결정적 테스트 synchronizer.
+/// CompositeSynchronizer가 child들을 동시에 dispatch하면 모두 배리어를 통과하고,
+/// 순차 await로 회귀하면 첫 child가 배리어에서 영구 대기 → 상위 호출이 타임아웃된다.
+class BarrierSynchronizer: Synchronizer {
+    private let barrier: Barrier
+    private(set) var synced = false
+
+    init(barrier: Barrier) {
+        self.barrier = barrier
+    }
+
+    func sync() async throws {
+        await barrier.wait()
+        synced = true
+    }
+}

--- a/Tests/HackleTests/Mock/HackleAppTestFactory.swift
+++ b/Tests/HackleTests/Mock/HackleAppTestFactory.swift
@@ -1,0 +1,86 @@
+import Foundation
+@testable import Hackle
+
+/// 모든 HackleApp SUT 배선이 공유하는 inAppMessage UI 체인.
+func makeInAppMessageUI(core: HackleCore) -> HackleInAppMessageUI {
+    let inAppMessageActionHandlerFactory = DefaultInAppMessageActionHandlerFactory(handlers: [])
+    let inAppMessageViewEventActorFactory = DefaultInAppMessageViewEventActorFactory(actors: [
+        InAppMessageViewImpressionEventActor(),
+        InAppMessageViewActionEventActor(actionHandlerFactory: inAppMessageActionHandlerFactory),
+        InAppMessageViewCloseEventActor()
+    ])
+    let inAppMessageViewEventActionHandler = InAppMessageViewEventActionHandler(
+        actorFactory: inAppMessageViewEventActorFactory
+    )
+    let inAppMessageEventTracker = DefaultInAppMessageEventTracker(core: core)
+    let inAppMessageViewEventTrackHandler = InAppMessageViewEventTrackHandler(
+        tracker: inAppMessageEventTracker
+    )
+    let inAppMessageViewEventHandlerFactory = DefaultInAppMessageViewEventHandlerFactory(handlers: [
+        inAppMessageViewEventActionHandler,
+        inAppMessageViewEventTrackHandler
+    ])
+    let inAppMessageViewEventProcessor = DefaultInAppMessageViewEventProcessor(
+        handlerFactory: inAppMessageViewEventHandlerFactory
+    )
+    return HackleInAppMessageUI(
+        clock: SystemClock.shared,
+        eventProcessor: inAppMessageViewEventProcessor,
+        htmlContentResolverFactory: MockInAppMessageHtmlContentResolverFactory()
+    )
+}
+
+/// DefaultHackleAppCore + HackleApp 배선. 각 테스트는 자신이 참조할 mock을 주입한다.
+func makeHackleApp(
+    core: HackleCore,
+    eventQueue: DispatchQueue,
+    synchronizer: Synchronizer,
+    userManager: UserManager,
+    workspaceManager: WorkspaceManager,
+    sessionManager: SessionManager,
+    screenManager: ScreenManager,
+    eventProcessor: UserEventProcessor,
+    pushTokenRegistry: PushTokenRegistry,
+    notificationManager: NotificationManager,
+    platformManager: PlatformManager,
+    userExplorer: HackleUserExplorer,
+    inAppMessageUI: HackleInAppMessageUI,
+    throttler: Throttler
+) -> (core: DefaultHackleAppCore, sut: HackleApp) {
+    let applicationInstallStateManager = ApplicationInstallStateManager(
+        platformManager: platformManager,
+        applicationInstallDeterminer: ApplicationInstallDeterminer(),
+        clock: SystemClock.shared
+    )
+    let hackleAppCore = DefaultHackleAppCore(
+        core: core,
+        eventQueue: eventQueue,
+        synchronizer: synchronizer,
+        applicationLifecycleObserver: ApplicationLifecycleObserver.shared,
+        viewLifecycleObserver: ViewLifecycleObserver.shared,
+        userManager: userManager,
+        workspaceManager: workspaceManager,
+        sessionManager: sessionManager,
+        screenManager: screenManager,
+        eventProcessor: eventProcessor,
+        pushTokenRegistry: pushTokenRegistry,
+        notificationManager: notificationManager,
+        fetchThrottler: throttler,
+        platformManager: platformManager,
+        inAppMessageUI: inAppMessageUI,
+        applicationInstallStateManager: applicationInstallStateManager,
+        userExplorer: userExplorer,
+        optOutManager: OptOutManager(configOptOutTracking: false)
+    )
+    let sut = HackleApp(
+        hackleAppCore: hackleAppCore,
+        sdk: Sdk.of(sdkKey: "abcd1234", config: HackleConfig.DEFAULT),
+        config: HackleConfig.builder().mode(.native).build(),
+        hackleInvocator: DefaultHackleInvocator(
+            processor: DefaultInvocationProcessor(
+                handlerFactory: DefaultInvocationHandlerFactory(core: hackleAppCore)
+            )
+        )
+    )
+    return (hackleAppCore, sut)
+}

--- a/Tests/HackleTests/Mock/MockHackleApp.swift
+++ b/Tests/HackleTests/Mock/MockHackleApp.swift
@@ -20,13 +20,19 @@ class MockHackleAppCore: Mock, HackleAppCore {
         self.sessionId = sessonId
         self.deviceId = deviceId
         self.user = user
+        super.init()
+        every(setUserRef).answers { _ in Task {} }
+        every(setUserIdRef).answers { _ in Task {} }
+        every(setDeviceIdRef).answers { _ in Task {} }
+        every(resetUserRef).answers { _ in Task {} }
+        every(fetchRef).answers { _ in Task {} }
     }
 
     lazy var getInAppMessageViewRef = MockFunction(self, getInAppMessageView)
     func getInAppMessageView(viewId: String) -> InAppMessageView? {
         call(getInAppMessageViewRef, args: viewId)
     }
-    
+
     lazy var showUserExplorerRef = MockFunction(self, showUserExplorer)
     func showUserExplorer() {
         call(showUserExplorerRef, args: ())
@@ -36,29 +42,29 @@ class MockHackleAppCore: Mock, HackleAppCore {
     func hideUserExplorer() {
         call(hideUserExplorerRef, args: ())
     }
-    
+
     lazy var setDeviceIdRef = MockFunction(self, setDeviceId)
-    func setDeviceId(deviceId: String, hackleAppContext: HackleAppContext, completion: @escaping () -> ()) {
+    func setDeviceId(deviceId: String, hackleAppContext: HackleAppContext) -> Task<Void, Never> {
         self.hackleAppContext = hackleAppContext
-        call(setDeviceIdRef, args: (deviceId, hackleAppContext, completion))
+        return call(setDeviceIdRef, args: (deviceId, hackleAppContext))
     }
-    
+
     lazy var setUserRef = MockFunction(self, setUser)
-    func setUser(user: User, hackleAppContext: HackleAppContext, completion: @escaping () -> ()) {
+    func setUser(user: User, hackleAppContext: HackleAppContext) -> Task<Void, Never> {
         self.hackleAppContext = hackleAppContext
-        call(setUserRef, args: (user, hackleAppContext, completion))
+        return call(setUserRef, args: (user, hackleAppContext))
     }
-    
+
     lazy var setUserIdRef = MockFunction(self, setUserId)
-    func setUserId(userId: String?, hackleAppContext: HackleAppContext, completion: @escaping () -> ()) {
+    func setUserId(userId: String?, hackleAppContext: HackleAppContext) -> Task<Void, Never> {
         self.hackleAppContext = hackleAppContext
-        call(setUserIdRef, args: (userId, hackleAppContext, completion))
+        return call(setUserIdRef, args: (userId, hackleAppContext))
     }
-    
+
     lazy var updateUserPropertiesRef = MockFunction(self, updateUserProperties)
-    func updateUserProperties(operations: PropertyOperations, hackleAppContext: HackleAppContext, completion: @escaping () -> ()) {
+    func updateUserProperties(operations: PropertyOperations, hackleAppContext: HackleAppContext) {
         self.hackleAppContext = hackleAppContext
-        call(updateUserPropertiesRef, args: (operations, hackleAppContext, completion))
+        call(updateUserPropertiesRef, args: (operations, hackleAppContext))
     }
     
     lazy var updatePushSubscriptionsRef = MockFunction(self, updatePushSubscriptions as (HackleSubscriptionOperations, HackleAppContext) -> ())
@@ -80,21 +86,21 @@ class MockHackleAppCore: Mock, HackleAppCore {
     }
     
     lazy var resetUserRef = MockFunction(self, resetUser)
-    func resetUser(hackleAppContext: HackleAppContext, completion: @escaping () -> ()) {
+    func resetUser(hackleAppContext: HackleAppContext) -> Task<Void, Never> {
         self.hackleAppContext = hackleAppContext
-        call(resetUserRef, args: (hackleAppContext, completion))
+        return call(resetUserRef, args: hackleAppContext)
     }
-    
+
     lazy var setPhoneNumberRef = MockFunction(self, setPhoneNumber)
-    func setPhoneNumber(phoneNumber: String, hackleAppContext: HackleAppContext, completion: @escaping () -> ()) {
+    func setPhoneNumber(phoneNumber: String, hackleAppContext: HackleAppContext) {
         self.hackleAppContext = hackleAppContext
-        call(setPhoneNumberRef, args: (phoneNumber, hackleAppContext, completion))
+        call(setPhoneNumberRef, args: (phoneNumber, hackleAppContext))
     }
-    
+
     lazy var unsetPhoneNumberRef = MockFunction(self, unsetPhoneNumber)
-    func unsetPhoneNumber(hackleAppContext: HackleAppContext, completion: @escaping () -> ()) {
+    func unsetPhoneNumber(hackleAppContext: HackleAppContext) {
         self.hackleAppContext = hackleAppContext
-        call(unsetPhoneNumberRef, args: (hackleAppContext, completion))
+        call(unsetPhoneNumberRef, args: hackleAppContext)
     }
     
     lazy var variationDetailRef = MockFunction(self, variationDetail as (Int, User?, String, HackleAppContext) -> Decision)
@@ -128,8 +134,8 @@ class MockHackleAppCore: Mock, HackleAppCore {
     }
     
     lazy var fetchRef = MockFunction(self, fetch)
-    func fetch(completion: @escaping () -> ()) {
-        call(fetchRef, args: completion)
+    func fetch() -> Task<Void, Never> {
+        call(fetchRef, args: ())
     }
 
     func initialize(user: User?, completion: @escaping () -> ()) {

--- a/Tests/HackleTests/Mock/MockHttpWorkspaceFetcher.swift
+++ b/Tests/HackleTests/Mock/MockHttpWorkspaceFetcher.swift
@@ -10,23 +10,25 @@ class MockHttpWorkspaceFetcher: Mock, HttpWorkspaceFetcher {
     init(returns: [Any?]) {
         self.returns = returns
     }
-    
-    lazy var fetchIfModifiedRef = MockFunction(self, fetchIfModified)
-    func fetchIfModified(lastModified: String?, completion: @escaping (Result<WorkspaceConfigResponse?, Error>) -> ()) {
-        call(fetchIfModifiedRef, args: (lastModified, completion))
-        
+
+    lazy var fetchIfModifiedRef = MockFunction(self, fetchIfModifiedStub)
+
+    private func fetchIfModifiedStub(lastModified: String?) {
+    }
+
+    func fetchIfModified(lastModified: String?) async throws -> WorkspaceConfigResponse? {
+        call(fetchIfModifiedRef, args: lastModified)
+
         let value = returns[count]
         count += 1
 
         switch value {
         case let config as WorkspaceConfigResponse:
-            completion(.success(config))
-            break
+            return config
         case let error as Error:
-            completion(.failure(error))
-            break
+            throw error
         default:
-            completion(.success(nil))
+            return nil
         }
     }
 }

--- a/Tests/HackleTests/Mock/MockNotificationManager.swift
+++ b/Tests/HackleTests/Mock/MockNotificationManager.swift
@@ -3,8 +3,10 @@ import Foundation
 
 class MockNotificationManager: NotificationManager {
 
-    func flush() {
+    var onFlush: (() -> Void)? = nil
 
+    func flush() {
+        onFlush?()
     }
 
     func onNotificationDataReceived(data: NotificationData, timestamp: Date) {


### PR DESCRIPTION
## 개요
SDK 공개 API와 내부 동기화 흐름을 async/await 기반으로 전환합니다.
실험, 기능 플래그, Remote Config, IAM 평가를 공통 EvaluateProcessor 계열로 재구성하고 평가 이벤트 기록 경로를 통합합니다.

## 주요 변경사항
| 카테고리 | 내용 |
|----------|------|
| Public API | `Hackle.initialize`, `HackleApp.setUser`, `setUserId`, `setDeviceId`, `resetUser`, `fetch` 등에 async/await API 추가 |
| Deprecated API | 기존 동기/콜백 호환 API를 deprecate 확장으로 분리 |
| Evaluation | `EvaluateRequest/Response/Result/Evaluation`, `EvaluateProcessor`, `DecisionProcessor`, Local evaluator 계열 추가 |
| Service 구조 | Experiment, RemoteConfig, InAppMessage 평가를 Service/Mode/Local 구조로 이동 |
| Event 기록 | `EvaluationEventFactory`와 `EvaluationEventRecorder`로 노출/평가 이벤트 생성 경로 통합 |
| Sync/User/Workspace | Synchronizer, Workspace/User fetcher를 async throws 기반으로 전환 |
| Decision Reason | `OPT_OUT`, `UNKNOWN` 추가 및 Explorer override 목록 정렬 |
| Swift 6 대응 | 락 기반 synchronizer(`Sendable`), completion handler `@preconcurrency @Sendable` 어노테이션 추가 |
| 테스트 | async API, 평가 계층, bulk record=false 회귀, sync/user/workspace async 전환 테스트 보강 |

## 사용 예제
```swift
await Hackle.initialize(sdkKey: "SDK_KEY")

await hackleApp.setUser(user: user)
await hackleApp.setUserId(userId: "user-id")
await hackleApp.fetch()
```
