### PR TITLE
fix: protect in-app impression recording race

### DIFF
--- a/Sources/Hackle/Core/Evaluation/Mode/Local/LocalEvaluateRequest.swift
+++ b/Sources/Hackle/Core/Evaluation/Mode/Local/LocalEvaluateRequest.swift
@@ -3,3 +3,7 @@ import Foundation
 protocol LocalEvaluateRequest: EvaluateRequest {
     var workspaceConfig: WorkspaceConfig { get }
 }
+
+extension LocalEvaluateRequest {
+    var workspace: Workspace { workspaceConfig }
+}

--- a/Sources/Hackle/Core/Evaluation/Mode/Remote/RemoteEvaluateRequest.swift
+++ b/Sources/Hackle/Core/Evaluation/Mode/Remote/RemoteEvaluateRequest.swift
@@ -4,3 +4,7 @@ protocol RemoteEvaluateRequest: EvaluateRequest {
     var evaluationWorkspace: WorkspaceEvaluation { get }
     var remoteResult: RemoteEvaluateResult { get }
 }
+
+extension RemoteEvaluateRequest {
+    var workspace: Workspace { evaluationWorkspace }
+}

--- a/Sources/Hackle/Core/Evaluation/Service/Experiment/ExperimentEvaluateRequest.swift
+++ b/Sources/Hackle/Core/Evaluation/Service/Experiment/ExperimentEvaluateRequest.swift
@@ -3,3 +3,7 @@ import Foundation
 protocol ExperimentEvaluateRequest: EvaluateRequest {
     var experiment: Experiment { get }
 }
+
+extension ExperimentEvaluateRequest {
+    var entity: Entity { experiment }
+}

--- a/Sources/Hackle/Core/Evaluation/Service/Experiment/Mode/Local/ExperimentLocalEvaluateRequest.swift
+++ b/Sources/Hackle/Core/Evaluation/Service/Experiment/Mode/Local/ExperimentLocalEvaluateRequest.swift
@@ -12,8 +12,6 @@ final class ExperimentLocalEvaluateRequest: LocalEvaluateRequest, ExperimentEval
     let user: HackleUser
     let record: Bool
 
-    var workspace: Workspace { workspaceConfig }
-    var entity: Entity { experimentConfig }
     var experiment: Experiment { experimentConfig }
 
     init(workspace: WorkspaceConfig, entity: ExperimentConfig, user: HackleUser, record: Bool) {

--- a/Sources/Hackle/Core/Evaluation/Service/Experiment/Mode/Remote/ExperimentRemoteEvaluateRequest.swift
+++ b/Sources/Hackle/Core/Evaluation/Service/Experiment/Mode/Remote/ExperimentRemoteEvaluateRequest.swift
@@ -7,8 +7,6 @@ final class ExperimentRemoteEvaluateRequest: RemoteEvaluateRequest, ExperimentEv
     let user: HackleUser
     let record: Bool
 
-    var workspace: Workspace { evaluationWorkspace }
-    var entity: Entity { result }
     var remoteResult: RemoteEvaluateResult { result }
     var experiment: Experiment { result }
 

--- a/Sources/Hackle/Core/Evaluation/Service/InAppMessage/Eligibility/InAppMessageEligibilityEvaluateRequest.swift
+++ b/Sources/Hackle/Core/Evaluation/Service/InAppMessage/Eligibility/InAppMessageEligibilityEvaluateRequest.swift
@@ -6,3 +6,7 @@ protocol InAppMessageEligibilityEvaluateRequest: EvaluateRequest {
     var platformType: PlatformType { get }
     var timestamp: Date { get }
 }
+
+extension InAppMessageEligibilityEvaluateRequest {
+    var entity: Entity { inAppMessage }
+}

--- a/Sources/Hackle/Core/Evaluation/Service/InAppMessage/Eligibility/Mode/Local/InAppMessageEligibilityLocalEvaluateRequest.swift
+++ b/Sources/Hackle/Core/Evaluation/Service/InAppMessage/Eligibility/Mode/Local/InAppMessageEligibilityLocalEvaluateRequest.swift
@@ -10,8 +10,6 @@ final class InAppMessageEligibilityLocalEvaluateRequest: LocalEvaluateRequest, I
     let platformType: PlatformType
     let timestamp: Date
 
-    var workspace: Workspace { workspaceConfig }
-    var entity: Entity { inAppMessageConfig }
     var inAppMessage: InAppMessage { inAppMessageConfig }
 
     private init(

--- a/Sources/Hackle/Core/Evaluation/Service/InAppMessage/Eligibility/Mode/Remote/InAppMessageEligibilityRemoteEvaluateRequest.swift
+++ b/Sources/Hackle/Core/Evaluation/Service/InAppMessage/Eligibility/Mode/Remote/InAppMessageEligibilityRemoteEvaluateRequest.swift
@@ -10,8 +10,6 @@ final class InAppMessageEligibilityRemoteEvaluateRequest: RemoteEvaluateRequest,
     let platformType: PlatformType
     let timestamp: Date
 
-    var workspace: Workspace { evaluationWorkspace }
-    var entity: Entity { result }
     var remoteResult: RemoteEvaluateResult { result }
     var inAppMessage: InAppMessage { result }
 

--- a/Sources/Hackle/Core/Evaluation/Service/InAppMessage/Layout/InAppMessageLayoutEvaluateRequest.swift
+++ b/Sources/Hackle/Core/Evaluation/Service/InAppMessage/Layout/InAppMessageLayoutEvaluateRequest.swift
@@ -4,3 +4,7 @@ protocol InAppMessageLayoutEvaluateRequest: EvaluateRequest {
     var inAppMessage: InAppMessage { get }
     var scope: InAppMessageEvaluateScope { get }
 }
+
+extension InAppMessageLayoutEvaluateRequest {
+    var entity: Entity { inAppMessage }
+}

--- a/Sources/Hackle/Core/Evaluation/Service/InAppMessage/Layout/Mode/Local/InAppMessageLayoutLocalEvaluateRequest.swift
+++ b/Sources/Hackle/Core/Evaluation/Service/InAppMessage/Layout/Mode/Local/InAppMessageLayoutLocalEvaluateRequest.swift
@@ -8,8 +8,6 @@ final class InAppMessageLayoutLocalEvaluateRequest: LocalEvaluateRequest, InAppM
     let record: Bool
     let scope: InAppMessageEvaluateScope
 
-    var workspace: Workspace { workspaceConfig }
-    var entity: Entity { inAppMessageConfig }
     var inAppMessage: InAppMessage { inAppMessageConfig }
 
     private init(

--- a/Sources/Hackle/Core/Evaluation/Service/InAppMessage/Layout/Mode/Remote/InAppMessageLayoutRemoteEvaluateRequest.swift
+++ b/Sources/Hackle/Core/Evaluation/Service/InAppMessage/Layout/Mode/Remote/InAppMessageLayoutRemoteEvaluateRequest.swift
@@ -8,8 +8,6 @@ final class InAppMessageLayoutRemoteEvaluateRequest: RemoteEvaluateRequest, InAp
     let scope: InAppMessageEvaluateScope
     let record: Bool
 
-    var workspace: Workspace { evaluationWorkspace }
-    var entity: Entity { result }
     var remoteResult: RemoteEvaluateResult { result }
     var inAppMessage: InAppMessage { result }
 

--- a/Sources/Hackle/Core/Evaluation/Service/RemoteConfig/Mode/Local/RemoteConfigLocalEvaluateRequest.swift
+++ b/Sources/Hackle/Core/Evaluation/Service/RemoteConfig/Mode/Local/RemoteConfigLocalEvaluateRequest.swift
@@ -13,9 +13,7 @@ final class RemoteConfigLocalEvaluateRequest: LocalEvaluateRequest, RemoteConfig
     let record: Bool
     let requiredType: HackleValueType
 
-    var workspace: Workspace { workspaceConfig }
     var parameter: RemoteConfigParameter { parameterConfig }
-    var entity: Entity { parameterConfig }
 
     private init(workspace: WorkspaceConfig, parameter: RemoteConfigParameterConfig, user: HackleUser, record: Bool, requiredType: HackleValueType) {
         self.workspaceConfig = workspace

--- a/Sources/Hackle/Core/Evaluation/Service/RemoteConfig/Mode/Remote/RemoteConfigRemoteEvaluateRequest.swift
+++ b/Sources/Hackle/Core/Evaluation/Service/RemoteConfig/Mode/Remote/RemoteConfigRemoteEvaluateRequest.swift
@@ -8,8 +8,6 @@ final class RemoteConfigRemoteEvaluateRequest: RemoteEvaluateRequest, RemoteConf
     let record: Bool
     let requiredType: HackleValueType
 
-    var workspace: Workspace { evaluationWorkspace }
-    var entity: Entity { result }
     var remoteResult: RemoteEvaluateResult { result }
     var parameter: RemoteConfigParameter { result }
 

--- a/Sources/Hackle/Core/Evaluation/Service/RemoteConfig/RemoteConfigEvaluateRequest.swift
+++ b/Sources/Hackle/Core/Evaluation/Service/RemoteConfig/RemoteConfigEvaluateRequest.swift
@@ -4,3 +4,7 @@ protocol RemoteConfigEvaluateRequest: EvaluateRequest {
     var parameter: RemoteConfigParameter { get }
     var requiredType: HackleValueType { get }
 }
+
+extension RemoteConfigEvaluateRequest {
+    var entity: Entity { parameter }
+}

--- a/Sources/Hackle/Core/InAppMessage/Present/Record/InAppMessageRecorder.swift
+++ b/Sources/Hackle/Core/InAppMessage/Present/Record/InAppMessageRecorder.swift
@@ -8,6 +8,7 @@ class DefaultInAppMessageRecorder: InAppMessageRecorder {
 
     private static let STORE_MAX_SIZE = 100
 
+    private let lock = ReadWriteLock(label: "io.hackle.DefaultInAppMessageRecorder.Lock")
     private let storage: InAppMessageImpressionStorage
 
     init(storage: InAppMessageImpressionStorage) {
@@ -27,15 +28,17 @@ class DefaultInAppMessageRecorder: InAppMessageRecorder {
     }
 
     private func doRecord(request: InAppMessagePresentRequest) throws {
-        var impressions = try storage.get(inAppMessage: request.inAppMessage)
-        let impression = InAppMessageImpression(identifiers: request.user.identifiers, timestamp: request.requestedAt.timeIntervalSince1970)
-        impressions.append(impression)
+        try lock.write {
+            var impressions = try storage.get(inAppMessage: request.inAppMessage)
+            let impression = InAppMessageImpression(identifiers: request.user.identifiers, timestamp: request.requestedAt.timeIntervalSince1970)
+            impressions.append(impression)
 
-        if impressions.count > Self.STORE_MAX_SIZE {
-            impressions.removeFirst(impressions.count - Self.STORE_MAX_SIZE)
+            if impressions.count > Self.STORE_MAX_SIZE {
+                impressions.removeFirst(impressions.count - Self.STORE_MAX_SIZE)
+            }
+
+            try storage.set(inAppMessage: request.inAppMessage, impressions: impressions)
+            Log.debug("InAppMessage Impression recorded. dispatchId: \(request.dispatchId), inAppMessageKey: \(request.inAppMessage.key), impression: \(impression)")
         }
-
-        try storage.set(inAppMessage: request.inAppMessage, impressions: impressions)
-        Log.debug("InAppMessage Impression recorded. dispatchId: \(request.dispatchId), inAppMessageKey: \(request.inAppMessage.key), impression: \(impression)")
     }
 }

--- a/Tests/HackleTests/Core/Evaluation/Mode/Local/LocalEvaluatorSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Mode/Local/LocalEvaluatorSpecs.swift
@@ -56,7 +56,6 @@ class LocalEvaluatorSpecs: QuickSpec {
     struct StubLocalEvaluateRequest: LocalEvaluateRequest {
         var user: HackleUser = HackleUser.builder().build()
         var workspaceConfig: WorkspaceConfig = MockWorkspace()
-        var workspace: Workspace { workspaceConfig }
         var entity: Entity = DefaultEntity(serviceType: .abTest, id: 1)
         var record: Bool = false
     }

--- a/Tests/HackleTests/Core/Evaluation/Mode/Remote/RemoteEvaluatorSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Mode/Remote/RemoteEvaluatorSpecs.swift
@@ -62,7 +62,6 @@ class RemoteEvaluatorSpecs: QuickSpec {
         let user: HackleUser = HackleUser.builder().build()
         let record: Bool = false
 
-        var workspace: Workspace { evaluationWorkspace }
         var entity: Entity { result }
         var remoteResult: RemoteEvaluateResult { result }
 

--- a/Tests/HackleTests/Core/InAppMessage/Present/Record/DefaultInAppMessageRecorderRaceSpecs.swift
+++ b/Tests/HackleTests/Core/InAppMessage/Present/Record/DefaultInAppMessageRecorderRaceSpecs.swift
@@ -1,0 +1,62 @@
+import Foundation
+import Quick
+import Nimble
+@testable import Hackle
+
+/// Regression spec for `DefaultInAppMessageRecorder`'s impression record data race.
+/// Run under Thread Sanitizer to verify no access race is reported.
+///
+/// The recorder/storage are intentionally shared across GCD queues so the get→append→trim→set
+/// read-modify-write is exercised concurrently. The compiler cannot prove that sharing is safe,
+/// so the shared locals are marked `nonisolated(unsafe)` — the safety is provided at runtime by
+/// the `ReadWriteLock` inside `DefaultInAppMessageRecorder`, which this spec exists to guard.
+class DefaultInAppMessageRecorderRaceSpecs: QuickSpec {
+    override class func spec() {
+
+        it("동시에 100건을 기록해도 유실 없이 모두 저장된다") {
+            nonisolated(unsafe) let storage = DefaultInAppMessageImpressionStorage(keyValueRepository: MemoryKeyValueRepository())
+            nonisolated(unsafe) let sut = DefaultInAppMessageRecorder(storage: storage)
+            let inAppMessage = InAppMessageEntity.create(id: 42)
+            nonisolated(unsafe) let request = InAppMessageEntity.presentRequest(inAppMessage: inAppMessage)
+            nonisolated(unsafe) let response = InAppMessageEntity.presentResponse()
+
+            let producerCount = 10
+            let perProducer = 10
+
+            let group = DispatchGroup()
+            for _ in 0..<producerCount {
+                DispatchQueue.global(qos: .utility).async(group: group) {
+                    for _ in 0..<perProducer {
+                        sut.record(request: request, response: response)
+                    }
+                }
+            }
+            group.wait()
+
+            expect(try storage.get(inAppMessage: inAppMessage).count) == 100
+        }
+
+        it("동시에 STORE_MAX_SIZE를 초과 기록해도 정확히 100건으로 유지된다") {
+            nonisolated(unsafe) let storage = DefaultInAppMessageImpressionStorage(keyValueRepository: MemoryKeyValueRepository())
+            nonisolated(unsafe) let sut = DefaultInAppMessageRecorder(storage: storage)
+            let inAppMessage = InAppMessageEntity.create(id: 42)
+            nonisolated(unsafe) let request = InAppMessageEntity.presentRequest(inAppMessage: inAppMessage)
+            nonisolated(unsafe) let response = InAppMessageEntity.presentResponse()
+
+            let producerCount = 8
+            let perProducer = 25
+
+            let group = DispatchGroup()
+            for _ in 0..<producerCount {
+                DispatchQueue.global(qos: .utility).async(group: group) {
+                    for _ in 0..<perProducer {
+                        sut.record(request: request, response: response)
+                    }
+                }
+            }
+            group.wait()
+
+            expect(try storage.get(inAppMessage: inAppMessage).count) == 100
+        }
+    }
+}

--- a/Tests/HackleTests/Core/InAppMessage/Trigger/MockInAppMessageTriggerEventMatcher.swift
+++ b/Tests/HackleTests/Core/InAppMessage/Trigger/MockInAppMessageTriggerEventMatcher.swift
@@ -10,24 +10,3 @@ class MockInAppMessageTriggerEventMatcher: Mock, InAppMessageTriggerEventMatcher
         return try call(matchesMock, args: (workspace, inAppMessage, event))
     }
 }
-
-
-class InAppMessageTriggerEventMatcherStub: InAppMessageTriggerEventMatcher {
-
-    var matches: [Bool] {
-        didSet {
-            count = 0
-        }
-    }
-    var count = 0
-
-    init(matches: [Bool] = []) {
-        self.matches = matches
-    }
-
-    func matches(workspace: Workspace, inAppMessage: InAppMessage, event: UserEvents.Track) throws -> Bool {
-        let isMatch = matches[count]
-        count += 1
-        return isMatch
-    }
-}

--- a/Tests/HackleTests/Core/Workspace/Evaluation/Evaluator/AllWorkspaceRemoteEvaluatorSpecs.swift
+++ b/Tests/HackleTests/Core/Workspace/Evaluation/Evaluator/AllWorkspaceRemoteEvaluatorSpecs.swift
@@ -146,5 +146,16 @@ class AllWorkspaceRemoteEvaluatorSpecs: AsyncSpec {
                 try await sut.evaluate(request: AllWorkspaceEvaluateRequest(context: context(), record: nil))
             }.to(throwError())
         }
+
+        it("지원하지 않는 request 타입이면 throw한다") {
+            let request = SpecificWorkspaceEvaluateRequest(
+                context: context(),
+                targets: [DefaultEntity(serviceType: .inAppMessage, id: 400)]
+            )
+
+            await expect {
+                try await sut.evaluate(request: request)
+            }.to(throwError())
+        }
     }
 }

--- a/Tests/HackleTests/Core/Workspace/Evaluation/Evaluator/SpecificWorkspaceRemoteEvaluatorSpecs.swift
+++ b/Tests/HackleTests/Core/Workspace/Evaluation/Evaluator/SpecificWorkspaceRemoteEvaluatorSpecs.swift
@@ -58,5 +58,14 @@ class SpecificWorkspaceRemoteEvaluatorSpecs: AsyncSpec {
             expect(response.status) == WorkspaceEvaluateStatus.full
             expect(response.evaluation).toNot(beNil())
         }
+
+        it("지원하지 않는 request 타입이면 throw한다") {
+            let user = HackleUser.builder().identifier(.id, "id_1").build()
+            let request = AllWorkspaceEvaluateRequest(context: WorkspaceEvaluateContext.of(user: user), record: nil)
+
+            await expect {
+                try await sut.evaluate(request: request)
+            }.to(throwError())
+        }
     }
 }

--- a/Tests/HackleTests/Mock/MockHackleApp.swift
+++ b/Tests/HackleTests/Mock/MockHackleApp.swift
@@ -144,10 +144,6 @@ class MockHackleAppCore: Mock, HackleAppCore {
         fatalError("NOT IMPLEMENTED")
     }
     
-    func allVariationDetails(user: User?) -> [Int: Decision] {
-        fatalError("NOT IMPLEMENTED")
-    }
-    
     func allVariationDetails(hackleAppContext: HackleAppContext) -> [Int: Decision] {
         fatalError("NOT IMPLEMENTED")
     }


### PR DESCRIPTION
## 개요
인앱 메시지 impression 기록 시 동시 접근으로 저장 데이터가 유실될 수 있는 문제를 수정합니다.
평가 요청 타입의 중복 getter 구현을 protocol extension으로 정리하고, 관련 회귀 테스트를 보강합니다.

## 작업 내용
- `DefaultInAppMessageRecorder`의 get-append-trim-set 흐름을 `ReadWriteLock`으로 보호
- 동시 impression 기록 및 `STORE_MAX_SIZE` 유지 동작 회귀 테스트 추가
- local/remote 평가 요청의 `workspace`, `entity` getter를 protocol extension으로 공통화
- workspace remote evaluator의 지원하지 않는 request 타입 테스트 추가
- 사용하지 않는 테스트 helper와 mock 메서드 제거
