### PR TITLE
fix: remote evaluation response handling

### DIFF
--- a/Sources/Hackle/Core/Decision/Decisions.swift
+++ b/Sources/Hackle/Core/Decision/Decisions.swift
@@ -1,6 +1,5 @@
 import Foundation
 
-// java-core decision/Decisions 대응 — receiver extension 형태
 extension ExperimentEvaluation {
 
     func toDecision() -> Decision {

--- a/Sources/Hackle/Core/Decision/Decisions.swift
+++ b/Sources/Hackle/Core/Decision/Decisions.swift
@@ -1,28 +1,32 @@
 import Foundation
 
-enum Decisions {
+// java-core decision/Decisions 대응 — receiver extension 형태
+extension ExperimentEvaluation {
 
-    static func toDecision(evaluation: ExperimentEvaluation) -> Decision {
-        let result = evaluation.experimentResult
+    func toDecision() -> Decision {
+        let result = experimentResult
         let config: ParameterConfig = result.variation.parameterConfiguration ?? EmptyParameterConfig.instance
         return Decision.of(
-            experiment: evaluation.experiment,
+            experiment: experiment,
             variation: result.variation.key,
             reason: result.reason,
             config: config
         )
     }
 
-    static func toFeatureFlagDecision(evaluation: ExperimentEvaluation) -> FeatureFlagDecision {
-        let result = evaluation.experimentResult
+    func toFeatureFlagDecision() -> FeatureFlagDecision {
+        let result = experimentResult
         let config: ParameterConfig = result.variation.parameterConfiguration ?? EmptyParameterConfig.instance
         return result.variation.key == "A"
-            ? FeatureFlagDecision.off(featureFlag: evaluation.experiment, reason: result.reason, config: config)
-            : FeatureFlagDecision.on(featureFlag: evaluation.experiment, reason: result.reason, config: config)
+            ? FeatureFlagDecision.off(featureFlag: experiment, reason: result.reason, config: config)
+            : FeatureFlagDecision.on(featureFlag: experiment, reason: result.reason, config: config)
     }
+}
 
-    static func toRemoteConfigDecision(evaluation: RemoteConfigEvaluation, requiredType: HackleValueType, defaultValue: HackleValue) -> RemoteConfigDecision {
-        let result = evaluation.remoteConfigResult
+extension RemoteConfigEvaluation {
+
+    func toDecision(requiredType: HackleValueType, defaultValue: HackleValue) -> RemoteConfigDecision {
+        let result = remoteConfigResult
         guard let value = result.value, let typedValue = requiredType.cast(value) else {
             return RemoteConfigDecision(value: defaultValue, reason: result.reason)
         }

--- a/Sources/Hackle/Core/Decision/LocalDecisionProcessor.swift
+++ b/Sources/Hackle/Core/Decision/LocalDecisionProcessor.swift
@@ -25,7 +25,7 @@ final class LocalDecisionProcessor: DecisionProcessor {
             record: true
         )
         let response = try evaluateProcessor.experiment(request)
-        return Decisions.toDecision(evaluation: response.experimentEvaluation)
+        return response.experimentEvaluation.toDecision()
     }
 
     func experiments(user: HackleUser) throws -> [(Experiment, Decision)] {
@@ -44,7 +44,7 @@ final class LocalDecisionProcessor: DecisionProcessor {
                 record: false
             )
             let response = try evaluateProcessor.experiment(request)
-            decisions.append((experiment, Decisions.toDecision(evaluation: response.experimentEvaluation)))
+            decisions.append((experiment, response.experimentEvaluation.toDecision()))
         }
         return decisions
     }
@@ -64,7 +64,7 @@ final class LocalDecisionProcessor: DecisionProcessor {
             record: true
         )
         let response = try evaluateProcessor.experiment(request)
-        return Decisions.toFeatureFlagDecision(evaluation: response.experimentEvaluation)
+        return response.experimentEvaluation.toFeatureFlagDecision()
     }
 
     func featureFlags(user: HackleUser) throws -> [(Experiment, FeatureFlagDecision)] {
@@ -83,7 +83,7 @@ final class LocalDecisionProcessor: DecisionProcessor {
                 record: false
             )
             let response = try evaluateProcessor.experiment(request)
-            decisions.append((featureFlag, Decisions.toFeatureFlagDecision(evaluation: response.experimentEvaluation)))
+            decisions.append((featureFlag, response.experimentEvaluation.toFeatureFlagDecision()))
         }
         return decisions
     }
@@ -103,6 +103,6 @@ final class LocalDecisionProcessor: DecisionProcessor {
             requiredType: defaultValue.type
         )
         let response = try evaluateProcessor.remoteConfig(request)
-        return Decisions.toRemoteConfigDecision(evaluation: response.remoteConfigEvaluation, requiredType: defaultValue.type, defaultValue: defaultValue)
+        return response.remoteConfigEvaluation.toDecision(requiredType: defaultValue.type, defaultValue: defaultValue)
     }
 }

--- a/Sources/Hackle/Core/Decision/RemoteDecisionProcessor.swift
+++ b/Sources/Hackle/Core/Decision/RemoteDecisionProcessor.swift
@@ -20,7 +20,7 @@ final class RemoteDecisionProcessor: DecisionProcessor {
 
         let request = ExperimentRemoteEvaluateRequest.of(workspace: workspace, experiment: experiment, user: user)
         let response = try evaluateProcessor.experiment(request)
-        return Decisions.toDecision(evaluation: response.experimentEvaluation)
+        return response.experimentEvaluation.toDecision()
     }
 
     func experiments(user: HackleUser) throws -> [(Experiment, Decision)] {
@@ -31,7 +31,7 @@ final class RemoteDecisionProcessor: DecisionProcessor {
         for experiment in workspace.experimentResults {
             let request = ExperimentRemoteEvaluateRequest.of(workspace: workspace, experiment: experiment, user: user, record: false)
             let response = try evaluateProcessor.experiment(request)
-            decisions.append((experiment, Decisions.toDecision(evaluation: response.experimentEvaluation)))
+            decisions.append((experiment, response.experimentEvaluation.toDecision()))
         }
         return decisions
     }
@@ -46,7 +46,7 @@ final class RemoteDecisionProcessor: DecisionProcessor {
 
         let request = ExperimentRemoteEvaluateRequest.of(workspace: workspace, experiment: featureFlag, user: user)
         let response = try evaluateProcessor.experiment(request)
-        return Decisions.toFeatureFlagDecision(evaluation: response.experimentEvaluation)
+        return response.experimentEvaluation.toFeatureFlagDecision()
     }
 
     func featureFlags(user: HackleUser) throws -> [(Experiment, FeatureFlagDecision)] {
@@ -57,7 +57,7 @@ final class RemoteDecisionProcessor: DecisionProcessor {
         for featureFlag in workspace.featureFlagResults {
             let request = ExperimentRemoteEvaluateRequest.of(workspace: workspace, experiment: featureFlag, user: user, record: false)
             let response = try evaluateProcessor.experiment(request)
-            decisions.append((featureFlag, Decisions.toFeatureFlagDecision(evaluation: response.experimentEvaluation)))
+            decisions.append((featureFlag, response.experimentEvaluation.toFeatureFlagDecision()))
         }
         return decisions
     }
@@ -72,6 +72,6 @@ final class RemoteDecisionProcessor: DecisionProcessor {
 
         let request = RemoteConfigRemoteEvaluateRequest.of(workspace: workspace, parameter: parameter, user: user, requiredType: defaultValue.type)
         let response = try evaluateProcessor.remoteConfig(request)
-        return Decisions.toRemoteConfigDecision(evaluation: response.remoteConfigEvaluation, requiredType: defaultValue.type, defaultValue: defaultValue)
+        return response.remoteConfigEvaluation.toDecision(requiredType: defaultValue.type, defaultValue: defaultValue)
     }
 }

--- a/Sources/Hackle/Core/Evaluation/Service/RemoteConfig/Mode/Local/RemoteConfigLocalEvaluator.swift
+++ b/Sources/Hackle/Core/Evaluation/Service/RemoteConfig/Mode/Local/RemoteConfigLocalEvaluator.swift
@@ -41,7 +41,7 @@ final class RemoteConfigLocalEvaluator: LocalEvaluator, RemoteConfigEvaluator {
         if request.requiredType.isInstance(value) {
             return RemoteConfigEvaluateResult.of(reason: reason, value: value)
         } else {
-            return RemoteConfigEvaluateResult.of(reason: DecisionReason.TYPE_MISMATCH, value: value)  // ★ TYPE_MISMATCH여도 value 유지 (의도된 wire 변경 ①)
+            return RemoteConfigEvaluateResult.of(reason: DecisionReason.TYPE_MISMATCH, value: value)  // TYPE_MISMATCH여도 value 유지 (의도된 wire 변경)
         }
     }
 }

--- a/Sources/Hackle/Core/InAppMessage/Schedule/InAppMessageScheduleProcessor.swift
+++ b/Sources/Hackle/Core/InAppMessage/Schedule/InAppMessageScheduleProcessor.swift
@@ -35,7 +35,7 @@ class DefaultInAppMessageScheduleProcessor: InAppMessageScheduleProcessor, InApp
         return try await scheduler.schedule(action: action, request: request)
     }
 
-    // InAppMessageScheduleListener — delay 타이머 콜백 (P9 Task 진입 경계 ②)
+    // InAppMessageScheduleListener의 delay 타이머 콜백
     func onSchedule(request: InAppMessageScheduleRequest) {
         Task {
             await self.process(request: request)

--- a/Sources/Hackle/Core/InAppMessage/Trigger/InAppMessageTriggerHandler.swift
+++ b/Sources/Hackle/Core/InAppMessage/Trigger/InAppMessageTriggerHandler.swift
@@ -11,7 +11,6 @@ class DefaultInAppMessageTriggerHandler: InAppMessageTriggerHandler, @unchecked 
         self.scheduleProcessor = scheduleProcessor
     }
 
-    // P9 Task 진입 경계 ① — trigger handler(eventQueue)
     func handle(trigger: InAppMessageTrigger) {
         let schedule = InAppMessageSchedule.create(trigger: trigger)
         let scheduleRequest = schedule.toRequest(type: .triggered, requestedAt: trigger.event.timestamp)

--- a/Sources/Hackle/Core/User/Local/LocalUserManager.swift
+++ b/Sources/Hackle/Core/User/Local/LocalUserManager.swift
@@ -253,11 +253,3 @@ extension LocalUserManager {
         saveUser(user: currentUser)
     }
 }
-
-fileprivate extension [String: Any] {
-    func append(_ new: [String: Any]) -> [String: Any] {
-        self.merging(new) {
-            (_, new) in new
-        }
-    }
-}

--- a/Sources/Hackle/Core/User/Local/LocalUserManager.swift
+++ b/Sources/Hackle/Core/User/Local/LocalUserManager.swift
@@ -147,7 +147,6 @@ class LocalUserManager: UserManager, @unchecked Sendable {
 
     // User update
 
-    // android LocalUserManager.update: `val updated = updateContext(update); return syncIfNeeded(updated)`.
     // mutation(updateContext)은 lock 안에서 동기적으로 끝난 뒤(= 동기 프리픽스), 네트워크 sync만 Task로 반환한다.
     func setUser(user: User) -> Task<Void, Never> {
         let updated = recursiveLock.lock {
@@ -170,7 +169,6 @@ class LocalUserManager: UserManager, @unchecked Sendable {
         return Task { await self.syncIfNeeded(updated: updated) }
     }
 
-    // android resetUser: updateContext -> trackProperties(clearAll) -> syncIfNeeded. 앞의 두 단계는 동기 프리픽스.
     func resetUser() -> Task<Void, Never> {
         let updated = recursiveLock.lock {
             let updated = updateContext { _ in

--- a/Sources/Hackle/Core/User/Remote/RemoteUserContext.swift
+++ b/Sources/Hackle/Core/User/Remote/RemoteUserContext.swift
@@ -12,10 +12,8 @@ struct RemoteUserContext: UserContext {
         RemoteUserContext(user: sanitize(user: user))
     }
 
-    // `User.toBuilder().properties([:])`는 HackleUserBuilder.properties(_:)가 내부적으로
-    // PropertiesBuilder.add(merge)를 호출하는 "추가" 방식이라 빈 dict를 넘겨도 기존 properties가
-    // 지워지지 않는다 (android toBuilder().properties(emptyMap())의 replace semantics와 다름 — Read로 확인됨).
-    // 그래서 fresh builder에 id/userId/deviceId/identifiers만 이관해 properties를 비운다.
+    // HackleUserBuilder.properties(_:)는 내부적으로 add(merge) 방식이라 빈 dict를 넘겨도 기존
+    // properties가 지워지지 않는다. 그래서 fresh builder에 식별자만 이관해 properties를 비운다.
     private static func sanitize(user: User) -> User {
         if user.properties.isEmpty {
             return user

--- a/Sources/Hackle/Core/User/Remote/RemoteUserManager.swift
+++ b/Sources/Hackle/Core/User/Remote/RemoteUserManager.swift
@@ -89,8 +89,8 @@ class RemoteUserManager: UserManager, @unchecked Sendable {
 
     private func hackleProperties(appContext: HackleAppContext) -> [String: Any] {
         appContext.browserProperties
-            .merging(device.properties) { _, new in new }
-            .merging(bundleInfo.properties) { _, new in new }
+            .append(device.properties)
+            .append(bundleInfo.properties)
     }
 
     // Update User

--- a/Sources/Hackle/Core/User/Remote/RemoteUserManager.swift
+++ b/Sources/Hackle/Core/User/Remote/RemoteUserManager.swift
@@ -15,9 +15,7 @@ class RemoteUserManager: UserManager, @unchecked Sendable {
     private let defaultUser: User
     private var context: RemoteUserContext
 
-    // 초기 sync용 컨텍스트 — Synchronizer.sync()가 1회 소비한다 (android initSyncContext 패리티).
-    // §11 known gap: REMOTE 분기에는 현재 sync()의 외부 호출자가 없다 — Task 18도 이를 등록하지 않는다.
-    // 정답지(android)도 동일한 상태이므로 여기서 "고치지" 않는다.
+    // 초기 sync용 컨텍스트 — sync()가 1회 소비한다.
     private let initSyncContext = AtomicReference<SyncContext?>(value: nil)
 
     private var currentContext: RemoteUserContext {
@@ -95,11 +93,8 @@ class RemoteUserManager: UserManager, @unchecked Sendable {
 
     // Update User
     //
-    // 동기 프리픽스 계약 (Task 11 확정, android 1:1): mutator는 mutation(updateContext)을
-    // recursiveLock 아래에서 동기적으로 끝내고, 네트워크 sync(syncIfNeeded)만 Task<Void, Never>로 반환한다.
-    // android: `val updated = updateContext(update); return syncIfNeeded(updated, syncContext)`
-    // (RemoteUserManager.kt:121-127) — updateContext는 synchronized(lock) 블록으로 이미 동기적이며,
-    // syncIfNeeded가 반환하는 CompletableFuture 생성 자체도 호출 스레드를 막지 않는다.
+    // 동기 프리픽스 계약: mutator는 mutation(updateContext)을 recursiveLock 아래에서 동기적으로 끝내고,
+    // 네트워크 sync(syncIfNeeded)만 Task<Void, Never>로 반환한다.
 
     func setUser(user: User) -> Task<Void, Never> {
         updateAndSyncIfNeeded(operations: RemoteUserManager.setOperations(properties: user.properties)) { _ in
@@ -125,9 +120,8 @@ class RemoteUserManager: UserManager, @unchecked Sendable {
         }
     }
 
-    // android updateProperties (kt:113-118): remote는 properties를 로컬에 저장하지 않으므로 mutation이 없다.
-    // syncContext는 Task 진입 전, 호출 시점에 동기적으로 캡처한다(currentContext는 lock을 통한 스냅샷) —
-    // android가 `val context = SyncContext(currentContext, operations)`를 future 생성 이전에 평가하는 것과 동일한 타이밍.
+    // remote는 properties를 로컬에 저장하지 않으므로 mutation이 없다.
+    // syncContext는 Task 진입 전 동기적으로 캡처한다(currentContext는 lock을 통한 스냅샷).
     func updateProperties(operations: PropertyOperations) -> Task<Void, Never> {
         if operations.count == 0 {
             return Task {}
@@ -136,15 +130,13 @@ class RemoteUserManager: UserManager, @unchecked Sendable {
         return Task { await self.sync(context: syncContext) }
     }
 
-    // updateAndSyncIfNeeded: updateContext(동기, lock 하)로 mutation을 즉시 끝낸 뒤,
-    // 네트워크 sync만 담당하는 Task를 반환한다. 이 함수 자체는 async가 아니다 — 동기 프리픽스의 핵심.
     private func updateAndSyncIfNeeded(
         operations: PropertyOperations = PropertyOperations.empty(),
         update: (RemoteUserContext) -> RemoteUserContext
     ) -> Task<Void, Never> {
         let updated = updateContext(update: update)
         let syncContext = SyncContext(userContext: updated.new, operations: operations)
-        // 동기 프리픽스: evaluationKey 변경 여부를 Task 진입 전에 판단해 Bool만 넘긴다.
+        // evaluationKey 변경 여부를 Task 진입 전에 판단해 Bool만 넘긴다.
         // updated(non-Sendable)를 Task 클로저로 캡처하지 않아 sending 데이터 레이스 경고를 피한다.
         let evaluationKeyChanged = updated.old.evaluationKey != updated.new.evaluationKey
         return Task { await self.syncIfNeeded(evaluationKeyChanged: evaluationKeyChanged, syncContext: syncContext) }
@@ -177,7 +169,7 @@ class RemoteUserManager: UserManager, @unchecked Sendable {
         let operations: PropertyOperations
     }
 
-    // Synchronizer 프로토콜 메서드. initSyncContext를 1회 소비한다 (§11 parity, 호출자는 REMOTE 분기에 없음).
+    // Synchronizer 프로토콜 메서드. initSyncContext를 1회 소비한다.
     func sync() async throws {
         let syncContext = initSyncContext.getAndSet(newValue: nil) ?? SyncContext(userContext: currentContext, operations: PropertyOperations.empty())
         await sync(context: syncContext)

--- a/Sources/Hackle/Core/User/UserManager.swift
+++ b/Sources/Hackle/Core/User/UserManager.swift
@@ -21,7 +21,6 @@ protocol UserManager: Synchronizer, ApplicationLifecycleListener {
     func addListener(listener: UserListener)
 }
 
-// Kotlin 기본 인자 대응 (D7)
 extension UserManager {
     func hackleUser() -> HackleUser {
         hackleUser(user: currentUser, appContext: .default)

--- a/Sources/Hackle/Core/Utilities/Collections.swift
+++ b/Sources/Hackle/Core/Utilities/Collections.swift
@@ -81,7 +81,7 @@ extension Array {
 
 extension Dictionary {
 
-    // Kotlin Map.plus(+) 대응 — 동일 키는 우측(new) 우선
+    // 동일 키는 우측(new) 우선
     func append(_ new: [Key: Value]) -> [Key: Value] {
         merging(new) { _, new in new }
     }

--- a/Sources/Hackle/Core/Utilities/Collections.swift
+++ b/Sources/Hackle/Core/Utilities/Collections.swift
@@ -78,3 +78,11 @@ extension Array {
         return result
     }
 }
+
+extension Dictionary {
+
+    // Kotlin Map.plus(+) 대응 — 동일 키는 우측(new) 우선
+    func append(_ new: [Key: Value]) -> [Key: Value] {
+        merging(new) { _, new in new }
+    }
+}

--- a/Sources/Hackle/Core/Workspace/Config/WorkspaceConfigs.swift
+++ b/Sources/Hackle/Core/Workspace/Config/WorkspaceConfigs.swift
@@ -462,10 +462,13 @@ extension BucketDto {
 
 extension VariationDto {
     func toVariation(parameterConfigurations: [ParameterConfiguration.Id: ParameterConfiguration]) -> Variation {
-        let parameterConfiguration = parameterConfigurationId.flatMap { id in
+        toVariation(parameterConfiguration: parameterConfigurationId.flatMap { id in
             parameterConfigurations[id]
-        }
-        return VariationEntity(
+        })
+    }
+
+    func toVariation(parameterConfiguration: ParameterConfiguration?) -> Variation {
+        VariationEntity(
             id: id,
             key: key,
             isDropped: status == "DROPPED",

--- a/Sources/Hackle/Core/Workspace/Evaluation/Evaluator/WorkspaceEvaluationMerger.swift
+++ b/Sources/Hackle/Core/Workspace/Evaluation/Evaluator/WorkspaceEvaluationMerger.swift
@@ -1,6 +1,5 @@
 import Foundation
 
-// android evaluator/WorkspaceEvaluations object 대응 (model/WorkspaceEvaluations.swift와 파일명 충돌 회피 — D2)
 enum WorkspaceEvaluationMerger {
 
     private struct Key: Hashable {
@@ -50,7 +49,7 @@ enum WorkspaceEvaluationMerger {
         )
     }
 
-    // 서버가 준 metadata hash(Kotlin Int = 32비트)와 비교하므로 반드시 Int32 랩핑 산술로 계산한다.
+    // 서버 metadata hash는 32비트 정수이므로 반드시 Int32 랩핑 산술로 계산한다.
     // Swift Int(64비트)로 계산하면 오버플로 시 불일치 → 불필요한 FORCE_FULL 재요청 루프.
     static func hash(results: [EvaluateResultDto]) -> Int32 {
         var acc: Int32 = 1

--- a/Sources/Hackle/Core/Workspace/Evaluation/Evaluator/WorkspaceRemoteEvaluator.swift
+++ b/Sources/Hackle/Core/Workspace/Evaluation/Evaluator/WorkspaceRemoteEvaluator.swift
@@ -1,6 +1,5 @@
 import Foundation
 
-// Kotlin 제네릭 <REQUEST: WorkspaceEvaluateRequest>는 비제네릭 protocol + 구현 내부 다운캐스트로 대응 (D5)
 protocol WorkspaceRemoteEvaluator: AnyObject {
     func supports(scope: WorkspaceEvaluateScope) -> Bool
     func evaluate(request: WorkspaceEvaluateRequest) async throws -> WorkspaceEvaluateResponse

--- a/Sources/Hackle/Core/Workspace/Evaluation/Model/WorkspaceEvaluateContext.swift
+++ b/Sources/Hackle/Core/Workspace/Evaluation/Model/WorkspaceEvaluateContext.swift
@@ -14,7 +14,6 @@ struct WorkspaceEvaluateContext {
         WorkspaceEvaluateContext(platformType: .ios, user: user, operations: operations)
     }
 
-    // Kotlin 기본 인자 대응 (D7)
     static func of(user: HackleUser) -> WorkspaceEvaluateContext {
         of(user: user, operations: PropertyOperations.empty())
     }

--- a/Sources/Hackle/Core/Workspace/Evaluation/Model/WorkspaceEvaluationDto.swift
+++ b/Sources/Hackle/Core/Workspace/Evaluation/Model/WorkspaceEvaluationDto.swift
@@ -20,8 +20,8 @@ struct WorkspaceEvaluateResponseDto: Codable {
 }
 
 extension WorkspaceEvaluateResponseDto {
-    // 서버가 deleted를 생략할 수 있다(특히 NOT_MODIFIED). android(Gson)는 누락을 조용히 허용하므로
-    // 동일하게 관용한다. init을 본체가 아닌 extension에 두어 memberwise init을 보존한다(테스트 생성부 사용).
+    // 서버가 deleted를 생략할 수 있어(특히 NOT_MODIFIED) 누락을 관용한다.
+    // init을 extension에 두어 memberwise init을 보존한다(테스트 생성부에서 사용).
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         status = try container.decode(String.self, forKey: .status)

--- a/Sources/Hackle/Core/Workspace/Evaluation/Model/WorkspaceEvaluationDto.swift
+++ b/Sources/Hackle/Core/Workspace/Evaluation/Model/WorkspaceEvaluationDto.swift
@@ -13,6 +13,21 @@ struct WorkspaceEvaluateResponseDto: Codable {
     let status: String // FULL, DELTA, NOT_MODIFIED
     let evaluation: WorkspaceEvaluationDto?
     let deleted: [EntityDto]
+
+    private enum CodingKeys: String, CodingKey {
+        case status, evaluation, deleted
+    }
+}
+
+extension WorkspaceEvaluateResponseDto {
+    // 서버가 deleted를 생략할 수 있다(특히 NOT_MODIFIED). android(Gson)는 누락을 조용히 허용하므로
+    // 동일하게 관용한다. init을 본체가 아닌 extension에 두어 memberwise init을 보존한다(테스트 생성부 사용).
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        status = try container.decode(String.self, forKey: .status)
+        evaluation = try container.decodeIfPresent(WorkspaceEvaluationDto.self, forKey: .evaluation)
+        deleted = try container.decodeIfPresent([EntityDto].self, forKey: .deleted) ?? []
+    }
 }
 
 struct WorkspaceEvaluationDto: Codable {

--- a/Sources/Hackle/Core/Workspace/Evaluation/Model/WorkspaceEvaluations.swift
+++ b/Sources/Hackle/Core/Workspace/Evaluation/Model/WorkspaceEvaluations.swift
@@ -2,20 +2,13 @@ import Foundation
 
 extension ExperimentEvaluateResultDto {
     func toResult(type: ExperimentType) -> ExperimentRemoteEvaluateResult {
-        let parameterConfigurations: [ParameterConfiguration.Id: ParameterConfiguration]
-        if let config = config {
-            let configuration = config.toParameterConfiguration()
-            parameterConfigurations = [configuration.id: configuration]
-        } else {
-            parameterConfigurations = [:]
-        }
         return ExperimentRemoteEvaluateResult(
             id: id,
             key: key,
             version: version,
             type: type,
             executionVersion: executionVersion,
-            variation: variation.toVariation(parameterConfigurations: parameterConfigurations),
+            variation: variation.toVariation(parameterConfiguration: config?.toParameterConfiguration()),
             reason: reason,
             references: references.compactMap { it in
                 it.toEntityOrNil()

--- a/Sources/Hackle/Core/Workspace/Evaluation/WorkspaceEvaluation.swift
+++ b/Sources/Hackle/Core/Workspace/Evaluation/WorkspaceEvaluation.swift
@@ -51,10 +51,4 @@ extension WorkspaceEvaluation {
     func getInAppMessageOrNil(inAppMessageKey: InAppMessage.Key) -> InAppMessage? {
         getInAppMessageResultOrNil(inAppMessageKey: inAppMessageKey)
     }
-
-    func toProperties() -> [String: Any] {
-        PropertiesBuilder()
-            .add("config_modified_at", modifiedAt)
-            .build()
-    }
 }

--- a/Sources/Hackle/Core/Workspace/Evaluation/WorkspaceEvaluationFetcher.swift
+++ b/Sources/Hackle/Core/Workspace/Evaluation/WorkspaceEvaluationFetcher.swift
@@ -1,5 +1,8 @@
 import Foundation
 
+// java-core WorkspaceEvaluationFetcher는 WorkspaceFetcher.workspace(user)를 covariant return으로
+// 정제하지만, Swift 프로토콜은 요구사항의 covariant 정제를 표현할 수 없어 독립 프로토콜 + 동명
+// 오버로드가 된다. concrete 타입(WorkspaceEvaluationManager) 호출부는 반환 타입 명시가 필요하다.
 protocol WorkspaceEvaluationFetcher {
     func workspace(user: HackleUser) -> WorkspaceEvaluation?
 }

--- a/Sources/Hackle/Core/Workspace/Evaluation/WorkspaceEvaluationFetcher.swift
+++ b/Sources/Hackle/Core/Workspace/Evaluation/WorkspaceEvaluationFetcher.swift
@@ -1,8 +1,6 @@
 import Foundation
 
-// java-core WorkspaceEvaluationFetcher는 WorkspaceFetcher.workspace(user)를 covariant return으로
-// 정제하지만, Swift 프로토콜은 요구사항의 covariant 정제를 표현할 수 없어 독립 프로토콜 + 동명
-// 오버로드가 된다. concrete 타입(WorkspaceEvaluationManager) 호출부는 반환 타입 명시가 필요하다.
+// WorkspaceFetcher.workspace(user)와 동명 오버로드이므로, concrete 타입 호출부는 반환 타입 명시가 필요하다.
 protocol WorkspaceEvaluationFetcher {
     func workspace(user: HackleUser) -> WorkspaceEvaluation?
 }

--- a/Tests/HackleTests/Core/Evaluation/Evaluator/Experiment/ExperimentEvaluationSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Evaluator/Experiment/ExperimentEvaluationSpecs.swift
@@ -70,7 +70,7 @@ class ExperimentEvaluationSpecs: QuickSpec {
             expect(evaluation.experimentResult.variation.parameterConfiguration).to(beNil())
         }
 
-        // 회귀 ①: ofControl 은 항상 컨트롤 그룹(A) 의 variation 을 반환하고, A 가 없으면 예외를 던진다.
+        // 회귀 가드: ofControl 은 항상 컨트롤 그룹(A) 의 variation 을 반환하고, A 가 없으면 예외를 던진다.
         it("ofControl 은 컨트롤 그룹(A) 의 variation 을 반환한다") {
             let exp = experiment(
                 type: .abTest,

--- a/Tests/HackleTests/Core/Evaluation/Evaluator/RemoteConfig/RemoteConfigEvaluatorSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Evaluator/RemoteConfig/RemoteConfigEvaluatorSpecs.swift
@@ -202,7 +202,7 @@ class RemoteConfigEvaluatorSpecs: QuickSpec {
                 expect(rcEvent.valueId) == 77
 
                 // then: 사용자에게 반환되는 값은 여전히 defaultValue (타입 불일치이므로)
-                expect(Decisions.toRemoteConfigDecision(evaluation: actual, requiredType: .string, defaultValue: .string("default")).value) == .string("default")
+                expect(actual.toDecision(requiredType: .string, defaultValue: .string("default")).value) == .string("default")
             }
         }
     }

--- a/Tests/HackleTests/Core/Evaluation/Evaluator/RemoteConfig/RemoteConfigEvaluatorSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Evaluator/RemoteConfig/RemoteConfigEvaluatorSpecs.swift
@@ -171,13 +171,13 @@ class RemoteConfigEvaluatorSpecs: QuickSpec {
                     expect(actual.remoteConfigResult.value?.rawValue) == v1
                     expect(actual.remoteConfigResult.reason) == DecisionReason.DEFAULT_RULE
                 } else {
-                    expect(actual.remoteConfigResult.value?.id) == 43       // ★ 이전: valueId nil
-                    expect(actual.remoteConfigResult.value?.rawValue) == v1 // ★ 이전: v2(defaultValue)
+                    expect(actual.remoteConfigResult.value?.id) == 43
+                    expect(actual.remoteConfigResult.value?.rawValue) == v1
                     expect(actual.remoteConfigResult.reason) == DecisionReason.TYPE_MISMATCH
                 }
             }
 
-            // 회귀 ②: TYPE_MISMATCH 여도 value 를 유지해 노출 이벤트 valueId 가 실제 값 id 로 기록된다.
+            // 회귀 가드: TYPE_MISMATCH 여도 value 를 유지해 노출 이벤트 valueId 가 실제 값 id 로 기록된다.
             it("TYPE_MISMATCH 여도 value 를 유지해 노출 이벤트 valueId 가 실제 값 id 로 기록된다") {
                 // given: string 요청 vs number 값
                 let parameter = parameter(
@@ -196,7 +196,7 @@ class RemoteConfigEvaluatorSpecs: QuickSpec {
                 expect(actual.remoteConfigResult.value?.id) == 77
                 expect(actual.remoteConfigResult.value?.rawValue) == HackleValue.double(999)
 
-                // then: 노출 이벤트 valueId = 실제 값 id (이전: nil)
+                // then: 노출 이벤트 valueId = 실제 값 id
                 let events = EvaluationEventFactory(clock: SystemClock.shared).create(response: response)
                 let rcEvent = events.first as! UserEvents.RemoteConfig
                 expect(rcEvent.valueId) == 77

--- a/Tests/HackleTests/Core/Evaluation/Service/InAppMessage/Eligibility/Mode/Remote/InAppMessageEligibilityRemoteEvaluatorSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Service/InAppMessage/Eligibility/Mode/Remote/InAppMessageEligibilityRemoteEvaluatorSpecs.swift
@@ -50,7 +50,7 @@ class InAppMessageEligibilityRemoteEvaluatorSpecs: QuickSpec {
             }
 
             it("stores the resolved layout response on the response when the flow resolves one") {
-                // LayoutResolve가 context에 layout response를 set한 뒤 Ineligible로 끝나는 flow (P8 시나리오)
+                // LayoutResolve가 context에 layout response를 set한 뒤 Ineligible로 끝나는 flow
                 let layoutEvaluator = InAppMessageLayoutRemoteEvaluator(
                     eventRecorder: EvaluationEventRecorder(
                         eventFactory: EvaluationEventFactory(clock: SystemClock.shared),

--- a/Tests/HackleTests/Core/InAppMessage/Deliver/Evaluator/MockInAppMessageDeliverEvaluator.swift
+++ b/Tests/HackleTests/Core/InAppMessage/Deliver/Evaluator/MockInAppMessageDeliverEvaluator.swift
@@ -3,7 +3,7 @@ import MockingKit
 @testable import Hackle
 
 class MockInAppMessageDeliverEvaluator: Mock, InAppMessageDeliverEvaluator {
-    // MockFunction은 sync 함수 타입만 받으므로, async 프로토콜 메서드 대신 sync stub으로 참조를 만든다(MockUserManager 관례와 동일).
+    // MockFunction은 sync 함수 타입만 받으므로, async 프로토콜 메서드는 sync stub으로 참조를 만든다.
     lazy var evaluateMock = MockFunction.throwable(self, evaluateStub)
 
     private func evaluateStub(request: InAppMessageDeliverRequest, user: HackleUser) throws -> InAppMessageDeliverEvaluateResponse {

--- a/Tests/HackleTests/Core/InAppMessage/Deliver/MockInAppMessageDeliverProcessor.swift
+++ b/Tests/HackleTests/Core/InAppMessage/Deliver/MockInAppMessageDeliverProcessor.swift
@@ -3,7 +3,7 @@ import MockingKit
 @testable import Hackle
 
 class MockInAppMessageDeliverProcessor: Mock, InAppMessageDeliverProcessor {
-    // MockFunction은 sync 함수 타입만 받으므로, async 프로토콜 메서드 대신 sync stub으로 참조를 만든다(MockUserManager 관례와 동일).
+    // MockFunction은 sync 함수 타입만 받으므로, async 프로토콜 메서드는 sync stub으로 참조를 만든다.
     lazy var processMock = MockFunction(self, processStub)
 
     private func processStub(request: InAppMessageDeliverRequest) -> InAppMessageDeliverResponse {

--- a/Tests/HackleTests/Core/InAppMessage/Schedule/MockInAppMessageScheduleProcessor.swift
+++ b/Tests/HackleTests/Core/InAppMessage/Schedule/MockInAppMessageScheduleProcessor.swift
@@ -3,7 +3,7 @@ import MockingKit
 @testable import Hackle
 
 class MockInAppMessageScheduleProcessor: Mock, InAppMessageScheduleProcessor {
-    // MockFunction은 sync 함수 타입만 받으므로, async 프로토콜 메서드 대신 sync stub으로 참조를 만든다(MockUserManager 관례와 동일).
+    // MockFunction은 sync 함수 타입만 받으므로, async 프로토콜 메서드는 sync stub으로 참조를 만든다.
     lazy var processMock = MockFunction(self, processStub)
 
     private func processStub(request: InAppMessageScheduleRequest) -> InAppMessageScheduleResponse {

--- a/Tests/HackleTests/Core/InAppMessage/Schedule/Scheduler/MockInAppMessageScheduler.swift
+++ b/Tests/HackleTests/Core/InAppMessage/Schedule/Scheduler/MockInAppMessageScheduler.swift
@@ -9,7 +9,7 @@ class MockInAppMessageScheduler: Mock, InAppMessageScheduler {
         return call(supportMock, args: scheduleType)
     }
 
-    // MockFunction은 sync 함수 타입만 받으므로, async 프로토콜 메서드 대신 sync stub으로 참조를 만든다(MockUserManager 관례와 동일).
+    // MockFunction은 sync 함수 타입만 받으므로, async 프로토콜 메서드는 sync stub으로 참조를 만든다.
     lazy var deliverMock = MockFunction.throwable(self, deliverStub)
 
     private func deliverStub(request: InAppMessageScheduleRequest) throws -> InAppMessageScheduleResponse {

--- a/Tests/HackleTests/Core/User/Local/LocalUserManagerSpecs.swift
+++ b/Tests/HackleTests/Core/User/Local/LocalUserManagerSpecs.swift
@@ -291,11 +291,9 @@ class LocalUserManagerSpecs: AsyncSpec {
             }
         }
 
-        // Task 11: syncIfNeeded(updated:)가 private으로 바뀌어 mutator가 내부에서 흡수한다.
-        // BEFORE(구 계약)에는 Updated(previous:current:)를 합성해 syncIfNeeded를 직접 호출/검증했으나,
-        // AFTER(신 계약)에서는 mutator(setUserId/setDeviceId/setUser/resetUser) 호출 후 cohort/targetEvent
-        // fetch 여부로 간접 검증한다. hasNewIdentifiers(추가된 식별자 유무 → cohort)와
-        // identifierEquals(userId+deviceId 동일 여부 → targetEvent)의 분기를 각각 대표 케이스로 커버한다.
+        // syncIfNeeded가 private이라 직접 검증할 수 없으므로, mutator 호출 후 cohort/targetEvent fetch 여부로
+        // 간접 검증한다. hasNewIdentifiers(추가된 식별자 유무 → cohort)와 identifierEquals(userId+deviceId
+        // 동일 여부 → targetEvent) 분기를 각각 대표 케이스로 커버한다.
         describe("mutator 호출에 따른 cohort/targetEvent 동기화") {
             it("변경이 없으면 cohort와 targetEvent 모두 동기화하지 않는다") {
                 sut.initialize(user: User.builder().userId("user_a").deviceId("device_a").build())
@@ -393,11 +391,9 @@ class LocalUserManagerSpecs: AsyncSpec {
             }
         }
 
-        // 동기 프리픽스 회귀 가드: mutator는 mutation을 반환 전에 동기적으로 끝내고(android updateContext),
-        // 네트워크 sync만 Task<Void, Never>로 반환한다(android syncIfNeeded). 반환된 Task를 await하지 않아도
-        // currentUser/hackleUser()는 이미 변경을 반영해야 한다.
-        // 구 형태(mutator가 async이고 HackleAppCore가 `Task { await ... }`로 통째로 감싸던)에서는 mutation이
-        // Task 실행 시점까지 지연되어 이 단언이 깨진다 — "log in 후 즉시 variation 평가" 순서 회귀의 가드.
+        // 동기 프리픽스 회귀 가드: mutator는 mutation을 반환 전에 동기적으로 끝내므로, 반환된 Task를
+        // await하지 않아도 currentUser/hackleUser()는 이미 변경을 반영해야 한다. mutator가 async이던 구 형태에서는
+        // mutation이 Task 실행 시점까지 지연되어 이 단언이 깨진다 — "log in 후 즉시 variation 평가" 순서 회귀의 가드.
         describe("동기 프리픽스 (mutation before Task return)") {
             it("setUser 반환 즉시 currentUser/hackleUser가 갱신된다 (Task await 이전)") {
                 sut.initialize(user: nil)

--- a/Tests/HackleTests/Core/User/Remote/RemoteUserManagerSpecs.swift
+++ b/Tests/HackleTests/Core/User/Remote/RemoteUserManagerSpecs.swift
@@ -26,10 +26,9 @@ private class RecordingUserListener: UserListener {
     }
 }
 
-// Task 12: RemoteUserManager는 REMOTE 모드의 UserManager 구현체다.
-// UserManager 프로토콜의 mutator는 Task 11에서 async가 아니라 `-> Task<Void, Never>`로 확정되었다
-// (mutation은 lock 아래 동기적으로 끝나고, 네트워크 sync만 Task로 미룬다 — LocalUserManager와 동일 계약).
-// 그래서 아래 테스트는 `await sut.setUser(...)`가 아니라 `await sut.setUser(...).value`로 sync 완료를 기다린다.
+// RemoteUserManager는 REMOTE 모드의 UserManager 구현체다. mutator는 async가 아니라 `-> Task<Void, Never>`이며
+// (mutation은 lock 아래 동기적으로 끝나고 네트워크 sync만 Task로 미룬다), 그래서 아래 테스트는
+// `await sut.setUser(...).value`로 sync 완료를 기다린다.
 class RemoteUserManagerSpecs: AsyncSpec {
     override class func spec() {
 
@@ -153,10 +152,9 @@ class RemoteUserManagerSpecs: AsyncSpec {
             }
         }
 
-        // 동기 프리픽스 회귀 가드 (Task 11 LocalUserManagerSpecs와 동일한 취지):
-        // mutator는 mutation을 반환 전에 recursiveLock 아래 동기적으로 끝내고(android updateContext),
-        // 네트워크 sync만 Task<Void, Never>로 반환한다(android syncIfNeeded). 반환된 Task를 await하기 전에도
-        // currentUser는 이미 변경을 반영해야 한다. updateProperties는 로컬 상태를 바꾸지 않으므로 가드 대상이 아니다.
+        // 동기 프리픽스 회귀 가드: mutator는 mutation을 반환 전에 recursiveLock 아래 동기적으로 끝내므로,
+        // 반환된 Task를 await하기 전에도 currentUser는 이미 변경을 반영해야 한다.
+        // updateProperties는 로컬 상태를 바꾸지 않으므로 가드 대상이 아니다.
         describe("동기 프리픽스 (mutation before Task return)") {
             beforeEach {
                 sut.initialize(user: HackleUserBuilder().userId("user_1").build())

--- a/Tests/HackleTests/Core/Workspace/Evaluation/DefaultWorkspaceEvaluationSpecs.swift
+++ b/Tests/HackleTests/Core/Workspace/Evaluation/DefaultWorkspaceEvaluationSpecs.swift
@@ -75,6 +75,14 @@ class DefaultWorkspaceEvaluationSpecs: QuickSpec {
                 expect(result.references.count) == 1 // UNKNOWN_TYPE reference는 skip
             }
 
+            it("config가 오면 parameterConfigurationId와 무관하게 variation에 직접 부착한다") {
+                let sut = DefaultWorkspaceEvaluation.from(dto: decodeResponse().evaluation!)
+                let result = sut.getExperimentResultOrNil(experimentKey: 10)!
+
+                // 픽스처의 variation.parameterConfigurationId는 null — pcid 조회 방식이면 config가 유실된다
+                expect(result.variation.parameterConfiguration?.id) == 9001
+            }
+
             it("in-app message result의 period·evaluateContext·layout을 매핑한다") {
                 let sut = DefaultWorkspaceEvaluation.from(dto: decodeResponse().evaluation!)
                 let result = sut.getInAppMessageResultOrNil(inAppMessageKey: 40)!

--- a/Tests/HackleTests/Core/Workspace/Evaluation/Evaluator/WorkspaceEvaluationMergerSpecs.swift
+++ b/Tests/HackleTests/Core/Workspace/Evaluation/Evaluator/WorkspaceEvaluationMergerSpecs.swift
@@ -105,8 +105,8 @@ class WorkspaceEvaluationMergerSpecs: QuickSpec {
                 expect(WorkspaceEvaluationMerger.hash(results: a)) == WorkspaceEvaluationMerger.hash(results: b)
             }
 
-            it("Int32 랩핑 산술로 오버플로해도 크래시 없이 서버(Kotlin Int)와 같은 값을 만든다") {
-                // Kotlin: acc=1; acc=acc*31+Int.MAX_VALUE = 2147483678 → Int 오버플로 = -2147483618
+            it("Int32 랩핑 산술로 오버플로해도 크래시 없이 서버(32비트 정수)와 같은 값을 만든다") {
+                // acc=1; acc = acc*31 + Int32.max = 2147483678 → Int32 오버플로 = -2147483618
                 let results = [result(id: 1, hash: Int32.max)]
                 expect(WorkspaceEvaluationMerger.hash(results: results)) == Int32(bitPattern: 0x8000001E)
 

--- a/Tests/HackleTests/Core/Workspace/Evaluation/Evaluator/WorkspaceRemoteEvaluateClientSpecs.swift
+++ b/Tests/HackleTests/Core/Workspace/Evaluation/Evaluator/WorkspaceRemoteEvaluateClientSpecs.swift
@@ -100,5 +100,15 @@ class WorkspaceRemoteEvaluateClientSpecs: AsyncSpec {
 
             await expect { try await sut.evaluate(request: requestDto()) }.to(throwError())
         }
+
+        it("deleted·evaluation이 생략된 NOT_MODIFIED 응답을 디코딩한다") {
+            stub(statusCode: 200, data: #"{"status":"NOT_MODIFIED"}"#.data(using: .utf8)!)
+
+            let response = try await sut.evaluate(request: requestDto())
+
+            expect(response.status) == "NOT_MODIFIED"
+            expect(response.evaluation).to(beNil())
+            expect(response.deleted).to(beEmpty())
+        }
     }
 }

--- a/Tests/HackleTests/Core/Workspace/Evaluation/WorkspaceEvaluationManagerSpecs.swift
+++ b/Tests/HackleTests/Core/Workspace/Evaluation/WorkspaceEvaluationManagerSpecs.swift
@@ -174,8 +174,6 @@ class WorkspaceEvaluationManagerSpecs: AsyncSpec {
         }
 
         describe("scope에 맞는 evaluator가 없는 경우") {
-            // Task 8 roll-up: WorkspaceRemoteEvaluatorFactory.get(scope:) not-found throw가
-            // Task 8에는 전용 spec이 없어 Task 9 통합 테스트로 커버리지가 이연됨.
             it("sync는 factory throw도 삼키고 기존 상태를 유지한다") {
                 let noEvaluatorSut = WorkspaceEvaluationManager(
                     evaluateProcessor: WorkspaceEvaluateProcessor(

--- a/Tests/HackleTests/Core/Workspace/Evaluation/WorkspaceEvaluationSpecs.swift
+++ b/Tests/HackleTests/Core/Workspace/Evaluation/WorkspaceEvaluationSpecs.swift
@@ -24,11 +24,5 @@ class WorkspaceEvaluationSpecs: QuickSpec {
             expect(found?.entityKey).to(equal(experiment.entityKey))
             expect(workspace.result(entity: DefaultEntity(serviceType: .abTest, id: 2))).to(beNil())
         }
-
-        it("toProperties exposes config_modified_at") {
-            let workspace = MockWorkspaceEvaluation()
-            workspace.modifiedAt = "modified"
-            expect(workspace.toProperties()["config_modified_at"] as? String).to(equal("modified"))
-        }
     }
 }

--- a/Tests/HackleTests/Core/Workspace/WorkspaceSpecs.swift
+++ b/Tests/HackleTests/Core/Workspace/WorkspaceSpecs.swift
@@ -36,7 +36,7 @@ class WorkspaceSpecs: QuickSpec {
             expect(config?.getString(forKey: "string", defaultValue: "42")) == "string_value"
         }
 
-        // 회귀 ③: variation.parameterConfiguration 은 parameterConfigurationId 로 resolve 되어야 한다 (variation.id 로 오조회하면 안 된다).
+        // 회귀 가드: variation.parameterConfiguration 은 parameterConfigurationId 로 resolve 되어야 한다 (variation.id 로 오조회하면 안 된다).
         it("variation 의 parameterConfiguration 은 parameterConfigurationId 로 resolve 된다 (variation.id 아님)") {
             let file = Bundle(for: WorkspaceSpecs.self).path(forResource: "workspace_response", ofType: "json")!
             let json = try! String(contentsOfFile: file)

--- a/Tests/HackleTests/HackleAppSpec.swift
+++ b/Tests/HackleTests/HackleAppSpec.swift
@@ -99,7 +99,6 @@ class HackleAppSpecs: QuickSpec {
                         done()
                     }
                 }
-                // Task 11: mutator가 sync 책임을 흡수해 async가 되며 syncIfNeeded(updated:)가 프로토콜에서 삭제됨.
                 // setUserMock 호출 완료(waitUntil로 대기)가 곧 update+sync 완료를 의미한다.
                 verify(exactly: 1) {
                     userManager.setUserMock
@@ -209,8 +208,8 @@ class HackleAppSpecs: QuickSpec {
 
         describe("setUserProperty") {
             it("update properties") {
-                // Task 11: updateUserProperties가 Task<Void, Never>를 반환하도록 바뀌며(LOCKED — user-confirmed)
-                // completion이 Task 완료 후 completionQueue로 재디스패치된다. mutator 호출도 이제 completion 이후에만 보장된다.
+                // updateUserProperties가 Task<Void, Never>를 반환하므로 completion은 Task 완료 후
+                // completionQueue로 재디스패치된다. mutator 호출도 completion 이후에만 보장된다.
                 waitUntil { done in
                     sut.setUserProperty(key: "age", value: 42) {
                         done()
@@ -269,8 +268,6 @@ class HackleAppSpecs: QuickSpec {
                 expect(count) == 1
             }
 
-            // Task 11 LOCKED divergence(user-confirmed): updateUserProperties -> Task<Void, Never>로 바뀌며
-            // completion이 completionQueue로 재디스패치된다. 이전의 "동기 인라인" 계약은 의도적으로 소실되었다.
             it("updateUserProperties completion은 Task 완료 후 비동기로 호출된다 (동기 인라인 계약 소실)") {
                 var called = false
                 waitUntil { done in

--- a/Tests/HackleTests/Mock/MockWorkspaceEvaluation.swift
+++ b/Tests/HackleTests/Mock/MockWorkspaceEvaluation.swift
@@ -34,6 +34,13 @@ class MockWorkspaceEvaluation: WorkspaceEvaluation {
         all.append(contentsOf: inAppMessageResults)
         return all.first { $0.entityKey == entity.entityKey }
     }
+
+    func toProperties() -> [String: Any] {
+        PropertiesBuilder()
+            .add("config_modified_at", modifiedAt)
+            .add("remote_evaluated_at", evaluatedAt)
+            .build()
+    }
 }
 
 class MockWorkspaceEvaluationFetcher: WorkspaceEvaluationFetcher {

--- a/Tests/HackleTests/Resources/workspace_evaluation_response.json
+++ b/Tests/HackleTests/Resources/workspace_evaluation_response.json
@@ -23,7 +23,12 @@
             "status": "ACTIVE",
             "parameterConfigurationId": null
           },
-          "config": null,
+          "config": {
+            "id": 9001,
+            "parameters": [
+              { "key": "button_color", "value": "blue" }
+            ]
+          },
           "reason": "TRAFFIC_ALLOCATED",
           "references": [
             { "type": "AB_TEST", "id": 100 },


### PR DESCRIPTION
## 개요
원격 workspace evaluate 응답 처리에서 누락되거나 직접 전달되는 데이터를 올바르게 반영하도록 수정합니다.
`deleted` 필드가 생략된 `NOT_MODIFIED` 응답을 허용하고, evaluate 응답의 config를 variation에 직접 부착하도록 변경하였습니다.

## 주요 변경사항
| 카테고리 | 내용 |
|----------|------|
| 원격 평가 응답 | `deleted` 필드가 없는 응답을 빈 배열로 디코딩하도록 수정 |
| Variation config | evaluate 응답의 `config`를 `parameterConfigurationId` 조회 없이 variation에 직접 연결 |
| Decision 변환 | `Decisions` 유틸을 evaluation receiver extension으로 정리 |
| Properties 병합 | 중복 dictionary merge 로직을 공용 `append` helper로 통합 |
| WorkspaceEvaluation | 기본 `toProperties` 구현을 제거하고 mock에서 remote 평가 시각까지 포함하도록 조정 |
| 테스트 | config 직접 부착 및 `NOT_MODIFIED` 응답 디코딩 회귀 테스트 추가 |