### PR TITLE
fix: remote cleanup race and property matching

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -128,5 +128,6 @@ jobs:
                 -only-testing:HackleTests/DelegatingMetricRegistrySpecs/concurrency \
                 -only-testing:HackleTests/MetricsRaceSpecs \
                 -only-testing:HackleTests/UserManagerRaceSpecs \
+                -only-testing:HackleTests/WorkspaceConfigManagerRaceSpecs \
                 -parallel-testing-enabled NO \
                 | xcbeautify --renderer github-actions --quiet

--- a/Sources/Hackle/Core/Evaluation/Match/TargetEventConditionMatcher.swift
+++ b/Sources/Hackle/Core/Evaluation/Match/TargetEventConditionMatcher.swift
@@ -109,11 +109,10 @@ class NumberOfEventsWithPropertyInDaysMatcher: NumberOfEventInDayMatcher {
     ///   - propertyCondition: 조건 프로퍼티
     /// - Returns: 만족 여부
     private func propertyMatch(property: TargetEvent.Property, propertyCondition: Target.Condition) -> Bool {
-        if property.type == propertyCondition.key.type && propertyCondition.key.name != property.key {
-            return false
+        if property.type == propertyCondition.key.type && property.key == propertyCondition.key.name {
+            return valueOperatorMatcher.matches(userValue: property.value, match: propertyCondition.match)
         }
-        
-        return valueOperatorMatcher.matches(userValue: property.value, match: propertyCondition.match)
+        return false
     }
 }
 

--- a/Sources/Hackle/Core/Workspace/Config/DefaultWorkspaceConfig.swift
+++ b/Sources/Hackle/Core/Workspace/Config/DefaultWorkspaceConfig.swift
@@ -9,7 +9,6 @@ class DefaultWorkspaceConfig: WorkspaceConfig {
     private let buckets: [Bucket.Id: Bucket]
     private let segments: [Segment.Key: Segment]
     private let containers: [Container.Id: Container]
-    private let parameterConfigurations: [ParameterConfiguration.Id: ParameterConfiguration]
     private let _remoteConfigParameters: [RemoteConfigParameter.Key: RemoteConfigParameter]
 
     private let _experiments: [Experiment.Key: Experiment]
@@ -25,7 +24,6 @@ class DefaultWorkspaceConfig: WorkspaceConfig {
         buckets: [Bucket],
         segments: [Segment],
         containers: [Container],
-        parameterConfigurations: [ParameterConfiguration],
         remoteConfigParameters: [RemoteConfigParameter],
         inAppMessages: [InAppMessage]
     ) {
@@ -41,9 +39,6 @@ class DefaultWorkspaceConfig: WorkspaceConfig {
             $0.key
         }
         self.containers = containers.associateBy {
-            $0.id
-        }
-        self.parameterConfigurations = parameterConfigurations.associateBy {
             $0.id
         }
         self._remoteConfigParameters = remoteConfigParameters.associateBy {
@@ -79,10 +74,6 @@ class DefaultWorkspaceConfig: WorkspaceConfig {
 
     func getContainerOrNil(containerId: Container.Id) -> Container? {
         containers[containerId]
-    }
-
-    func getParameterConfigurationOrNil(parameterConfigurationId: ParameterConfiguration.Id) -> ParameterConfiguration? {
-        parameterConfigurations[parameterConfigurationId]
     }
 
     func getRemoteConfigParameterOrNil(parameterKey: RemoteConfigParameter.Key) -> RemoteConfigParameter? {
@@ -161,7 +152,6 @@ class DefaultWorkspaceConfig: WorkspaceConfig {
             buckets: buckets,
             segments: segments,
             containers: containers,
-            parameterConfigurations: parameterConfigurations,
             remoteConfigParameters: remoteConfigParameters,
             inAppMessages: inAppMessages
         )

--- a/Sources/Hackle/Core/Workspace/Config/WorkspaceConfig.swift
+++ b/Sources/Hackle/Core/Workspace/Config/WorkspaceConfig.swift
@@ -11,5 +11,4 @@ protocol WorkspaceConfig: Workspace {
     func getBucketOrNil(bucketId: Bucket.Id) -> Bucket?
     func getSegmentOrNil(segmentKey: Segment.Key) -> Segment?
     func getContainerOrNil(containerId: Container.Id) -> Container?
-    func getParameterConfigurationOrNil(parameterConfigurationId: ParameterConfiguration.Id) -> ParameterConfiguration?
 }

--- a/Sources/Hackle/Core/Workspace/Config/WorkspaceConfigManager.swift
+++ b/Sources/Hackle/Core/Workspace/Config/WorkspaceConfigManager.swift
@@ -10,7 +10,7 @@ class WorkspaceConfigManager: WorkspaceManager, WorkspaceConfigFetcher, Synchron
     private let httpWorkspaceConfigFetcher: HttpWorkspaceConfigFetcher
     private let repository: WorkspaceConfigRepository
 
-    private var context: WorkspaceConfigContext? = nil
+    private let context = AtomicReference<WorkspaceConfigContext?>(value: nil)
 
     init(httpWorkspaceConfigFetcher: HttpWorkspaceConfigFetcher, repository: WorkspaceConfigRepository) {
         self.httpWorkspaceConfigFetcher = httpWorkspaceConfigFetcher
@@ -22,19 +22,20 @@ class WorkspaceConfigManager: WorkspaceManager, WorkspaceConfigFetcher, Synchron
     }
 
     func metadata() -> WorkspaceMetadata? {
-        context?.workspace.metadata
+        context.get()?.workspace.metadata
     }
 
     func workspace(user: HackleUser) -> Workspace? {
-        context?.workspace
+        context.get()?.workspace
     }
 
     func workspace(user: HackleUser) -> WorkspaceConfig? {
-        context?.workspace
+        context.get()?.workspace
     }
 
     func sync() async throws {
-        let context = try await httpWorkspaceConfigFetcher.fetchIfModified(lastModified: self.context?.modifiedAt)
+        let lastModified = context.get()?.modifiedAt
+        let context = try await httpWorkspaceConfigFetcher.fetchIfModified(lastModified: lastModified)
         store(context: context)
     }
 
@@ -42,13 +43,13 @@ class WorkspaceConfigManager: WorkspaceManager, WorkspaceConfigFetcher, Synchron
         guard let context else {
             return
         }
-        self.context = context
+        self.context.set(newValue: context)
         repository.set(value: context)
     }
 
     private func load() {
         if let context = repository.get() {
-            self.context = context
+            self.context.set(newValue: context)
             Log.debug("WorkspaceConfig loaded: [modifiedAt: \(context.modifiedAt ?? "nil")]")
         }
     }

--- a/Sources/Hackle/UI/ExplorerUI/View/Experiment/AbTestListView.swift
+++ b/Sources/Hackle/UI/ExplorerUI/View/Experiment/AbTestListView.swift
@@ -53,18 +53,21 @@ struct AbTestListView: View {
     }
 }
 
-private extension HackleAbTestItem {
+extension HackleAbTestItem {
     var keyLabel: String {
         "[\(experiment.key)] \((experiment as? ExperimentConfig)?.name ?? "")"
     }
 
     var descLabel: String {
-        [
-            "V\(experiment.version)",
-            (experiment as? ExperimentConfig)?.status.rawValue ?? "",
-            ((experiment as? ExperimentConfig)?.variations ?? []).map(\.key)
+        guard let config = experiment as? ExperimentConfig else {
+            return ""
+        }
+        return [
+            "V\(config.version)",
+            config.status.rawValue,
+            config.variations.map(\.key)
                 .joined(separator: "/"),
-            (experiment as? ExperimentConfig)?.identifierType ?? ""
+            config.identifierType
         ]
             .joined(separator: " | ")
     }

--- a/Sources/Hackle/UI/ExplorerUI/View/Experiment/FeatureFlagListView.swift
+++ b/Sources/Hackle/UI/ExplorerUI/View/Experiment/FeatureFlagListView.swift
@@ -54,13 +54,16 @@ struct FeatureFlagListView: View {
     }
 }
 
-private extension HackleFeatureFlagItem {
+extension HackleFeatureFlagItem {
     var keyLabel: String {
         "[\(experiment.key)] \((experiment as? ExperimentConfig)?.name ?? "")"
     }
 
     var descLabel: String {
-        "\((experiment as? ExperimentConfig)?.status.rawValue ?? "") | \((experiment as? ExperimentConfig)?.identifierType ?? "")"
+        guard let config = experiment as? ExperimentConfig else {
+            return ""
+        }
+        return "\(config.status.rawValue) | \(config.identifierType)"
     }
 }
 

--- a/Tests/HackleTests/Core/Evaluation/Match/TargetEventConditionMatchSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Match/TargetEventConditionMatchSpecs.swift
@@ -72,6 +72,24 @@ class TargetEventConditionMatchSpecs: QuickSpec {
             )
         }
 
+        it("when property type matches but key name mismatches, do not count event") {
+            let targetEvents = [
+                TargetEvent(eventKey: "purchase", stats: makeSingleTargetEventStat(clock: clock, daysAgo: 5), property: TargetEvent.Property(key: "product", type: .eventProperty, value: HackleValue(value: "milk")))
+            ]
+
+            verify(
+                targetEvents: targetEvents,
+                key: try getKeyString(eventKey: "purchase", days: 7, filter: Target.Condition(
+                    key: Target.Key(type: .eventProperty, name: "productName"),
+                    match: Target.Match(type: .match, matchOperator: ._in, valueType: .string, values: [HackleValue(value: "milk")])
+                )),
+                operator: .gte,
+                valueType: .number,
+                targetValue: 1,
+                expected: false
+            )
+        }
+
         it("when target event is empty in 30 days, fail") {
             verify(
                 targetEvents: [],

--- a/Tests/HackleTests/Core/Evaluation/Match/TargetEventConditionMatchSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Match/TargetEventConditionMatchSpecs.swift
@@ -38,9 +38,9 @@ class TargetEventConditionMatchSpecs: QuickSpec {
         
         it("when unsupport propertyType, fail") {
             let targetEvents = [
-                TargetEvent(eventKey: "purchase", stats: [], property: TargetEvent.Property(key: "purchase", type: .eventProperty, value: HackleValue(value: "1")))
+                TargetEvent(eventKey: "purchase", stats: makeSingleTargetEventStat(clock: clock, daysAgo: 5), property: TargetEvent.Property(key: "purchase", type: .eventProperty, value: HackleValue(value: "1")))
             ]
-            
+
             verify(
                 targetEvents: targetEvents,
                 key: try getKeyString(eventKey: "purchase", days: 7, filter: Target.Condition(
@@ -53,7 +53,25 @@ class TargetEventConditionMatchSpecs: QuickSpec {
                 expected: false
             )
         }
-        
+
+        it("when property type mismatches, do not count event even if key and value match") {
+            let targetEvents = [
+                TargetEvent(eventKey: "purchase", stats: makeSingleTargetEventStat(clock: clock, daysAgo: 5), property: TargetEvent.Property(key: "productName", type: .eventProperty, value: HackleValue(value: "milk")))
+            ]
+
+            verify(
+                targetEvents: targetEvents,
+                key: try getKeyString(eventKey: "purchase", days: 7, filter: Target.Condition(
+                    key: Target.Key(type: .hackleProperty, name: "productName"),
+                    match: Target.Match(type: .match, matchOperator: ._in, valueType: .string, values: [HackleValue(value: "milk")])
+                )),
+                operator: .gte,
+                valueType: .number,
+                targetValue: 1,
+                expected: false
+            )
+        }
+
         it("when target event is empty in 30 days, fail") {
             verify(
                 targetEvents: [],

--- a/Tests/HackleTests/Core/Model/ModelTestExt.swift
+++ b/Tests/HackleTests/Core/Model/ModelTestExt.swift
@@ -20,7 +20,6 @@ extension DefaultWorkspaceConfig {
         buckets: [Bucket] = [],
         segments: [Segment] = [],
         containers: [Container] = [],
-        parameterConfigurations: [ParameterConfiguration] = [],
         remoteConfigParameters: [RemoteConfigParameter] = [],
         inAppMessages: [InAppMessage] = []
     ) -> DefaultWorkspaceConfig {
@@ -33,7 +32,6 @@ extension DefaultWorkspaceConfig {
             buckets: buckets,
             segments: segments,
             containers: containers,
-            parameterConfigurations: parameterConfigurations,
             remoteConfigParameters: remoteConfigParameters,
             inAppMessages: inAppMessages
         )

--- a/Tests/HackleTests/Core/Workspace/WorkspaceConfigManagerRaceSpecs.swift
+++ b/Tests/HackleTests/Core/Workspace/WorkspaceConfigManagerRaceSpecs.swift
@@ -1,0 +1,62 @@
+import Foundation
+import Quick
+import Nimble
+@testable import Hackle
+
+
+/// WorkspaceConfigManager.context에 대한 data race 재현 스펙.
+/// -enableThreadSanitizer YES 로 실행할 것.
+class WorkspaceConfigManagerRaceSpecs: QuickSpec {
+    override class func spec() {
+
+        it("WorkspaceConfigManager: concurrent context write (sync) vs read (workspace/metadata)") {
+            let data = WorkspaceConfigManagerSpecs.loadWorkspaceConfigFromRes()
+            let fetcher = FixedHttpWorkspaceConfigFetcher(context: data)
+            let repository = MockWorkspaceConfigRepository()
+            let sut = WorkspaceConfigManager(httpWorkspaceConfigFetcher: fetcher, repository: repository)
+            sut.initialize()
+
+            let writerIterations = 2_000
+            let readerCount = 4
+            let readerIterations = 15_000
+            let group = DispatchGroup()
+            let user = HackleUser.of(userId: "user")
+
+            DispatchQueue.global(qos: .utility).async(group: group) {
+                for _ in 0..<writerIterations {
+                    let sem = DispatchSemaphore(value: 0)
+                    Task {
+                        try? await sut.sync()
+                        sem.signal()
+                    }
+                    sem.wait()
+                }
+            }
+
+            for _ in 0..<readerCount {
+                DispatchQueue.global(qos: .utility).async(group: group) {
+                    for _ in 0..<readerIterations {
+                        let _: WorkspaceConfig? = sut.workspace(user: user)
+                        _ = sut.metadata()
+                    }
+                }
+            }
+
+            group.wait()
+
+            expect(sut.metadata()?.id) == 3
+        }
+    }
+}
+
+private final class FixedHttpWorkspaceConfigFetcher: HttpWorkspaceConfigFetcher {
+    private let context: WorkspaceConfigContext
+
+    init(context: WorkspaceConfigContext) {
+        self.context = context
+    }
+
+    func fetchIfModified(lastModified: String?) async throws -> WorkspaceConfigContext? {
+        context
+    }
+}

--- a/Tests/HackleTests/Core/Workspace/WorkspaceSpecs.swift
+++ b/Tests/HackleTests/Core/Workspace/WorkspaceSpecs.swift
@@ -17,7 +17,11 @@ class WorkspaceSpecs: QuickSpec {
             let experiment = workspace.getExperimentOrNil(experimentKey: 42)
             expect(experiment).toNot(beNil())
 
-            let config = workspace.getParameterConfigurationOrNil(parameterConfigurationId: 100538)
+            // pcid 100538은 fixture상 featureFlag(key 42)의 variation(105052)에 parse-time 부착된다
+            let config = workspace.featureFlags
+                .flatMap { ($0 as? ExperimentConfig)?.variations ?? [] }
+                .compactMap { $0.parameterConfiguration }
+                .first { $0.id == 100538 }
             expect(config).toNot(beNil())
 
             expect(config?.getInt(forKey: "int1", defaultValue: 42)) == 1
@@ -49,9 +53,8 @@ class WorkspaceSpecs: QuickSpec {
             }!
             let variation = ((experiment as? ExperimentConfig)?.variations ?? []).first { $0.parameterConfiguration != nil }!
 
-            // parse-time resolve 된 객체가 workspace 조회 결과와 동일 id
-            let expected = workspace.getParameterConfigurationOrNil(parameterConfigurationId: variation.parameterConfiguration!.id)
-            expect(variation.parameterConfiguration?.id) == expected?.id
+            // parse-time resolve 된 객체는 dto의 parameterConfigurationId(100550)여야 한다 (variation.id 223310로 오조회 금지)
+            expect(variation.parameterConfiguration?.id) == 100550
             expect(variation.parameterConfiguration?.id) != variation.id
         }
     }

--- a/Tests/HackleTests/Core/Workspace/WorkspaceSpecs.swift
+++ b/Tests/HackleTests/Core/Workspace/WorkspaceSpecs.swift
@@ -17,7 +17,8 @@ class WorkspaceSpecs: QuickSpec {
             let experiment = workspace.getExperimentOrNil(experimentKey: 42)
             expect(experiment).toNot(beNil())
 
-            // pcid 100538은 fixture상 featureFlag(key 42)의 variation(105052)에 parse-time 부착된다
+            // pcid 100538은 fixture상 어떤 featureFlag의 variation에 parse-time 부착되어 있으며,
+            // 아래 검증은 parse된 그래프 전체(featureFlags의 모든 variation)를 훑어 해당 parameterConfiguration을 찾아낸다
             let config = workspace.featureFlags
                 .flatMap { ($0 as? ExperimentConfig)?.variations ?? [] }
                 .compactMap { $0.parameterConfiguration }

--- a/Tests/HackleTests/Mock/MockWorkspace.swift
+++ b/Tests/HackleTests/Mock/MockWorkspace.swift
@@ -57,12 +57,6 @@ class MockWorkspace: Mock, WorkspaceConfig {
         call(getContainerOrNilMock, args: containerId)
     }
 
-    lazy var getParameterConfigurationOrNilMock = MockFunction(self, getParameterConfigurationOrNil)
-
-    func getParameterConfigurationOrNil(parameterConfigurationId: ParameterConfiguration.Id) -> ParameterConfiguration? {
-        call(getParameterConfigurationOrNilMock, args: parameterConfigurationId)
-    }
-
     lazy var getRemoteConfigParameterMock = MockFunction(self, getRemoteConfigParameterOrNil)
 
     func getRemoteConfigParameterOrNil(parameterKey: RemoteConfigParameter.Key) -> RemoteConfigParameter? {

--- a/Tests/HackleTests/UI/ExplorerUI/ExplorerExperimentItemLabelSpecs.swift
+++ b/Tests/HackleTests/UI/ExplorerUI/ExplorerExperimentItemLabelSpecs.swift
@@ -1,0 +1,62 @@
+import Foundation
+import Nimble
+import Quick
+@testable import Hackle
+
+class ExplorerExperimentItemLabelSpecs: QuickSpec {
+    override class func spec() {
+
+        func remoteExperiment(type: ExperimentType) -> Experiment {
+            ExperimentRemoteEvaluateResult(
+                id: 1,
+                key: 42,
+                version: 3,
+                type: type,
+                executionVersion: 1,
+                variation: VariationEntity(id: 1, key: "A", isDropped: false, parameterConfiguration: nil),
+                reason: DecisionReason.TRAFFIC_ALLOCATED,
+                references: []
+            )
+        }
+
+        it("AB descLabel: ExperimentConfig(LOCAL)는 기존 형식을 유지한다") {
+            let config = experiment(id: 1, key: 42, type: .abTest)
+            let item = HackleAbTestItem(
+                experiment: config,
+                decision: Decision.of(experiment: config, variation: "A", reason: DecisionReason.TRAFFIC_ALLOCATED),
+                overriddenVariation: nil
+            )
+            expect(item.descLabel) == "V1 | running | A/B | $id"
+        }
+
+        it("AB descLabel: ExperimentConfig가 아니면(REMOTE) 빈 문자열을 반환한다") {
+            let remote = remoteExperiment(type: .abTest)
+            let item = HackleAbTestItem(
+                experiment: remote,
+                decision: Decision.of(experiment: remote, variation: "A", reason: DecisionReason.TRAFFIC_ALLOCATED),
+                overriddenVariation: nil
+            )
+            expect(item.descLabel) == ""
+        }
+
+        it("FF descLabel: ExperimentConfig(LOCAL)는 기존 형식을 유지한다") {
+            let config = experiment(id: 2, key: 43, type: .featureFlag)
+            let item = HackleFeatureFlagItem(
+                experiment: config,
+                decision: FeatureFlagDecision.off(featureFlag: config, reason: DecisionReason.FEATURE_FLAG_INACTIVE),
+                overriddenVariation: nil
+            )
+            expect(item.descLabel) == "running | $id"
+        }
+
+        it("FF descLabel: ExperimentConfig가 아니면(REMOTE) 빈 문자열을 반환한다") {
+            let remote = remoteExperiment(type: .featureFlag)
+            let item = HackleFeatureFlagItem(
+                experiment: remote,
+                decision: FeatureFlagDecision.off(featureFlag: remote, reason: DecisionReason.FEATURE_FLAG_INACTIVE),
+                overriddenVariation: nil
+            )
+            expect(item.descLabel) == ""
+        }
+    }
+}


### PR DESCRIPTION
## 개요
WorkspaceConfigManager의 config context 접근을 AtomicReference로 보호하여 동시 sync/read 상황의 data race를 방지합니다.
타겟 이벤트 property 조건은 type과 key가 모두 일치할 때만 매칭되도록 수정합니다.
Remote evaluate 결과처럼 ExperimentConfig가 아닌 explorer item은 desc label을 빈 문자열로 표시하도록 정리합니다.

## 주요 변경사항
| 카테고리 | 내용 |
|----------|------|
| Evaluation | target event property 매칭 시 type과 key를 모두 검증하도록 수정 |
| Workspace | 사용되지 않는 parameter configuration 직접 조회 API 제거 및 parse-time 연결 검증 방식으로 테스트 정리 |
| Concurrency | WorkspaceConfigManager context를 AtomicReference로 관리하고 race 재현 테스트 추가 |
| Explorer UI | non-config experiment의 AB/FF desc label을 빈 문자열로 반환 |
| Test | property type/key mismatch, explorer label, workspace config race 테스트 추가 및 race workflow 대상에 포함 |