### PR TITLE
fix: record in-app message impression only when presented

### DIFF
--- a/Sources/Hackle/Core/InAppMessage/Deliver/InAppMessageDeliverProcessor.swift
+++ b/Sources/Hackle/Core/InAppMessage/Deliver/InAppMessageDeliverProcessor.swift
@@ -52,14 +52,14 @@ class DefaultInAppMessageDeliverProcessor: InAppMessageDeliverProcessor {
 
         // evaluate (dedup + re-evaluate)
         let response = try await evaluator.evaluate(request: request, user: user)
-        return try resolve(request: request, user: user, response: response)
+        return try await resolve(request: request, user: user, response: response)
     }
 
     private func resolve(
         request: InAppMessageDeliverRequest,
         user: HackleUser,
         response: InAppMessageDeliverEvaluateResponse
-    ) throws -> InAppMessageDeliverResponse {
+    ) async throws -> InAppMessageDeliverResponse {
         if !response.isEligible {
             return InAppMessageDeliverResponse.of(request: request, code: response.code ?? .ineligible)
         }
@@ -73,7 +73,7 @@ class DefaultInAppMessageDeliverProcessor: InAppMessageDeliverProcessor {
             user: user,
             evaluation: evaluation
         )
-        let presentResponse = try presentProcessor.process(request: presentRequest)
+        let presentResponse = try await presentProcessor.process(request: presentRequest)
 
         return InAppMessageDeliverResponse.of(request: request, code: .present, presentResponse: presentResponse)
     }

--- a/Sources/Hackle/Core/InAppMessage/Present/InAppMessagePresentProcessor.swift
+++ b/Sources/Hackle/Core/InAppMessage/Present/InAppMessagePresentProcessor.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 protocol InAppMessagePresentProcessor {
-    func process(request: InAppMessagePresentRequest) throws -> InAppMessagePresentResponse
+    func process(request: InAppMessagePresentRequest) async throws -> InAppMessagePresentResponse
 }
 
 class DefaultInAppMessagePresentProcessor: InAppMessagePresentProcessor {
@@ -14,19 +14,19 @@ class DefaultInAppMessagePresentProcessor: InAppMessagePresentProcessor {
         self.recorder = recorder
     }
 
-    func process(request: InAppMessagePresentRequest) throws -> InAppMessagePresentResponse {
+    func process(request: InAppMessagePresentRequest) async throws -> InAppMessagePresentResponse {
         Log.debug("InAppMessage Present Request: \(request)")
 
-        let response = try present(request: request)
-        recorder.record(request: request, response: response)
+        let context = InAppMessagePresentationContext.of(request: request)
+        let presented = await presenter.present(context: context)
+        let response = InAppMessagePresentResponse.of(request: request, context: context)
+
+        // 실제로 노출된 경우에만 impression을 기록한다. 노출되지 않은 메시지가 frequency cap을 소모하면 안 된다.
+        if presented {
+            recorder.record(request: request, response: response)
+        }
 
         Log.debug("InAppMessage Present Response: \(response)")
         return response
-    }
-
-    private func present(request: InAppMessagePresentRequest) throws -> InAppMessagePresentResponse {
-        let context = InAppMessagePresentationContext.of(request: request)
-        presenter.present(context: context)
-        return InAppMessagePresentResponse.of(request: request, context: context)
     }
 }

--- a/Sources/Hackle/Core/InAppMessage/Present/Presentation/InAppMessagePresenter.swift
+++ b/Sources/Hackle/Core/InAppMessage/Present/Presentation/InAppMessagePresenter.swift
@@ -8,5 +8,6 @@
 import Foundation
 
 protocol InAppMessagePresenter {
-    func present(context: InAppMessagePresentationContext)
+    /// 메시지 표시를 시도하고 실제 노출 여부를 반환한다. 노출되지 않은 메시지는 impression으로 기록되지 않아야 한다.
+    func present(context: InAppMessagePresentationContext) async -> Bool
 }

--- a/Sources/Hackle/Core/InAppMessage/Present/Presentation/InAppMessagePresenter.swift
+++ b/Sources/Hackle/Core/InAppMessage/Present/Presentation/InAppMessagePresenter.swift
@@ -8,6 +8,5 @@
 import Foundation
 
 protocol InAppMessagePresenter {
-    /// 메시지 표시를 시도하고 실제 노출 여부를 반환한다. 노출되지 않은 메시지는 impression으로 기록되지 않아야 한다.
     func present(context: InAppMessagePresentationContext) async -> Bool
 }

--- a/Sources/Hackle/UI/InAppMessageUI/InAppMessageUI.swift
+++ b/Sources/Hackle/UI/InAppMessageUI/InAppMessageUI.swift
@@ -39,23 +39,21 @@ class HackleInAppMessageUI: NSObject, InAppMessagePresenter, InAppMessageViewPro
         return view
     }
 
-    func present(context: InAppMessagePresentationContext) {
-        Task { @MainActor in
-            self.presentNow(context: context)
-        }
+    func present(context: InAppMessagePresentationContext) async -> Bool {
+        await presentNow(context: context)
     }
 
-    @MainActor private func presentNow(context: InAppMessagePresentationContext) {
+    @MainActor private func presentNow(context: InAppMessagePresentationContext) -> Bool {
         guard checkRootViewController(),
               noMessagePresented(),
               orientationSupported(context: context)
         else {
-            return
+            return false
         }
 
         // Message View
         guard let messageView = createMessageView(context: context) else {
-            return
+            return false
         }
 
         // ViewController
@@ -77,6 +75,7 @@ class HackleInAppMessageUI: NSObject, InAppMessagePresenter, InAppMessageViewPro
         } else {
             window.isHidden = false
         }
+        return true
     }
 
     @MainActor private func checkRootViewController() -> Bool {

--- a/Tests/HackleTests/Core/InAppMessage/Present/DefaultInAppMessagePresentProcessorSpecs.swift
+++ b/Tests/HackleTests/Core/InAppMessage/Present/DefaultInAppMessagePresentProcessorSpecs.swift
@@ -3,30 +3,25 @@ import Quick
 import Nimble
 @testable import Hackle
 
-class DefaultInAppMessagePresentProcessorSpecs: QuickSpec {
+class DefaultInAppMessagePresentProcessorSpecs: AsyncSpec {
     override class func spec() {
-
-        var presenter: MockInAppMessagePresenter!
-        var recorder: MockInAppMessageRecorder!
-        var sut: DefaultInAppMessagePresentProcessor!
-
-        beforeEach {
-            presenter = MockInAppMessagePresenter()
-            recorder = MockInAppMessageRecorder()
-            sut = DefaultInAppMessagePresentProcessor(
-                presenter: presenter,
-                recorder: recorder
-            )
-        }
 
         it("process") {
             // given
+            let presenter = MockInAppMessagePresenter()
+            let recorder = MockInAppMessageRecorder()
+            let sut = DefaultInAppMessagePresentProcessor(
+                presenter: presenter,
+                recorder: recorder
+            )
+            every(presenter.presentMock).returns(true)
+
             let request = InAppMessageEntity.presentRequest(
                 dispatchId: "111"
             )
 
             // when
-            let actual = try sut.process(request: request)
+            let actual = try await sut.process(request: request)
 
             // then
             expect(actual.dispatchId) == "111"
@@ -35,6 +30,33 @@ class DefaultInAppMessagePresentProcessorSpecs: QuickSpec {
                 presenter.presentMock
             }
             verify(exactly: 1) {
+                recorder.recordMock
+            }
+        }
+
+        it("노출되지 않은 메시지는 impression을 기록하지 않는다") {
+            // given
+            let presenter = MockInAppMessagePresenter()
+            let recorder = MockInAppMessageRecorder()
+            let sut = DefaultInAppMessagePresentProcessor(
+                presenter: presenter,
+                recorder: recorder
+            )
+            every(presenter.presentMock).returns(false)
+
+            let request = InAppMessageEntity.presentRequest(
+                dispatchId: "111"
+            )
+
+            // when
+            let actual = try await sut.process(request: request)
+
+            // then
+            expect(actual.dispatchId) == "111"
+            verify(exactly: 1) {
+                presenter.presentMock
+            }
+            verify(exactly: 0) {
                 recorder.recordMock
             }
         }

--- a/Tests/HackleTests/Core/InAppMessage/Present/MockInAppMessagePresentProcessor.swift
+++ b/Tests/HackleTests/Core/InAppMessage/Present/MockInAppMessagePresentProcessor.swift
@@ -4,9 +4,14 @@ import MockingKit
 
 class MockInAppMessagePresentProcessor: Mock, InAppMessagePresentProcessor {
 
-    lazy var processMock = MockFunction.throwable(self, process)
+    // MockFunction은 sync 함수 타입만 받으므로, async 프로토콜 메서드는 sync stub으로 참조를 만든다.
+    lazy var processMock = MockFunction.throwable(self, processStub)
 
-    func process(request: InAppMessagePresentRequest) throws -> InAppMessagePresentResponse {
+    private func processStub(request: InAppMessagePresentRequest) throws -> InAppMessagePresentResponse {
+        fatalError("processStub is not invoked directly; it only exists to type the MockFunction reference")
+    }
+
+    func process(request: InAppMessagePresentRequest) async throws -> InAppMessagePresentResponse {
         return try call(processMock, args: request)
     }
 }

--- a/Tests/HackleTests/Core/InAppMessage/Present/Presentation/MockInAppMessagePresenter.swift
+++ b/Tests/HackleTests/Core/InAppMessage/Present/Presentation/MockInAppMessagePresenter.swift
@@ -4,9 +4,14 @@ import MockingKit
 
 class MockInAppMessagePresenter: Mock, InAppMessagePresenter {
 
-    lazy var presentMock = MockFunction(self, present)
+    // MockFunction은 sync 함수 타입만 받으므로, async 프로토콜 메서드는 sync stub으로 참조를 만든다.
+    lazy var presentMock = MockFunction(self, presentStub)
 
-    func present(context: InAppMessagePresentationContext) {
-        call(presentMock, args: context)
+    private func presentStub(context: InAppMessagePresentationContext) -> Bool {
+        fatalError("presentStub is not invoked directly; it only exists to type the MockFunction reference")
+    }
+
+    func present(context: InAppMessagePresentationContext) async -> Bool {
+        return call(presentMock, args: context)
     }
 }


### PR DESCRIPTION
## 개요
인앱 메시지가 실제로 노출된 경우에만 impression을 기록하도록 수정합니다.
노출에 실패한 메시지가 frequency cap을 소모하지 않도록 presentation 결과를 기반으로 기록 여부를 결정합니다.

## 작업 내용
- `InAppMessagePresenter.present`가 실제 노출 여부를 `Bool`로 반환하도록 변경
- 인앱 메시지 표시 흐름을 async로 전환하여 노출 결과를 기다린 뒤 impression 기록
- root view controller, 중복 표시, orientation, message view 생성 실패 시 노출 실패로 처리
- 메시지가 노출되지 않은 경우 recorder가 호출되지 않는 테스트 추가