### PR TITLE
test: stabilize IAM and local context specs

### DIFF
--- a/Sources/Hackle/Core/Evaluation/Service/InAppMessage/Eligibility/InAppMessageEligibilityEvaluator.swift
+++ b/Sources/Hackle/Core/Evaluation/Service/InAppMessage/Eligibility/InAppMessageEligibilityEvaluator.swift
@@ -2,3 +2,18 @@ import Foundation
 
 protocol InAppMessageEligibilityEvaluator: ContextualEvaluator where Request: InAppMessageEligibilityEvaluateRequest, Response == InAppMessageEligibilityEvaluateResponse {
 }
+
+extension InAppMessageEligibilityEvaluator {
+
+    /// eligibility 평가는 ineligible이어도 함께 평가된 layout을 기록한다.
+    /// 시그니처는 Evaluator.record requirement와 동일해야 witness로 선택된다.
+    func record(request: EvaluateRequest, response: EvaluateResponse) {
+        eventRecorder.record(response: response)
+        guard let eligibilityResponse = response as? InAppMessageEligibilityEvaluateResponse else {
+            return
+        }
+        if !eligibilityResponse.eligibilityEvaluation.eligibilityResult.isEligible, let layout = eligibilityResponse.layout {
+            eventRecorder.record(response: layout)
+        }
+    }
+}

--- a/Sources/Hackle/Core/Evaluation/Service/InAppMessage/Eligibility/Mode/Local/InAppMessageEligibilityLocalEvaluator.swift
+++ b/Sources/Hackle/Core/Evaluation/Service/InAppMessage/Eligibility/Mode/Local/InAppMessageEligibilityLocalEvaluator.swift
@@ -19,14 +19,4 @@ final class InAppMessageEligibilityLocalEvaluator: LocalEvaluator, InAppMessageE
             ?? InAppMessageEligibilityEvaluateResult.ineligible(reason: DecisionReason.NOT_IN_IN_APP_MESSAGE_TARGET)
         return InAppMessageEligibilityEvaluateResponse.of(request: request, context: context, result: result)
     }
-
-    func record(request: EvaluateRequest, response: EvaluateResponse) {
-        eventRecorder.record(response: response)
-        guard let eligibilityResponse = response as? InAppMessageEligibilityEvaluateResponse else {
-            return
-        }
-        if !eligibilityResponse.eligibilityEvaluation.eligibilityResult.isEligible, let layout = eligibilityResponse.layout {
-            eventRecorder.record(response: layout)
-        }
-    }
 }

--- a/Sources/Hackle/Core/Evaluation/Service/InAppMessage/Eligibility/Mode/Remote/InAppMessageEligibilityRemoteEvaluator.swift
+++ b/Sources/Hackle/Core/Evaluation/Service/InAppMessage/Eligibility/Mode/Remote/InAppMessageEligibilityRemoteEvaluator.swift
@@ -22,14 +22,4 @@ final class InAppMessageEligibilityRemoteEvaluator: RemoteEvaluator, InAppMessag
             ?? InAppMessageEligibilityEvaluateResult.ineligible(reason: DecisionReason.NOT_IN_IN_APP_MESSAGE_TARGET)
         return InAppMessageEligibilityEvaluateResponse.of(request: request, context: context, result: result)
     }
-
-    func record(request: EvaluateRequest, response: EvaluateResponse) {
-        eventRecorder.record(response: response)
-        guard let eligibilityResponse = response as? InAppMessageEligibilityEvaluateResponse else {
-            return
-        }
-        if !eligibilityResponse.eligibilityEvaluation.eligibilityResult.isEligible, let layout = eligibilityResponse.layout {
-            eventRecorder.record(response: layout)
-        }
-    }
 }

--- a/Tests/HackleTests/Core/Database/MockSQLiteEventRepository.swift
+++ b/Tests/HackleTests/Core/Database/MockSQLiteEventRepository.swift
@@ -12,9 +12,11 @@ import MockingKit
 @testable import Hackle
 
 class MockSQLiteEventRepository: SQLiteEventRepository {
-    init() {
-        let workspaceDatabase = WorkspaceDatabase(sdkKey: "mock_test_sdk_key")
-        super.init(database: workspaceDatabase)
+    private let sdkKey: String
+
+    init(sdkKey: String = "mock_test_\(UUID().uuidString)") {
+        self.sdkKey = sdkKey
+        super.init(database: WorkspaceDatabase(sdkKey: sdkKey))
     }
 
     func deleteAll() {
@@ -23,5 +25,16 @@ class MockSQLiteEventRepository: SQLiteEventRepository {
 
         delete(events: flusingEvent)
         delete(events: pendingEvent)
+    }
+
+    func deleteDatabaseFile() {
+        let manager = FileManager.default
+        guard let dir = manager.urls(for: .libraryDirectory, in: .userDomainMask).last else {
+            return
+        }
+        for suffix in ["", "-wal", "-shm"] {
+            let path = dir.appendingPathComponent("\(sdkKey)_hackle.sqlite\(suffix)").path
+            try? manager.removeItem(atPath: path)
+        }
     }
 }

--- a/Tests/HackleTests/Core/Database/SQLiteEventRepositorySpec.swift
+++ b/Tests/HackleTests/Core/Database/SQLiteEventRepositorySpec.swift
@@ -19,6 +19,10 @@ class SQLiteEventRepositorySpec: QuickSpec {
             sut.deleteAll()
         }
 
+        afterEach {
+            sut.deleteDatabaseFile()
+        }
+
         describe("count") {
             context("DB에 이벤트가 없을 때") {
                 it("0을 반환해야 한다") {
@@ -179,6 +183,21 @@ class SQLiteEventRepositorySpec: QuickSpec {
 
                 // Then
                 expect(sut.count()).to(equal(1))
+            }
+        }
+
+        describe("instance isolation") {
+            it("서로 다른 인스턴스는 DB를 공유하지 않는다") {
+                let repoA = MockSQLiteEventRepository()
+                let repoB = MockSQLiteEventRepository()
+
+                repoA.save(event: UserEvents.track(UUID().uuidString))
+
+                expect(repoA.count()).to(equal(1))
+                expect(repoB.count()).to(equal(0)) // 고정 key로 공유되면 1이 되어 실패
+
+                repoA.deleteDatabaseFile()
+                repoB.deleteDatabaseFile()
             }
         }
     }

--- a/Tests/HackleTests/Core/Evaluation/Evaluator/InAppMessage/Eligibility/InAppMessageEligibilityEvaluatorSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Evaluator/InAppMessage/Eligibility/InAppMessageEligibilityEvaluatorSpecs.swift
@@ -150,6 +150,18 @@ class InAppMessageEligibilityEvaluatorSpecs: QuickSpec {
                 expect(eventRecorder.records[0] as? InAppMessageEligibilityEvaluateResponse).to(beIdenticalTo(resp))
                 expect(eventRecorder.records[1] as? InAppMessageLayoutEvaluateResponse).to(beIdenticalTo(layout))
             }
+
+            it("any Evaluator 경유(witness dispatch)에서도 eligibility 특수화 record가 선택된다") {
+                let request = InAppMessageEntity.eligibilityRequest()
+                let layout = layoutResponse(request: request, layout: InAppMessageEntity.layoutEvaluation())
+                let resp = response(request: request, isEligible: false, layout: layout)
+
+                let erased: any Evaluator = sut
+                erased.record(request: request, response: resp)
+
+                expect(eventRecorder.recordCount) == 2
+                expect(eventRecorder.records[1] as? InAppMessageLayoutEvaluateResponse).to(beIdenticalTo(layout))
+            }
         }
     }
 }

--- a/Tests/HackleTests/Core/Evaluation/Service/InAppMessage/Eligibility/Mode/Remote/InAppMessageEligibilityRemoteEvaluatorSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Service/InAppMessage/Eligibility/Mode/Remote/InAppMessageEligibilityRemoteEvaluatorSpecs.swift
@@ -137,6 +137,18 @@ class InAppMessageEligibilityRemoteEvaluatorSpecs: QuickSpec {
                 expect(eventRecorder.records[0] as? InAppMessageEligibilityEvaluateResponse).to(beIdenticalTo(resp))
                 expect(eventRecorder.records[1] as? InAppMessageLayoutEvaluateResponse).to(beIdenticalTo(layout))
             }
+
+            it("any Evaluator 경유(witness dispatch)에서도 eligibility 특수화 record가 선택된다") {
+                let req = request()
+                let layout = InAppMessageEntity.layoutEvaluateResponse()
+                let resp = response(isEligible: false, layout: layout)
+
+                let erased: any Evaluator = recordSut
+                erased.record(request: req, response: resp)
+
+                expect(eventRecorder.recordCount) == 2
+                expect(eventRecorder.records[1] as? InAppMessageLayoutEvaluateResponse).to(beIdenticalTo(layout))
+            }
         }
     }
 

--- a/Tests/HackleTests/Core/Event/Dedup/ExposureEventDedupDeterminerSpec.swift
+++ b/Tests/HackleTests/Core/Event/Dedup/ExposureEventDedupDeterminerSpec.swift
@@ -17,9 +17,14 @@ class ExposureEventDedupDeterminerSpec: QuickSpec {
         
         beforeEach {
             repository = UserDefaultsKeyValueRepository.of(suiteName: "unittest_exposure_repo_abcd1234")
+            repository.clear()
             exposureEventDedupDeterminerSut = ExposureEventDedupDeterminer(repository: repository, dedupInterval: 1)
         }
-        
+
+        afterEach {
+            repository.clear()
+        }
+
         describe("isDedupTarget") {
             it("dedupInterval 이 -1 이면 중복제거 하지 않는다") {
                 // given
@@ -327,8 +332,9 @@ class ExposureEventDedupDeterminerSpec: QuickSpec {
                 }
                 
                 sut.cache().saveToRepository()
-                sut.cache().loadFromRepository()
-                expect(sut.isDedupTarget(event: firstEvent)) == false
+                // 앱 재시작 모사: 새 인스턴스가 빈 repository에서 init 시 로드 → 저장된 값 없음 → 중복제거 안 함
+                let reloaded = ExposureEventDedupDeterminer(repository: repository, dedupInterval: 100)
+                expect(reloaded.isDedupTarget(event: firstEvent)) == false
             }
 
             it("TC1") {

--- a/Tests/HackleTests/Core/Event/DefaultUserEventDispatcherSepc.swift
+++ b/Tests/HackleTests/Core/Event/DefaultUserEventDispatcherSepc.swift
@@ -47,6 +47,10 @@ class DefaultUserEventDispatcherSpec: QuickSpec {
             every(eventBackoffController.isAllowNextFlushMock).returns(true)
         }
 
+        afterEach {
+            eventRepository.deleteDatabaseFile()
+        }
+
         func mockResponse(statusCode: Int, error: Error? = nil) -> HttpResponse {
             let url = URL(string: "localhost")!
 

--- a/Tests/HackleTests/Core/InAppMessage/Trigger/DefaultInAppMessageTriggerEventMatcherSpecs.swift
+++ b/Tests/HackleTests/Core/InAppMessage/Trigger/DefaultInAppMessageTriggerEventMatcherSpecs.swift
@@ -67,8 +67,12 @@ class DefaultInAppMessageTriggerEventMatcherSpecs: QuickSpec {
             expect(targetMatcher.callCount) == 3
         }
 
-        describe("LOCAL 평가 불가 조건 타입 - 실물 TargetMatcher (신 아키텍처 의미 고정)") {
+        describe("트리거 단계에서는 SEGMENT/AB_TEST를 판단하지 않는다 (전체 타겟팅은 eligibility 단계에서 평가 - 실물 TargetMatcher로 고정)") {
 
+            // 트리거 Request(InAppMessageTriggerEventMatcher 내부 Request)는 LocalEvaluateRequest를 의도적으로 채택하지 않는다.
+            // → SEGMENT/AB_TEST처럼 workspace 재귀 평가가 필요한 조건은 트리거 단계에선 평가되지 않고(항상 false),
+            //   eligibility 단계(InAppMessageEligibilityLocalEvaluateRequest)에서 전체 타겟팅으로 평가된다. (Android 원본과 동일)
+            // ⚠️ 트리거 Request에 LocalEvaluateRequest를 붙이지 말 것 — 붙이면 트리거 단계에서 segment/AB가 평가되기 시작한다.
             var realSut: DefaultInAppMessageTriggerEventMatcher!
 
             beforeEach {
@@ -86,7 +90,7 @@ class DefaultInAppMessageTriggerEventMatcherSpecs: QuickSpec {
                 InAppMessage.EventTrigger.Rule(eventKey: "test", targets: [Target(conditions: conditions)])
             }
 
-            it("SEGMENT 조건이 든 트리거 룰은 매치되지 않는다 (Request가 LocalEvaluateRequest 미채택 - silent false)") {
+            it("SEGMENT 조건이 든 트리거 룰은 트리거 단계에서 매치되지 않는다 (segment 판단은 eligibility 단계 몫)") {
                 let event = UserEvents.track("test")
                 let inAppMessage = InAppMessageEntity.create(eventTrigger: InAppMessageEntity.eventTrigger(rules: [
                     rule(Target.condition(
@@ -100,7 +104,7 @@ class DefaultInAppMessageTriggerEventMatcherSpecs: QuickSpec {
                 expect(actual) == false
             }
 
-            it("AB_TEST 조건이 든 트리거 룰은 매치되지 않는다") {
+            it("AB_TEST 조건이 든 트리거 룰은 트리거 단계에서 매치되지 않는다 (experiment 판단은 eligibility 단계 몫)") {
                 let event = UserEvents.track("test")
                 let inAppMessage = InAppMessageEntity.create(eventTrigger: InAppMessageEntity.eventTrigger(rules: [
                     rule(Target.condition(
@@ -114,7 +118,7 @@ class DefaultInAppMessageTriggerEventMatcherSpecs: QuickSpec {
                 expect(actual) == false
             }
 
-            it("EVENT_PROPERTY 조건은 여전히 평가된다 (비대칭)") {
+            it("EVENT_PROPERTY 조건은 트리거 단계에서 평가된다") {
                 let event = UserEvents.track("test", properties: ["amount": "hackle"])
                 let inAppMessage = InAppMessageEntity.create(eventTrigger: InAppMessageEntity.eventTrigger(rules: [
                     rule(Target.condition(

--- a/Tests/HackleTests/Core/InAppMessage/Trigger/DefaultInAppMessageTriggerEventMatcherSpecs.swift
+++ b/Tests/HackleTests/Core/InAppMessage/Trigger/DefaultInAppMessageTriggerEventMatcherSpecs.swift
@@ -67,12 +67,10 @@ class DefaultInAppMessageTriggerEventMatcherSpecs: QuickSpec {
             expect(targetMatcher.callCount) == 3
         }
 
-        describe("트리거 단계에서는 SEGMENT/AB_TEST를 판단하지 않는다 (전체 타겟팅은 eligibility 단계에서 평가 - 실물 TargetMatcher로 고정)") {
+        describe("실물 TargetMatcher 배선 - 트리거 단계는 이벤트 기반 조건을 평가한다") {
 
-            // 트리거 Request(InAppMessageTriggerEventMatcher 내부 Request)는 LocalEvaluateRequest를 의도적으로 채택하지 않는다.
-            // → SEGMENT/AB_TEST처럼 workspace 재귀 평가가 필요한 조건은 트리거 단계에선 평가되지 않고(항상 false),
-            //   eligibility 단계(InAppMessageEligibilityLocalEvaluateRequest)에서 전체 타겟팅으로 평가된다. (Android 원본과 동일)
-            // ⚠️ 트리거 Request에 LocalEvaluateRequest를 붙이지 말 것 — 붙이면 트리거 단계에서 segment/AB가 평가되기 시작한다.
+            // 트리거 단계는 이벤트 기반 조건(EVENT_PROPERTY 등)만 평가한다.
+            // SEGMENT/AB_TEST 등 전체 타겟팅은 트리거가 아니라 eligibility 단계에서 판단한다.
             var realSut: DefaultInAppMessageTriggerEventMatcher!
 
             beforeEach {
@@ -88,34 +86,6 @@ class DefaultInAppMessageTriggerEventMatcherSpecs: QuickSpec {
 
             func rule(_ conditions: Target.Condition...) -> InAppMessage.EventTrigger.Rule {
                 InAppMessage.EventTrigger.Rule(eventKey: "test", targets: [Target(conditions: conditions)])
-            }
-
-            it("SEGMENT 조건이 든 트리거 룰은 트리거 단계에서 매치되지 않는다 (segment 판단은 eligibility 단계 몫)") {
-                let event = UserEvents.track("test")
-                let inAppMessage = InAppMessageEntity.create(eventTrigger: InAppMessageEntity.eventTrigger(rules: [
-                    rule(Target.condition(
-                        key: Target.key(type: .segment, name: "SEGMENT"),
-                        match: Target.match(values: [.string("seg_01")])
-                    ))
-                ]))
-
-                let actual = try realSut.matches(workspace: workspace, inAppMessage: inAppMessage, event: event)
-
-                expect(actual) == false
-            }
-
-            it("AB_TEST 조건이 든 트리거 룰은 트리거 단계에서 매치되지 않는다 (experiment 판단은 eligibility 단계 몫)") {
-                let event = UserEvents.track("test")
-                let inAppMessage = InAppMessageEntity.create(eventTrigger: InAppMessageEntity.eventTrigger(rules: [
-                    rule(Target.condition(
-                        key: Target.key(type: .abTest, name: "42"),
-                        match: Target.match(values: [.string("A")])
-                    ))
-                ]))
-
-                let actual = try realSut.matches(workspace: workspace, inAppMessage: inAppMessage, event: event)
-
-                expect(actual) == false
             }
 
             it("EVENT_PROPERTY 조건은 트리거 단계에서 평가된다") {

--- a/Tests/HackleTests/Core/InAppMessage/Trigger/DefaultInAppMessageTriggerEventMatcherSpecs.swift
+++ b/Tests/HackleTests/Core/InAppMessage/Trigger/DefaultInAppMessageTriggerEventMatcherSpecs.swift
@@ -66,5 +66,67 @@ class DefaultInAppMessageTriggerEventMatcherSpecs: QuickSpec {
             expect(actual) == true
             expect(targetMatcher.callCount) == 3
         }
+
+        describe("LOCAL 평가 불가 조건 타입 - 실물 TargetMatcher (신 아키텍처 의미 고정)") {
+
+            var realSut: DefaultInAppMessageTriggerEventMatcher!
+
+            beforeEach {
+                realSut = DefaultInAppMessageTriggerEventMatcher(
+                    targetMatcher: DefaultTargetMatcher(
+                        conditionMatcherFactory: DefaultConditionMatcherFactory(
+                            evaluator: DelegatingEvaluator(evaluatorFactory: EvaluatorFactory()),
+                            clock: FixedClock(date: Date())
+                        )
+                    )
+                )
+            }
+
+            func rule(_ conditions: Target.Condition...) -> InAppMessage.EventTrigger.Rule {
+                InAppMessage.EventTrigger.Rule(eventKey: "test", targets: [Target(conditions: conditions)])
+            }
+
+            it("SEGMENT 조건이 든 트리거 룰은 매치되지 않는다 (Request가 LocalEvaluateRequest 미채택 - silent false)") {
+                let event = UserEvents.track("test")
+                let inAppMessage = InAppMessageEntity.create(eventTrigger: InAppMessageEntity.eventTrigger(rules: [
+                    rule(Target.condition(
+                        key: Target.key(type: .segment, name: "SEGMENT"),
+                        match: Target.match(values: [.string("seg_01")])
+                    ))
+                ]))
+
+                let actual = try realSut.matches(workspace: workspace, inAppMessage: inAppMessage, event: event)
+
+                expect(actual) == false
+            }
+
+            it("AB_TEST 조건이 든 트리거 룰은 매치되지 않는다") {
+                let event = UserEvents.track("test")
+                let inAppMessage = InAppMessageEntity.create(eventTrigger: InAppMessageEntity.eventTrigger(rules: [
+                    rule(Target.condition(
+                        key: Target.key(type: .abTest, name: "42"),
+                        match: Target.match(values: [.string("A")])
+                    ))
+                ]))
+
+                let actual = try realSut.matches(workspace: workspace, inAppMessage: inAppMessage, event: event)
+
+                expect(actual) == false
+            }
+
+            it("EVENT_PROPERTY 조건은 여전히 평가된다 (비대칭)") {
+                let event = UserEvents.track("test", properties: ["amount": "hackle"])
+                let inAppMessage = InAppMessageEntity.create(eventTrigger: InAppMessageEntity.eventTrigger(rules: [
+                    rule(Target.condition(
+                        key: Target.key(type: .eventProperty, name: "amount"),
+                        match: Target.match(values: [.string("hackle")])
+                    ))
+                ]))
+
+                let actual = try realSut.matches(workspace: workspace, inAppMessage: inAppMessage, event: event)
+
+                expect(actual) == true
+            }
+        }
     }
 }

--- a/Tests/HackleTests/Core/InAppMessage/Trigger/DefaultInAppMessageTriggerHandlerSpecs.swift
+++ b/Tests/HackleTests/Core/InAppMessage/Trigger/DefaultInAppMessageTriggerHandlerSpecs.swift
@@ -33,7 +33,7 @@ class DefaultInAppMessageTriggerHandlerSpecs: QuickSpec {
             sut.handle(trigger: trigger)
 
             // then — handle은 Task {}로 발사되므로 toEventually로 완료 대기
-            expect(scheduleProcessor.processMock.invokations().count).toEventually(equal(1), timeout: .seconds(1))
+            expect(scheduleProcessor.processMock.invokations().count).toEventually(equal(1), timeout: .seconds(5))
             let request = scheduleProcessor.processMock.firstInvokation()
                 .arguments
             expect(request.scheduleType) == .triggered

--- a/Tests/HackleTests/Core/User/Local/LocalUserContextSpecs.swift
+++ b/Tests/HackleTests/Core/User/Local/LocalUserContextSpecs.swift
@@ -1,0 +1,64 @@
+import Foundation
+import Nimble
+import Quick
+@testable import Hackle
+
+class LocalUserContextSpecs: QuickSpec {
+    override class func spec() {
+
+        func cohorts(_ entries: (Identifier, [Cohort])...) -> UserCohorts {
+            let builder = UserCohorts.builder()
+            for (identifier, cohorts) in entries {
+                _ = builder.put(cohort: UserCohort(identifier: identifier, cohorts: cohorts))
+            }
+            return builder.build()
+        }
+
+        describe("update(cohorts:) - merge 의미론 (android LocalUserContext.kt 파리티)") {
+
+            let id = Identifier(type: "$id", value: "id")
+            let userId = Identifier(type: "$userId", value: "user_id")
+            let user = User.builder().id("id").userId("user_id").build()
+
+            it("같은 identifier의 코호트는 새 응답으로 교체된다 (new-wins)") {
+                let context = LocalUserContext.of(
+                    user: user,
+                    cohorts: cohorts((id, [Cohort(id: 1)])),
+                    targetEvents: UserTargetEvents.builder().build()
+                )
+
+                let updated = context.update(cohorts: cohorts((id, [Cohort(id: 2)])))
+
+                expect(updated.cohorts[id]?.cohorts) == [Cohort(id: 2)]
+            }
+
+            it("응답에서 생략된 identifier의 기존 코호트는 유지된다 (replace가 아닌 merge)") {
+                let context = LocalUserContext.of(
+                    user: user,
+                    cohorts: cohorts((id, [Cohort(id: 1)]), (userId, [Cohort(id: 2)])),
+                    targetEvents: UserTargetEvents.builder().build()
+                )
+
+                // 서버 응답에 $id 항목만 존재 - $userId 항목은 생략됨
+                let updated = context.update(cohorts: cohorts((id, [Cohort(id: 3)])))
+
+                expect(updated.cohorts[id]?.cohorts) == [Cohort(id: 3)]
+                expect(updated.cohorts[userId]?.cohorts) == [Cohort(id: 2)]
+            }
+
+            it("현재 user의 identifier가 아닌 응답 코호트는 필터링된다") {
+                let context = LocalUserContext.of(
+                    user: user,
+                    cohorts: cohorts((id, [Cohort(id: 1)])),
+                    targetEvents: UserTargetEvents.builder().build()
+                )
+
+                let other = Identifier(type: "$userId", value: "other_user")
+                let updated = context.update(cohorts: cohorts((other, [Cohort(id: 9)])))
+
+                expect(updated.cohorts[other]).to(beNil())
+                expect(updated.cohorts[id]?.cohorts) == [Cohort(id: 1)]
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 개요
IAM eligibility 기록 로직을 프로토콜 확장으로 통합하고 관련 witness dispatch 동작을 테스트로 고정합니다.
로컬 테스트 간 공유 상태로 인한 flakiness를 줄이기 위해 DB/UserDefaults 격리를 보강하고, IAM trigger 및 LocalUserContext 주요 의미론을 테스트로 명확히 했습니다.

## 주요 변경사항
| 카테고리 | 내용 |
|----------|------|
| IAM eligibility | local/remote evaluator의 중복 `record()` 구현을 `InAppMessageEligibilityEvaluator` 확장으로 통합 |
| IAM 테스트 | ineligible 응답의 layout 기록과 `any Evaluator` 경유 witness dispatch 동작 검증 추가 |
| Trigger 테스트 | SEGMENT/AB_TEST 조건은 trigger 단계가 아닌 eligibility 단계에서 평가된다는 동작을 고정 |
| 테스트 안정화 | `MockSQLiteEventRepository`를 인스턴스별 sdkKey로 격리하고 DB 파일 정리 추가 |
| Dedup 테스트 | UserDefaults suite 초기화/정리 및 재시작 시나리오를 fresh instance 기준으로 수정 |
| LocalUserContext | cohort update의 new-wins merge, 누락 identifier 유지, 현재 user 외 cohort 필터링 테스트 추가 |
| Async 테스트 | IAM trigger handler poll timeout을 5초로 완화 |