### PR TITLE
refactor: Swift 6 Concurrency Compatibility

### DIFF
--- a/Sources/Hackle/Core/Application/Lifecycle/ApplicationLifecycleManager.swift
+++ b/Sources/Hackle/Core/Application/Lifecycle/ApplicationLifecycleManager.swift
@@ -86,7 +86,7 @@ class DefaultApplicationLifecycleManager: ApplicationLifecycleManager, Applicati
         }
     }
     
-    private func execute(_ action: @escaping () -> Void) {
+    private func execute(_ action: @escaping @Sendable () -> Void) {
         if let queue = queue {
             queue.async(execute: action)
         } else {

--- a/Sources/Hackle/Core/Event/UserEvent.swift
+++ b/Sources/Hackle/Core/Event/UserEvent.swift
@@ -2,7 +2,7 @@
 
 import Foundation
 
-protocol UserEvent {
+protocol UserEvent: Sendable {
     var insertId: String { get }
     var type: UserEventType { get }
     var timestamp: Date { get }

--- a/Sources/Hackle/Core/Event/UserEventDispatcher.swift
+++ b/Sources/Hackle/Core/Event/UserEventDispatcher.swift
@@ -8,7 +8,7 @@ protocol UserEventDispatcher {
     func dispatch(events: [EventEntity])
 }
 
-// 저장 프로퍼티가 모두 let(불변)이라 thread-safe. DB 작업은 eventQueue로 직렬화된다.
+// 저장 프로퍼티가 모두 let(불변)이라 thread-safe.
 final class DefaultUserEventDispatcher: UserEventDispatcher, @unchecked Sendable {
     private let endpoint: URL
     private let eventQueue: DispatchQueue

--- a/Sources/Hackle/Core/Event/UserEventDispatcher.swift
+++ b/Sources/Hackle/Core/Event/UserEventDispatcher.swift
@@ -8,7 +8,9 @@ protocol UserEventDispatcher {
     func dispatch(events: [EventEntity])
 }
 
-class DefaultUserEventDispatcher: UserEventDispatcher {
+// 모든 저장 프로퍼티가 let(불변)이고, DB 접근은 eventQueue, 네트워크 응답 처리는
+// httpQueue로 직렬화되어 thread-safe.
+final class DefaultUserEventDispatcher: UserEventDispatcher, @unchecked Sendable {
     private let endpoint: URL
     private let eventQueue: DispatchQueue
     private let eventRepository: EventRepository

--- a/Sources/Hackle/Core/Event/UserEventDispatcher.swift
+++ b/Sources/Hackle/Core/Event/UserEventDispatcher.swift
@@ -8,8 +8,7 @@ protocol UserEventDispatcher {
     func dispatch(events: [EventEntity])
 }
 
-// 모든 저장 프로퍼티가 let(불변)이고, DB 접근은 eventQueue, 네트워크 응답 처리는
-// httpQueue로 직렬화되어 thread-safe.
+// 저장 프로퍼티가 모두 let(불변)이라 thread-safe. DB 작업은 eventQueue로 직렬화된다.
 final class DefaultUserEventDispatcher: UserEventDispatcher, @unchecked Sendable {
     private let endpoint: URL
     private let eventQueue: DispatchQueue

--- a/Sources/Hackle/Core/Event/UserEventProcessor.swift
+++ b/Sources/Hackle/Core/Event/UserEventProcessor.swift
@@ -21,8 +21,7 @@ extension UserEventProcessor {
     }
 }
 
-// flushingJob은 ReadWriteLock(lock)으로 보호되고 나머지 저장 프로퍼티는 let(불변).
-// 이벤트 처리는 eventQueue로 직렬화된다. (테스트 서브클래스 OnNotifiedSpy가 있어 final 미지정)
+// flushingJob은 lock(ReadWriteLock)으로 보호되고 나머지 저장 프로퍼티는 let(불변)이라 thread-safe.
 class DefaultUserEventProcessor: UserEventProcessor, ApplicationLifecycleListener, OptOutListener, @unchecked Sendable {
 
     private let lock: ReadWriteLock = ReadWriteLock(label: "io.hackle.DefaultUserEventProcessor.Lock")

--- a/Sources/Hackle/Core/Event/UserEventProcessor.swift
+++ b/Sources/Hackle/Core/Event/UserEventProcessor.swift
@@ -21,7 +21,9 @@ extension UserEventProcessor {
     }
 }
 
-class DefaultUserEventProcessor: UserEventProcessor, ApplicationLifecycleListener, OptOutListener {
+// flushingJob은 ReadWriteLock(lock)으로 보호되고 나머지 저장 프로퍼티는 let(불변).
+// 이벤트 처리는 eventQueue로 직렬화된다. (테스트 서브클래스 OnNotifiedSpy가 있어 final 미지정)
+class DefaultUserEventProcessor: UserEventProcessor, ApplicationLifecycleListener, OptOutListener, @unchecked Sendable {
 
     private let lock: ReadWriteLock = ReadWriteLock(label: "io.hackle.DefaultUserEventProcessor.Lock")
 

--- a/Sources/Hackle/Core/Http/HttpClient.swift
+++ b/Sources/Hackle/Core/Http/HttpClient.swift
@@ -5,8 +5,8 @@
 import Foundation
 
 protocol HttpClient {
-    func execute(request: HttpRequest, completion: @escaping (HttpResponse) -> Void)
-    func execute(request: HttpRequest, timeout: TimeInterval, completion: @escaping (HttpResponse) -> Void)
+    func execute(request: HttpRequest, completion: @escaping @Sendable (HttpResponse) -> Void)
+    func execute(request: HttpRequest, timeout: TimeInterval, completion: @escaping @Sendable (HttpResponse) -> Void)
 }
 
 extension HttpClient {
@@ -18,7 +18,7 @@ extension HttpClient {
     ///   answer가 반드시 completion을 1회 호출해야 한다.
     func execute(request: HttpRequest, timeout: TimeInterval? = nil) async -> HttpResponse {
         await withCheckedContinuation { continuation in
-            let completion: (HttpResponse) -> Void = { response in
+            let completion: @Sendable (HttpResponse) -> Void = { response in
                 continuation.resume(returning: response)
             }
             if let timeout {
@@ -43,11 +43,11 @@ class DefaultHttpClient: HttpClient {
         self.session = URLSession(configuration: configuration)
     }
 
-    func execute(request: HttpRequest, completion: @escaping (HttpResponse) -> Void) {
+    func execute(request: HttpRequest, completion: @escaping @Sendable (HttpResponse) -> Void) {
         execute(request: request, timeout: session.configuration.timeoutIntervalForRequest, completion: completion)
     }
-    
-    func execute(request: HttpRequest, timeout: TimeInterval, completion: @escaping (HttpResponse) -> Void) {
+
+    func execute(request: HttpRequest, timeout: TimeInterval, completion: @escaping @Sendable (HttpResponse) -> Void) {
         var req = URLRequest(url: request.url)
         req.httpMethod = request.method
         req.httpBody = request.body

--- a/Sources/Hackle/Core/InAppMessage/Schedule/Scheduler/DelayedInAppMessageScheduler.swift
+++ b/Sources/Hackle/Core/InAppMessage/Schedule/Scheduler/DelayedInAppMessageScheduler.swift
@@ -15,7 +15,7 @@ class DelayedInAppMessageScheduler: InAppMessageScheduler {
     }
 
     func deliver(request: InAppMessageScheduleRequest) async throws -> InAppMessageScheduleResponse {
-        guard let delay = delayManager.delete(request: request) else {
+        guard delayManager.delete(request: request) != nil else {
             throw HackleError.error("InAppMessageDelay not found (inAppMessageKey: \(request.schedule.inAppMessageKey))")
         }
 
@@ -25,7 +25,7 @@ class DelayedInAppMessageScheduler: InAppMessageScheduler {
     }
 
     func delay(request: InAppMessageScheduleRequest) async throws -> InAppMessageScheduleResponse {
-        let delay = try delayManager.delay(request: request)
+        let delay = delayManager.delay(request: request)
         return InAppMessageScheduleResponse.of(request: request, code: .delay, delay: delay)
     }
 

--- a/Sources/Hackle/Core/Metrics/Timer.swift
+++ b/Sources/Hackle/Core/Metrics/Timer.swift
@@ -64,7 +64,8 @@ class TimerBuilder {
     }
 }
 
-class TimerSample {
+// clock, startTick 모두 let(불변)이므로 thread-safe.
+final class TimerSample: @unchecked Sendable {
 
     private let clock: Clock
     private let startTick: UInt64

--- a/Sources/Hackle/Core/View/Lifecycle/ViewLifecycleManager.swift
+++ b/Sources/Hackle/Core/View/Lifecycle/ViewLifecycleManager.swift
@@ -70,7 +70,7 @@ class ViewLifecycleManager: ViewLifecyclePublisher, @unchecked Sendable {
         }
     }
     
-    private func execute(_ action: @escaping () -> Void) {
+    private func execute(_ action: @escaping @Sendable () -> Void) {
         if let queue = queue {
             queue.async(execute: action)
         } else {

--- a/Sources/Hackle/Hackle+Notification.swift
+++ b/Sources/Hackle/Hackle+Notification.swift
@@ -95,10 +95,10 @@ extension Hackle {
         notificationContent: UNMutableNotificationContent,
         contentHandler: @escaping (UNNotificationContent) -> Void
     ) -> Bool {
-        guard let notificationData = NotificationData.from(data: notificationContent.userInfo) else {
+        guard NotificationData.from(data: notificationContent.userInfo) != nil else {
             return false
         }
-        
+
         return resolveRichNotificationContent(notificationContent: notificationContent, completion: { hackleNotificationContent in
             contentHandler(hackleNotificationContent)
         })

--- a/Sources/Hackle/UI/InAppMessageUI/Views/Html/InAppMessageHtmlContentResolver.swift
+++ b/Sources/Hackle/UI/InAppMessageUI/Views/Html/InAppMessageHtmlContentResolver.swift
@@ -2,7 +2,7 @@ import Foundation
 
 protocol InAppMessageHtmlContentResolver {
     func supports(resourceType: InAppMessage.HtmlResourceType) -> Bool
-    func resolve(html: InAppMessage.Message.Html, completion: @escaping (Result<String, Error>) -> Void)
+    func resolve(html: InAppMessage.Message.Html, completion: @escaping @Sendable (Result<String, Error>) -> Void)
 }
 
 class TextInAppMessageHtmlContentResolver: InAppMessageHtmlContentResolver {
@@ -10,7 +10,7 @@ class TextInAppMessageHtmlContentResolver: InAppMessageHtmlContentResolver {
         return resourceType == .text
     }
 
-    func resolve(html: InAppMessage.Message.Html, completion: @escaping (Result<String, Error>) -> Void) {
+    func resolve(html: InAppMessage.Message.Html, completion: @escaping @Sendable (Result<String, Error>) -> Void) {
         guard let content = html.text else {
             completion(.failure(HackleError.error("Html text is nil")))
             return
@@ -19,7 +19,9 @@ class TextInAppMessageHtmlContentResolver: InAppMessageHtmlContentResolver {
     }
 }
 
-class PathInAppMessageHtmlContentResolver: InAppMessageHtmlContentResolver {
+// 저장 프로퍼티가 httpClient(let) 하나뿐이고 그 외 상태가 없다(stateless).
+// resolve의 [weak self] 캡처를 @Sendable 경계에서 허용하기 위한 표기.
+final class PathInAppMessageHtmlContentResolver: InAppMessageHtmlContentResolver, @unchecked Sendable {
     private let httpClient: HttpClient
 
     init(httpClient: HttpClient) {
@@ -32,7 +34,7 @@ class PathInAppMessageHtmlContentResolver: InAppMessageHtmlContentResolver {
         resourceType == .path
     }
 
-    func resolve(html: InAppMessage.Message.Html, completion: @escaping (Result<String, Error>) -> Void) {
+    func resolve(html: InAppMessage.Message.Html, completion: @escaping @Sendable (Result<String, Error>) -> Void) {
         guard let path = html.path, let url = URL(string: path) else {
             completion(.failure(HackleError.error("Html path is nil or invalid")))
             return

--- a/Sources/Hackle/UI/InAppMessageUI/Views/Html/InAppMessageHtmlContentResolver.swift
+++ b/Sources/Hackle/UI/InAppMessageUI/Views/Html/InAppMessageHtmlContentResolver.swift
@@ -19,8 +19,7 @@ class TextInAppMessageHtmlContentResolver: InAppMessageHtmlContentResolver {
     }
 }
 
-// 저장 프로퍼티가 httpClient(let) 하나뿐이고 그 외 상태가 없다(stateless).
-// resolve의 [weak self] 캡처를 @Sendable 경계에서 허용하기 위한 표기.
+// 저장 프로퍼티가 httpClient(let) 하나뿐이라 thread-safe(stateless).
 final class PathInAppMessageHtmlContentResolver: InAppMessageHtmlContentResolver, @unchecked Sendable {
     private let httpClient: HttpClient
 

--- a/Sources/Hackle/UI/Internal/WebViewUserScript.swift
+++ b/Sources/Hackle/UI/Internal/WebViewUserScript.swift
@@ -31,7 +31,7 @@ extension WKWebView {
     }
 
     /// Evaluates the script on the current page.
-    func evaluate(script: WebViewUserScript, completion: ((Any?, Error?) -> Void)? = nil) {
+    func evaluate(script: WebViewUserScript, completion: (@MainActor @Sendable (Any?, Error?) -> Void)? = nil) {
         evaluateJavaScript(script.source, completionHandler: completion)
     }
 }

--- a/Sources/Hackle/UI/Notification/NotificationDataReceiver.swift
+++ b/Sources/Hackle/UI/Notification/NotificationDataReceiver.swift
@@ -4,7 +4,8 @@ protocol NotificationDataReceiver {
     func onNotificationDataReceived(data: NotificationData, timestamp: Date)
 }
 
-class DefaultNotificationDataReceiver: NotificationDataReceiver {
+// 저장 프로퍼티가 모두 let(불변)이고, 저장 작업은 dispatchQueue로 직렬화되어 thread-safe.
+final class DefaultNotificationDataReceiver: NotificationDataReceiver, @unchecked Sendable {
     let dispatchQueue: DispatchQueue
     let repository: NotificationRepository
     

--- a/Sources/Hackle/UI/Notification/NotificationDataReceiver.swift
+++ b/Sources/Hackle/UI/Notification/NotificationDataReceiver.swift
@@ -4,7 +4,7 @@ protocol NotificationDataReceiver {
     func onNotificationDataReceived(data: NotificationData, timestamp: Date)
 }
 
-// 저장 프로퍼티가 모두 let(불변)이고, 저장 작업은 dispatchQueue로 직렬화되어 thread-safe.
+// 저장 프로퍼티가 모두 let(불변)이라 thread-safe.
 final class DefaultNotificationDataReceiver: NotificationDataReceiver, @unchecked Sendable {
     let dispatchQueue: DispatchQueue
     let repository: NotificationRepository

--- a/Sources/Hackle/UI/Notification/NotificationHandler.swift
+++ b/Sources/Hackle/UI/Notification/NotificationHandler.swift
@@ -85,12 +85,16 @@ extension NotificationHandler {
         }
 
         if let url = URL(string: imageUrl) {
+            // URLSession의 completionHandler는 @Sendable이라 non-Sendable `completion`을
+            // 직접 캡처할 수 없다. completion은 정확히 1회만 호출되고 공유 가변 상태가 없으므로
+            // @unchecked Sendable 박스로 세탁해 경계를 안전하게 넘긴다.
+            let sink = UncheckedSendableBox(completion)
             URLSession.shared.downloadTask(with: url) { (location, response, error) in
                 guard let response = response,
                       let location = location,
                       error == nil else {
                     Log.info("Push Image download error: \(error?.localizedDescription ?? "")")
-                    completion(nil)
+                    sink.value(nil)
                     return
                 }
 
@@ -99,7 +103,7 @@ extension NotificationHandler {
                       let fileExtension = MimeType.preferredFileExtension(mimeType: mimeType)
                 else {
                     Log.info("Image type check error: \(response.mimeType ?? "")")
-                    completion(nil)
+                    sink.value(nil)
                     return
                 }
 
@@ -107,10 +111,10 @@ extension NotificationHandler {
                     let destinationURL = location.appendingPathExtension(fileExtension)
                     try FileManager.default.moveItem(at: location, to: destinationURL)
                     // NOTE: 이미지 저장 된 url을 리턴
-                    completion(destinationURL)
+                    sink.value(destinationURL)
                 } catch {
                     Log.info("Image rename error")
-                    completion(nil)
+                    sink.value(nil)
                 }
             }.resume()
         } else {
@@ -118,4 +122,11 @@ extension NotificationHandler {
             completion(nil)
         }
     }
+}
+
+/// non-Sendable 값을 `@Sendable` 클로저 경계 너머로 손으로 나른다.
+/// 값이 정확히 1회 넘겨지고 동시 접근이 없는 경우에만 안전하다.
+private final class UncheckedSendableBox<T>: @unchecked Sendable {
+    let value: T
+    init(_ value: T) { self.value = value }
 }

--- a/Sources/Hackle/UI/Notification/NotificationHandler.swift
+++ b/Sources/Hackle/UI/Notification/NotificationHandler.swift
@@ -85,9 +85,6 @@ extension NotificationHandler {
         }
 
         if let url = URL(string: imageUrl) {
-            // URLSession의 completionHandler는 @Sendable이라 non-Sendable `completion`을
-            // 직접 캡처할 수 없다. completion은 정확히 1회만 호출되고 공유 가변 상태가 없으므로
-            // @unchecked Sendable 박스로 세탁해 경계를 안전하게 넘긴다.
             let sink = UncheckedSendableBox(completion)
             URLSession.shared.downloadTask(with: url) { (location, response, error) in
                 guard let response = response,

--- a/Tests/HackleTests/Core/Workspace/DefaultHttpWorkspaceConfigFetcherSpecs.swift
+++ b/Tests/HackleTests/Core/Workspace/DefaultHttpWorkspaceConfigFetcherSpecs.swift
@@ -185,7 +185,7 @@ private class HttpClientStub: HttpClient {
         self.error = error
     }
 
-    func execute(request: HttpRequest, completion: @escaping (HttpResponse) -> ()) {
+    func execute(request: HttpRequest, completion: @escaping @Sendable (HttpResponse) -> ()) {
         var urlResponse: HTTPURLResponse? = nil
         if let statusCode {
             urlResponse = HTTPURLResponse(url: request.url, statusCode: statusCode, httpVersion: nil, headerFields: nil)
@@ -194,7 +194,7 @@ private class HttpClientStub: HttpClient {
         completion(response)
     }
 
-    func execute(request: HttpRequest, timeout: TimeInterval, completion: @escaping (HttpResponse) -> Void) {
+    func execute(request: HttpRequest, timeout: TimeInterval, completion: @escaping @Sendable (HttpResponse) -> Void) {
         execute(request: request, completion: completion)
     }
 }

--- a/Tests/HackleTests/Mock/MockHttpClient.swift
+++ b/Tests/HackleTests/Mock/MockHttpClient.swift
@@ -7,14 +7,14 @@ import MockingKit
 @testable import Hackle
 
 class MockHttpClient: Mock, HttpClient {
-    lazy var executeMock = MockFunction(self, execute as (HttpRequest, @escaping (HttpResponse) -> ()) -> Void)
+    lazy var executeMock = MockFunction(self, execute as (HttpRequest, @escaping @Sendable (HttpResponse) -> ()) -> Void)
 
-    func execute(request: HttpRequest, completion: @escaping (HttpResponse) -> ()) {
+    func execute(request: HttpRequest, completion: @escaping @Sendable (HttpResponse) -> ()) {
         call(executeMock, args: (request, completion))
     }
-    
-    func execute(request: HttpRequest, timeout: TimeInterval, completion: @escaping (HttpResponse) -> Void) {
+
+    func execute(request: HttpRequest, timeout: TimeInterval, completion: @escaping @Sendable (HttpResponse) -> Void) {
         call(executeMock, args: (request, completion))
     }
-    
+
 }

--- a/Tests/HackleTests/Mock/MockUserEvent.swift
+++ b/Tests/HackleTests/Mock/MockUserEvent.swift
@@ -5,7 +5,6 @@
 import Foundation
 @testable import Hackle
 
-// 테스트 더블 — UserEvent: Sendable 상속을 맞추기 위한 표기.
 class MockUserEvent: UserEvent, @unchecked Sendable {
     var insertId: String
     var type: UserEventType

--- a/Tests/HackleTests/Mock/MockUserEvent.swift
+++ b/Tests/HackleTests/Mock/MockUserEvent.swift
@@ -5,7 +5,8 @@
 import Foundation
 @testable import Hackle
 
-class MockUserEvent: UserEvent {
+// 테스트 더블 — UserEvent: Sendable 상속을 맞추기 위한 표기.
+class MockUserEvent: UserEvent, @unchecked Sendable {
     var insertId: String
     var type: UserEventType
     var user: HackleUser


### PR DESCRIPTION
## 개요
Swift 6 concurrency 경고/오류를 줄이기 위해 내부 타입과 비동기 콜백 경계를 정리했습니다.
Sendable 요구가 필요한 내부 프로토콜, completion, serial queue 기반 매니저에 concurrency annotation을 보강했습니다.

## 주요 변경사항
| 카테고리 | 내용 |
|----------|------|
| Sendable 적용 | `UserEvent`, `TimerSample`, 이벤트/알림 처리 타입에 Sendable conformance 추가 |
| Completion 경계 | `HttpClient`, HTML resolver, WebView script evaluation, lifecycle execute closure에 `@Sendable` 또는 `@MainActor` 적용 |
| Notification 처리 | 이미지 다운로드 completion을 `UncheckedSendableBox`로 감싸 Sendable closure 경계를 명시 |
| 정리 | 미사용 바인딩과 불필요한 `try` 제거, 테스트 mock signature 동기화 |