### PR TITLE
refactor: unify HTTP response handling and user listeners

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ claudedocs
 AGENTS.md
 CLAUDE.md
 .conductor
+.superpowers

--- a/Sources/Hackle/Core/Event/UserEventDispatcher.swift
+++ b/Sources/Hackle/Core/Event/UserEventDispatcher.swift
@@ -68,18 +68,18 @@ class DefaultUserEventDispatcher: UserEventDispatcher {
             return
         }
 
-        guard let urlResponse = response.urlResponse as? HTTPURLResponse else {
+        guard let statusCode = response.statusCode else {
             Log.error("Failed to dispatch events: Response is empty")
             delete(events: events)
             return
         }
 
-        if (200..<300).contains(urlResponse.statusCode) {
+        if (200..<300).contains(statusCode) {
             delete(events: events)
             return
         }
 
-        if (400..<500).contains(urlResponse.statusCode) {
+        if (400..<500).contains(statusCode) {
             delete(events: events)
             return
         }

--- a/Sources/Hackle/Core/Monitoring/Metric/MonitoringMetricRegistry.swift
+++ b/Sources/Hackle/Core/Monitoring/Metric/MonitoringMetricRegistry.swift
@@ -189,6 +189,17 @@ enum ApiCallMetrics {
     }
 }
 
+extension ApiCallMetrics {
+    /// 타이밍 측정 + 기록을 감싸는 HOF. android의 예외-감싸기 HOF를 async response 버전으로 조정한 형태.
+    /// (iOS httpClient.execute는 throw 대신 response.error로 에러를 표현)
+    static func record(operation: String, _ call: () async -> HttpResponse) async -> HttpResponse {
+        let sample = TimerSample.start()
+        let response = await call()
+        record(operation: operation, sample: sample, response: response)
+        return response
+    }
+}
+
 extension URLError.Code {
     fileprivate func toString() -> String {
         switch self {

--- a/Sources/Hackle/Core/User/Local/LocalUserManager.swift
+++ b/Sources/Hackle/Core/User/Local/LocalUserManager.swift
@@ -211,7 +211,7 @@ class LocalUserManager: UserManager, @unchecked Sendable {
         saveUser(user: newUser)
         return UserUpdated(old: oldContext, new: newContext)
     }
-    
+
     private func publishPropertyOperations(user: User, operations: PropertyOperations, timestamp: Date) {
         Log.debug("UserManager.publishPropertyOperations()")
         for listener in userListeners {

--- a/Sources/Hackle/Core/User/Local/LocalUserManager.swift
+++ b/Sources/Hackle/Core/User/Local/LocalUserManager.swift
@@ -211,6 +211,13 @@ class LocalUserManager: UserManager, @unchecked Sendable {
         saveUser(user: newUser)
         return UserUpdated(old: oldContext, new: newContext)
     }
+    
+    private func publishPropertyOperations(user: User, operations: PropertyOperations, timestamp: Date) {
+        Log.debug("UserManager.publishPropertyOperations()")
+        for listener in userListeners {
+            listener.onPropertyOperations(user: user, operations: operations, timestamp: timestamp)
+        }
+    }
 
     private func loadUser() -> User? {
         repository.get()

--- a/Sources/Hackle/Core/User/Local/LocalUserManager.swift
+++ b/Sources/Hackle/Core/User/Local/LocalUserManager.swift
@@ -5,7 +5,7 @@ class LocalUserManager: UserManager, @unchecked Sendable {
 
     private let recursiveLock = RecursiveLock(label: "io.hackle.LocalUserManager")
 
-    private var userListeners: [UserListener]
+    var userListeners: [UserListener]
     private let repository: UserRepository
     private let cohortFetcher: UserCohortFetcher
     private let targetFetcher: UserTargetEventFetcher
@@ -35,11 +35,6 @@ class LocalUserManager: UserManager, @unchecked Sendable {
         self.bundleInfo = bundleInfo
         self.defaultUser = HackleUserBuilder().id(device.id).deviceId(device.id).build()
         self.context = LocalUserContext.of(user: defaultUser, cohorts: UserCohorts.empty(), targetEvents: UserTargetEvents.empty())
-    }
-
-    func addListener(listener: UserListener) {
-        userListeners.append(listener)
-        Log.debug("UserListener added [\(listener)]")
     }
 
     func initialize(user: User?) {
@@ -210,25 +205,11 @@ class LocalUserManager: UserManager, @unchecked Sendable {
         context = newContext
 
         if !newUser.identifierEquals(other: oldUser) {
-            changeUser(oldUser: oldUser, newUser: newUser, timestamp: clock.now())
+            publishUserUpdated(oldUser: oldUser, newUser: newUser, timestamp: clock.now())
         }
 
         saveUser(user: newUser)
         return UserUpdated(old: oldContext, new: newContext)
-    }
-
-    private func changeUser(oldUser: User, newUser: User, timestamp: Date) {
-        Log.debug("UserManager.publishUserUpdated()")
-        for listener in userListeners {
-            listener.onUserUpdated(oldUser: oldUser, newUser: newUser, timestamp: timestamp)
-        }
-    }
-
-    private func publishPropertyOperations(user: User, operations: PropertyOperations, timestamp: Date) {
-        Log.debug("UserManager.publishPropertyOperations()")
-        for listener in userListeners {
-            listener.onPropertyOperations(user: user, operations: operations, timestamp: timestamp)
-        }
     }
 
     private func loadUser() -> User? {

--- a/Sources/Hackle/Core/User/Local/UserCohortFetcher.swift
+++ b/Sources/Hackle/Core/User/Local/UserCohortFetcher.swift
@@ -28,9 +28,9 @@ class DefaultUserCohortFetcher: UserCohortFetcher {
 
     func fetch(user: User) async throws -> UserCohorts {
         let request = try createRequest(user: user)
-        let sample = TimerSample.start()
-        let response = await httpClient.execute(request: request, timeout: timeout)
-        ApiCallMetrics.record(operation: "get.cohorts", sample: sample, response: response)
+        let response = await ApiCallMetrics.record(operation: "get.cohorts") {
+            await self.httpClient.execute(request: request, timeout: self.timeout)
+        }
         return try handleResponse(response: response)
     }
 

--- a/Sources/Hackle/Core/User/Local/UserCohortFetcher.swift
+++ b/Sources/Hackle/Core/User/Local/UserCohortFetcher.swift
@@ -47,23 +47,19 @@ class DefaultUserCohortFetcher: UserCohortFetcher {
         if let error = response.error {
             throw error
         }
-
-        guard let urlResponse = response.urlResponse as? HTTPURLResponse else {
+        // statusCode nil == non-HTTP 응답. "Response is empty" 계약 보존(테스트가 잠금)
+        guard let statusCode = response.statusCode else {
             throw HackleError.error("Response is empty")
         }
-
-        guard urlResponse.isSuccessful else {
-            throw HackleError.error("Http status code: \(urlResponse.statusCode)")
+        guard response.isSuccessful else {
+            throw HackleError.error("Http status code: \(statusCode)")
         }
-
         guard let responseBody = response.data else {
             throw HackleError.error("Response body is empty")
         }
-
         guard let dto = try? JSONDecoder().decode(UserCohortsResponseDto.self, from: responseBody) else {
             throw HackleError.error("Invalid format")
         }
-
         return UserCohorts.from(dto: dto)
     }
 }

--- a/Sources/Hackle/Core/User/Local/UserCohortFetcher.swift
+++ b/Sources/Hackle/Core/User/Local/UserCohortFetcher.swift
@@ -47,7 +47,6 @@ class DefaultUserCohortFetcher: UserCohortFetcher {
         if let error = response.error {
             throw error
         }
-        // statusCode nil == non-HTTP 응답. "Response is empty" 계약 보존(테스트가 잠금)
         guard let statusCode = response.statusCode else {
             throw HackleError.error("Response is empty")
         }

--- a/Sources/Hackle/Core/User/Local/UserTargetEventFetcher.swift
+++ b/Sources/Hackle/Core/User/Local/UserTargetEventFetcher.swift
@@ -47,23 +47,19 @@ class DefaultUserTargetEventFetcher: UserTargetEventFetcher {
         if let error = response.error {
             throw error
         }
-
-        guard let urlResponse = response.urlResponse as? HTTPURLResponse else {
+        // statusCode nil == non-HTTP 응답. "Response is empty" 계약 보존(테스트가 잠금)
+        guard let statusCode = response.statusCode else {
             throw HackleError.error("Response is empty")
         }
-
-        guard urlResponse.isSuccessful else {
-            throw HackleError.error("Http status code: \(urlResponse.statusCode)")
+        guard response.isSuccessful else {
+            throw HackleError.error("Http status code: \(statusCode)")
         }
-
         guard let responseBody = response.data else {
             throw HackleError.error("Response body is empty")
         }
-
         guard let dto = try? JSONDecoder().decode(UserTargetResponseDto.self, from: responseBody) else {
             throw HackleError.error("Invalid format")
         }
-
         return UserTargetEvents.from(dto: dto)
     }
 }

--- a/Sources/Hackle/Core/User/Local/UserTargetEventFetcher.swift
+++ b/Sources/Hackle/Core/User/Local/UserTargetEventFetcher.swift
@@ -28,9 +28,9 @@ class DefaultUserTargetEventFetcher: UserTargetEventFetcher {
 
     func fetch(user: User) async throws -> UserTargetEvents {
         let request = try createRequest(user: user)
-        let sample = TimerSample.start()
-        let response = await httpClient.execute(request: request, timeout: timeout)
-        ApiCallMetrics.record(operation: "get.user-targets", sample: sample, response: response)
+        let response = await ApiCallMetrics.record(operation: "get.user-targets") {
+            await self.httpClient.execute(request: request, timeout: self.timeout)
+        }
         return try handleResponse(response: response)
     }
 

--- a/Sources/Hackle/Core/User/Local/UserTargetEventFetcher.swift
+++ b/Sources/Hackle/Core/User/Local/UserTargetEventFetcher.swift
@@ -47,7 +47,6 @@ class DefaultUserTargetEventFetcher: UserTargetEventFetcher {
         if let error = response.error {
             throw error
         }
-        // statusCode nil == non-HTTP 응답. "Response is empty" 계약 보존(테스트가 잠금)
         guard let statusCode = response.statusCode else {
             throw HackleError.error("Response is empty")
         }

--- a/Sources/Hackle/Core/User/Remote/RemoteUserManager.swift
+++ b/Sources/Hackle/Core/User/Remote/RemoteUserManager.swift
@@ -5,7 +5,7 @@ class RemoteUserManager: UserManager, @unchecked Sendable {
 
     private let recursiveLock = RecursiveLock(label: "io.hackle.RemoteUserManager")
 
-    private var userListeners: [UserListener]
+    var userListeners: [UserListener]
     private let clock: Clock
     private let device: Device
     private let bundleInfo: BundleInfo
@@ -42,11 +42,6 @@ class RemoteUserManager: UserManager, @unchecked Sendable {
         self.evaluationManager = evaluationManager
         self.defaultUser = HackleUserBuilder().deviceId(device.id).build()
         self.context = RemoteUserContext.from(user: defaultUser)
-    }
-
-    func addListener(listener: UserListener) {
-        userListeners.append(listener)
-        Log.debug("UserListener added [\(listener)]")
     }
 
     // Initialize
@@ -153,12 +148,6 @@ class RemoteUserManager: UserManager, @unchecked Sendable {
             }
 
             return UserUpdated(old: old, new: new)
-        }
-    }
-
-    private func publishUserUpdated(oldUser: User, newUser: User, timestamp: Date) {
-        for listener in userListeners {
-            listener.onUserUpdated(oldUser: oldUser, newUser: newUser, timestamp: timestamp)
         }
     }
 

--- a/Sources/Hackle/Core/User/UserManager.swift
+++ b/Sources/Hackle/Core/User/UserManager.swift
@@ -4,6 +4,13 @@ protocol UserManager: Synchronizer, ApplicationLifecycleListener {
 
     var currentUser: User { get }
 
+    // 리스너 저장소. iOS UserManager는 protocol이라 저장 프로퍼티를 못 가지므로
+    // 각 구현체가 이 프로퍼티 1줄만 선언하고, plumbing은 아래 extension이 제공한다.
+    // (android는 ApplicationListenerRegistry<T> base 상속으로 해결)
+    // nonmutating set: class 전용 extension(where Self: AnyObject)에서 append 등으로
+    // 값을 바꾸려면 setter가 self를 mutable로 요구하지 않아야 한다(컴파일러 제약).
+    var userListeners: [UserListener] { get nonmutating set }
+
     func initialize(user: User?)
 
     func hackleUser(user: User, appContext: HackleAppContext) -> HackleUser
@@ -32,5 +39,29 @@ extension UserManager {
 
     func hackleUser(appContext: HackleAppContext) -> HackleUser {
         hackleUser(user: currentUser, appContext: appContext)
+    }
+}
+
+// 리스너 plumbing 공통 구현. userListeners(get set)를 변형하므로 참조 타입 전용.
+// 모든 conformer(Local/Remote UserManager)가 class라 안전하다.
+extension UserManager where Self: AnyObject {
+
+    func addListener(listener: UserListener) {
+        userListeners.append(listener)
+        Log.debug("UserListener added [\(listener)]")
+    }
+
+    func publishUserUpdated(oldUser: User, newUser: User, timestamp: Date) {
+        Log.debug("UserManager.publishUserUpdated()")
+        for listener in userListeners {
+            listener.onUserUpdated(oldUser: oldUser, newUser: newUser, timestamp: timestamp)
+        }
+    }
+
+    func publishPropertyOperations(user: User, operations: PropertyOperations, timestamp: Date) {
+        Log.debug("UserManager.publishPropertyOperations()")
+        for listener in userListeners {
+            listener.onPropertyOperations(user: user, operations: operations, timestamp: timestamp)
+        }
     }
 }

--- a/Sources/Hackle/Core/User/UserManager.swift
+++ b/Sources/Hackle/Core/User/UserManager.swift
@@ -4,11 +4,6 @@ protocol UserManager: Synchronizer, ApplicationLifecycleListener {
 
     var currentUser: User { get }
 
-    // 리스너 저장소. iOS UserManager는 protocol이라 저장 프로퍼티를 못 가지므로
-    // 각 구현체가 이 프로퍼티 1줄만 선언하고, plumbing은 아래 extension이 제공한다.
-    // (android는 ApplicationListenerRegistry<T> base 상속으로 해결)
-    // nonmutating set: class 전용 extension(where Self: AnyObject)에서 append 등으로
-    // 값을 바꾸려면 setter가 self를 mutable로 요구하지 않아야 한다(컴파일러 제약).
     var userListeners: [UserListener] { get nonmutating set }
 
     func initialize(user: User?)
@@ -42,8 +37,6 @@ extension UserManager {
     }
 }
 
-// 리스너 plumbing 공통 구현. userListeners(get set)를 변형하므로 참조 타입 전용.
-// 모든 conformer(Local/Remote UserManager)가 class라 안전하다.
 extension UserManager where Self: AnyObject {
 
     func addListener(listener: UserListener) {
@@ -55,13 +48,6 @@ extension UserManager where Self: AnyObject {
         Log.debug("UserManager.publishUserUpdated()")
         for listener in userListeners {
             listener.onUserUpdated(oldUser: oldUser, newUser: newUser, timestamp: timestamp)
-        }
-    }
-
-    func publishPropertyOperations(user: User, operations: PropertyOperations, timestamp: Date) {
-        Log.debug("UserManager.publishPropertyOperations()")
-        for listener in userListeners {
-            listener.onPropertyOperations(user: user, operations: operations, timestamp: timestamp)
         }
     }
 }

--- a/Sources/Hackle/Core/Workspace/Config/HttpWorkspaceConfigFetcher.swift
+++ b/Sources/Hackle/Core/Workspace/Config/HttpWorkspaceConfigFetcher.swift
@@ -48,7 +48,6 @@ class DefaultHttpWorkspaceConfigFetcher: HttpWorkspaceConfigFetcher {
         if let error = response.error {
             throw error
         }
-        // statusCode nil == non-HTTP 응답. "Response is empty" 계약 보존(테스트가 잠금)
         guard let statusCode = response.statusCode else {
             throw HackleError.error("Response is empty")
         }

--- a/Sources/Hackle/Core/Workspace/Config/HttpWorkspaceConfigFetcher.swift
+++ b/Sources/Hackle/Core/Workspace/Config/HttpWorkspaceConfigFetcher.swift
@@ -38,9 +38,9 @@ class DefaultHttpWorkspaceConfigFetcher: HttpWorkspaceConfigFetcher {
     }
 
     private func execute(request: HttpRequest) async throws -> WorkspaceConfigContext? {
-        let sample = TimerSample.start()
-        let response = await httpClient.execute(request: request)
-        ApiCallMetrics.record(operation: "get.workspace", sample: sample, response: response)
+        let response = await ApiCallMetrics.record(operation: "get.workspace") {
+            await self.httpClient.execute(request: request)
+        }
         return try handleResponse(response: response)
     }
 

--- a/Sources/Hackle/Core/Workspace/Config/HttpWorkspaceConfigFetcher.swift
+++ b/Sources/Hackle/Core/Workspace/Config/HttpWorkspaceConfigFetcher.swift
@@ -48,31 +48,26 @@ class DefaultHttpWorkspaceConfigFetcher: HttpWorkspaceConfigFetcher {
         if let error = response.error {
             throw error
         }
-
-        guard let urlResponse = response.urlResponse as? HTTPURLResponse else {
+        // statusCode nil == non-HTTP 응답. "Response is empty" 계약 보존(테스트가 잠금)
+        guard let statusCode = response.statusCode else {
             throw HackleError.error("Response is empty")
         }
-
-        if urlResponse.isNotModified {
+        if response.isNotModified {
             Log.debug("Workspace is not modified")
             return nil
         }
-
-        guard urlResponse.isSuccessful else {
-            throw HackleError.error("Http status code: \(urlResponse.statusCode)")
+        guard response.isSuccessful else {
+            throw HackleError.error("Http status code: \(statusCode)")
         }
-
         guard let responseBody = response.data else {
             throw HackleError.error("Response body is empty")
         }
-
-        let lastModified = urlResponse.header(.lastModified)
+        // lastModified 헤더는 HttpResponse extension에 접근자가 없어 국소 캐스팅 유지
+        let lastModified = (response.urlResponse as? HTTPURLResponse)?.header(.lastModified)
         guard let workspaceDto = try? JSONDecoder().decode(WorkspaceConfigDto.self, from: responseBody) else {
             throw HackleError.error("Invalid format")
         }
-
         Log.debug("Workspace fetched")
-
         return WorkspaceConfigContext.of(dto: workspaceDto, modifiedAt: lastModified)
     }
 }

--- a/Sources/Hackle/Core/Workspace/Evaluation/Client/RemoteEvaluateClient.swift
+++ b/Sources/Hackle/Core/Workspace/Evaluation/Client/RemoteEvaluateClient.swift
@@ -30,10 +30,9 @@ class RemoteEvaluateClient {
             throw HackleError.error("Failed to serialize \(operation) request")
         }
         let httpRequest = HttpRequest.post(url: url, body: data)
-        let sample = TimerSample.start()
-        let response = await httpClient.execute(request: httpRequest)
-        ApiCallMetrics.record(operation: operation, sample: sample, response: response)
-        return response
+        return await ApiCallMetrics.record(operation: operation) {
+            await self.httpClient.execute(request: httpRequest)
+        }
     }
 
     private func handleWorkspaceResponse(response: HttpResponse) throws -> WorkspaceEvaluateResponseDto? {

--- a/Tests/HackleTests/Core/User/Local/DefaultUserCohortFetcherSpecs.swift
+++ b/Tests/HackleTests/Core/User/Local/DefaultUserCohortFetcherSpecs.swift
@@ -113,6 +113,29 @@ class DefaultUserCohortFetcherSpecs: AsyncSpec {
             expect(request.headers?["X-HACKLE-USER"]).toNot(beNil())
         }
 
+        it("api.call 메트릭을 기록한다") {
+            // given
+            Metrics.clear()
+            let cumulative = CumulativeMetricRegistry()
+            Metrics.addRegistry(registry: cumulative)
+            let json = try! String(contentsOfFile: Bundle(for: DefaultUserCohortFetcherSpecs.self).path(forResource: "workspace_cohorts", ofType: "json")!)
+            every(httpClient.executeMock).answers { request, completion in
+                completion(response(statusCode: 200, data: json.data(using: .utf8)))
+            }
+
+            // when
+            await awaitCompletion { _ = try await sut.fetch(user: User.builder().id("42").build()) }
+
+            // then
+            let timer = Metrics.timer(name: "api.call", tags: [
+                "operation": "get.cohorts",
+                "success": "true",
+                "status": "200",
+                "exception": "NONE"
+            ])
+            expect(timer.count()) == 1
+        }
+
         func response(statusCode: Int, data: Data? = nil, error: Error? = nil) -> HttpResponse {
             let url = URL(string: "localhost")!
 

--- a/Tests/HackleTests/Core/User/MockUserManager.swift
+++ b/Tests/HackleTests/Core/User/MockUserManager.swift
@@ -7,6 +7,7 @@ class MockUserManager: Mock, UserManager, @unchecked Sendable {
 
     var currentUser: User
     var lastHackleAppContext: HackleAppContext? = nil
+    var userListeners: [UserListener] = []
 
     init(currentUser: User = HackleUserBuilder().build()) {
         self.currentUser = currentUser


### PR DESCRIPTION
## 개요
HTTP 응답 처리와 `api.call` 메트릭 기록 방식을 공통 유틸리티 기준으로 정리했습니다.
UserManager 리스너 등록 및 사용자 변경 이벤트 발행 로직을 protocol extension으로 통합했습니다.

## 주요 변경사항
| 카테고리 | 내용 |
|----------|------|
| HTTP 응답 처리 | `HttpResponse.statusCode`, `isSuccessful`, `isNotModified` 접근자를 사용하도록 fetcher/dispatcher 응답 처리 정리 |
| API 메트릭 | `ApiCallMetrics.record(operation:_:)` async HOF를 추가해 호출 시간 측정과 메트릭 기록을 공통화 |
| UserManager | `userListeners`를 protocol 요구사항으로 올리고 `addListener`, `publishUserUpdated` 공통 구현 추가 |
