### PR TITLE
feat: support remote evaluation experiment status

### DIFF
--- a/Sources/Hackle/Core/Evaluation/Mode/Remote/RemoteEvaluateRequest.swift
+++ b/Sources/Hackle/Core/Evaluation/Mode/Remote/RemoteEvaluateRequest.swift
@@ -2,7 +2,7 @@ import Foundation
 
 protocol RemoteEvaluateRequest: EvaluateRequest {
     var evaluationWorkspace: WorkspaceEvaluation { get }
-    var remoteResult: RemoteEvaluateResult { get }
+    var remoteResult: any RemoteEvaluateResult { get }
 }
 
 extension RemoteEvaluateRequest {

--- a/Sources/Hackle/Core/Evaluation/Service/Experiment/Mode/Remote/ExperimentRemoteEvaluateRequest.swift
+++ b/Sources/Hackle/Core/Evaluation/Service/Experiment/Mode/Remote/ExperimentRemoteEvaluateRequest.swift
@@ -7,7 +7,7 @@ final class ExperimentRemoteEvaluateRequest: RemoteEvaluateRequest, ExperimentEv
     let user: HackleUser
     let record: Bool
 
-    var remoteResult: RemoteEvaluateResult { result }
+    var remoteResult: any RemoteEvaluateResult { result }
     var experiment: Experiment { result }
 
     private init(workspace: WorkspaceEvaluation, entity: ExperimentRemoteEvaluateResult, user: HackleUser, record: Bool) {

--- a/Sources/Hackle/Core/Evaluation/Service/InAppMessage/Eligibility/Mode/Remote/InAppMessageEligibilityRemoteEvaluateRequest.swift
+++ b/Sources/Hackle/Core/Evaluation/Service/InAppMessage/Eligibility/Mode/Remote/InAppMessageEligibilityRemoteEvaluateRequest.swift
@@ -10,7 +10,7 @@ final class InAppMessageEligibilityRemoteEvaluateRequest: RemoteEvaluateRequest,
     let platformType: PlatformType?
     let timestamp: Date
 
-    var remoteResult: RemoteEvaluateResult { result }
+    var remoteResult: any RemoteEvaluateResult { result }
     var inAppMessage: InAppMessage { result }
 
     private init(

--- a/Sources/Hackle/Core/Evaluation/Service/InAppMessage/Layout/Mode/Remote/InAppMessageLayoutRemoteEvaluateRequest.swift
+++ b/Sources/Hackle/Core/Evaluation/Service/InAppMessage/Layout/Mode/Remote/InAppMessageLayoutRemoteEvaluateRequest.swift
@@ -8,7 +8,7 @@ final class InAppMessageLayoutRemoteEvaluateRequest: RemoteEvaluateRequest, InAp
     let scope: InAppMessageEvaluateScope
     let record: Bool
 
-    var remoteResult: RemoteEvaluateResult { result }
+    var remoteResult: any RemoteEvaluateResult { result }
     var inAppMessage: InAppMessage { result }
 
     private init(

--- a/Sources/Hackle/Core/Evaluation/Service/RemoteConfig/Mode/Remote/RemoteConfigRemoteEvaluateRequest.swift
+++ b/Sources/Hackle/Core/Evaluation/Service/RemoteConfig/Mode/Remote/RemoteConfigRemoteEvaluateRequest.swift
@@ -8,7 +8,7 @@ final class RemoteConfigRemoteEvaluateRequest: RemoteEvaluateRequest, RemoteConf
     let record: Bool
     let requiredType: HackleValueType
 
-    var remoteResult: RemoteEvaluateResult { result }
+    var remoteResult: any RemoteEvaluateResult { result }
     var parameter: RemoteConfigParameter { result }
 
     private init(

--- a/Sources/Hackle/Core/Model/Experiment.swift
+++ b/Sources/Hackle/Core/Model/Experiment.swift
@@ -9,6 +9,7 @@ protocol Experiment: Entity, Sendable {
     var id: Id { get }
     var key: Key { get }
     var version: Int { get }
+    var status: ExperimentStatus { get }
     var order: Int64 { get }
     var type: ExperimentType { get }
     var executionVersion: Int { get }

--- a/Sources/Hackle/Core/Model/Experiment.swift
+++ b/Sources/Hackle/Core/Model/Experiment.swift
@@ -36,6 +36,22 @@ enum ExperimentStatus: String {
     case running
     case paused
     case completed
+
+    static func from(executionStatus: String) -> ExperimentStatus? {
+        switch executionStatus {
+        case "READY":
+            return .draft
+        case "RUNNING":
+            return .running
+        case "PAUSED":
+            return .paused
+        case "STOPPED":
+            return .completed
+        default:
+            Log.debug("Unsupported experiment status [\(executionStatus)]")
+            return nil
+        }
+    }
 }
 
 final class ExperimentEntity: Experiment, Sendable {

--- a/Sources/Hackle/Core/Workspace/Config/Entity/ExperimentConfig.swift
+++ b/Sources/Hackle/Core/Workspace/Config/Entity/ExperimentConfig.swift
@@ -3,7 +3,6 @@ import Foundation
 protocol ExperimentConfig: Experiment, ConfigEntity {
     var name: String? { get }
     var identifierType: String { get }
-    var status: ExperimentStatus { get }
     var variations: [Variation] { get }
     var userOverrides: [User.Id: Variation.Id] { get }
     var segmentOverrides: [TargetRule] { get }

--- a/Sources/Hackle/Core/Workspace/Config/WorkspaceConfigs.swift
+++ b/Sources/Hackle/Core/Workspace/Config/WorkspaceConfigs.swift
@@ -480,7 +480,7 @@ extension VariationDto {
 
 extension ExperimentDto {
     func toExperimentOrNil(type: ExperimentType, parameterConfigurations: [ParameterConfiguration.Id: ParameterConfiguration]) -> Experiment? {
-        guard let experimentStatus = ExperimentDto.experimentStatusOrNil(executionStatus: execution.status) else {
+        guard let experimentStatus = ExperimentStatus.from(executionStatus: execution.status) else {
             return nil
         }
 
@@ -526,22 +526,6 @@ extension ExperimentDto {
             containerId: containerId,
             winnerVariationId: winnerVariationId
         )
-    }
-
-    static func experimentStatusOrNil(executionStatus: String) -> ExperimentStatus? {
-        switch executionStatus {
-        case "READY":
-            return .draft
-        case "RUNNING":
-            return .running
-        case "PAUSED":
-            return .paused
-        case "STOPPED":
-            return .completed
-        default:
-            Log.debug("Unsupported experiment status [\(executionStatus)]")
-            return nil
-        }
     }
 }
 

--- a/Sources/Hackle/Core/Workspace/Evaluation/DefaultWorkspaceEvaluation.swift
+++ b/Sources/Hackle/Core/Workspace/Evaluation/DefaultWorkspaceEvaluation.swift
@@ -124,11 +124,11 @@ final class DefaultWorkspaceEvaluation: WorkspaceEvaluation, @unchecked Sendable
             }
             switch serviceType {
             case .abTest:
-                if let it = result.experiment?.toResult(type: .abTest) {
+                if let it = result.experiment?.toResultOrNil(type: .abTest) {
                     experiments.append(it)
                 }
             case .featureFlag:
-                if let it = result.featureFlag?.toResult(type: .featureFlag) {
+                if let it = result.featureFlag?.toResultOrNil(type: .featureFlag) {
                     featureFlags.append(it)
                 }
             case .remoteConfig:

--- a/Sources/Hackle/Core/Workspace/Evaluation/DefaultWorkspaceEvaluation.swift
+++ b/Sources/Hackle/Core/Workspace/Evaluation/DefaultWorkspaceEvaluation.swift
@@ -74,8 +74,8 @@ final class DefaultWorkspaceEvaluation: WorkspaceEvaluation, @unchecked Sendable
         _inAppMessages[inAppMessageKey]
     }
 
-    func result(entity: Entity) -> RemoteEvaluateResult? {
-        let results: [RemoteEvaluateResult]
+    func result(entity: Entity) -> (any RemoteEvaluateResult)? {
+        let results: [any RemoteEvaluateResult]
         switch entity.serviceType {
         case .abTest:
             results = experimentResults

--- a/Sources/Hackle/Core/Workspace/Evaluation/Entity/ExperimentRemoteEvaluateResult.swift
+++ b/Sources/Hackle/Core/Workspace/Evaluation/Entity/ExperimentRemoteEvaluateResult.swift
@@ -5,6 +5,7 @@ final class ExperimentRemoteEvaluateResult: ExperimentEvaluateResult, Experiment
     let id: Experiment.Id
     let key: Experiment.Key
     let version: Int
+    let status: ExperimentStatus
     let order: Int64
     let type: ExperimentType
     let executionVersion: Int
@@ -14,6 +15,7 @@ final class ExperimentRemoteEvaluateResult: ExperimentEvaluateResult, Experiment
         id: Experiment.Id,
         key: Experiment.Key,
         version: Int,
+        status: ExperimentStatus,
         order: Int64,
         type: ExperimentType,
         executionVersion: Int,
@@ -24,6 +26,7 @@ final class ExperimentRemoteEvaluateResult: ExperimentEvaluateResult, Experiment
         self.id = id
         self.key = key
         self.version = version
+        self.status = status
         self.order = order
         self.type = type
         self.executionVersion = executionVersion
@@ -36,6 +39,6 @@ final class ExperimentRemoteEvaluateResult: ExperimentEvaluateResult, Experiment
     }
 
     override var description: String {
-        "ExperimentRemoteEvaluateResult(id=\(id), key=\(key), type=\(type), version=\(version), variation=\(variation), reason=\(reason))"
+        "ExperimentRemoteEvaluateResult(id=\(id), key=\(key), type=\(type), version=\(version), status=\(status), variation=\(variation), reason=\(reason))"
     }
 }

--- a/Sources/Hackle/Core/Workspace/Evaluation/Entity/ExperimentRemoteEvaluateResult.swift
+++ b/Sources/Hackle/Core/Workspace/Evaluation/Entity/ExperimentRemoteEvaluateResult.swift
@@ -34,7 +34,7 @@ final class ExperimentRemoteEvaluateResult: ExperimentEvaluateResult, Experiment
         super.init(reason: reason, variation: variation)
     }
 
-    func toEvaluation() -> Evaluation {
+    func toEvaluation() -> ExperimentEvaluation {
         ExperimentEvaluation(entity: self, result: self)
     }
 

--- a/Sources/Hackle/Core/Workspace/Evaluation/Entity/InAppMessageEligibilityRemoteEvaluateResult.swift
+++ b/Sources/Hackle/Core/Workspace/Evaluation/Entity/InAppMessageEligibilityRemoteEvaluateResult.swift
@@ -40,7 +40,7 @@ final class InAppMessageEligibilityRemoteEvaluateResult: InAppMessageEligibility
         super.init(reason: reason, isEligible: isEligible)
     }
 
-    func toEvaluation() -> Evaluation {
+    func toEvaluation() -> InAppMessageEligibilityEvaluation {
         InAppMessageEligibilityEvaluation(entity: self, result: self)
     }
 }

--- a/Sources/Hackle/Core/Workspace/Evaluation/Entity/InAppMessageLayoutRemoteEvaluateResult.swift
+++ b/Sources/Hackle/Core/Workspace/Evaluation/Entity/InAppMessageLayoutRemoteEvaluateResult.swift
@@ -37,7 +37,7 @@ final class InAppMessageLayoutRemoteEvaluateResult: InAppMessageLayoutEvaluateRe
         super.init(reason: reason, message: message)
     }
 
-    func toEvaluation() -> Evaluation {
+    func toEvaluation() -> InAppMessageLayoutEvaluation {
         InAppMessageLayoutEvaluation(entity: self, result: self)
     }
 }

--- a/Sources/Hackle/Core/Workspace/Evaluation/Entity/RemoteConfigParameterRemoteEvaluateResult.swift
+++ b/Sources/Hackle/Core/Workspace/Evaluation/Entity/RemoteConfigParameterRemoteEvaluateResult.swift
@@ -22,7 +22,7 @@ final class RemoteConfigParameterRemoteEvaluateResult: RemoteConfigEvaluateResul
         super.init(reason: reason, value: value)
     }
 
-    func toEvaluation() -> Evaluation {
+    func toEvaluation() -> RemoteConfigEvaluation {
         RemoteConfigEvaluation(entity: self, result: self)
     }
 }

--- a/Sources/Hackle/Core/Workspace/Evaluation/Entity/RemoteEvaluateResult.swift
+++ b/Sources/Hackle/Core/Workspace/Evaluation/Entity/RemoteEvaluateResult.swift
@@ -1,7 +1,9 @@
 import Foundation
 
 protocol RemoteEvaluateResult: EvaluateResult, Entity {
+    associatedtype EvaluationType: Evaluation
+
     var references: [Entity] { get }
 
-    func toEvaluation() -> Evaluation
+    func toEvaluation() -> EvaluationType
 }

--- a/Sources/Hackle/Core/Workspace/Evaluation/Model/WorkspaceEvaluationDto.swift
+++ b/Sources/Hackle/Core/Workspace/Evaluation/Model/WorkspaceEvaluationDto.swift
@@ -79,13 +79,18 @@ struct ExperimentEvaluateResultDto: Codable {
     let key: Int64
     let order: Int64
     let version: Int
-    let executionVersion: Int
+    let execution: ExecutionDto
 
     let variation: VariationDto
     let config: ParameterConfigurationDto?
 
     let reason: String
     let references: [EntityDto]
+
+    struct ExecutionDto: Codable {
+        let status: String
+        let version: Int
+    }
 }
 
 struct RemoteConfigParameterEvaluateResultDto: Codable {

--- a/Sources/Hackle/Core/Workspace/Evaluation/Model/WorkspaceEvaluations.swift
+++ b/Sources/Hackle/Core/Workspace/Evaluation/Model/WorkspaceEvaluations.swift
@@ -1,14 +1,18 @@
 import Foundation
 
 extension ExperimentEvaluateResultDto {
-    func toResult(type: ExperimentType) -> ExperimentRemoteEvaluateResult {
+    func toResultOrNil(type: ExperimentType) -> ExperimentRemoteEvaluateResult? {
+        guard let status = ExperimentStatus.from(executionStatus: execution.status) else {
+            return nil
+        }
         return ExperimentRemoteEvaluateResult(
             id: id,
             key: key,
             version: version,
+            status: status,
             order: order,
             type: type,
-            executionVersion: executionVersion,
+            executionVersion: execution.version,
             variation: variation.toVariation(parameterConfiguration: config?.toParameterConfiguration()),
             reason: reason,
             references: references.compactMap { it in

--- a/Sources/Hackle/Core/Workspace/Evaluation/WorkspaceEvaluation.swift
+++ b/Sources/Hackle/Core/Workspace/Evaluation/WorkspaceEvaluation.swift
@@ -15,7 +15,7 @@ protocol WorkspaceEvaluation: Workspace {
     func getRemoteConfigParameterResultOrNil(parameterKey: RemoteConfigParameter.Key) -> RemoteConfigParameterRemoteEvaluateResult?
     func getInAppMessageResultOrNil(inAppMessageKey: InAppMessage.Key) -> InAppMessageEligibilityRemoteEvaluateResult?
 
-    func result(entity: Entity) -> RemoteEvaluateResult?
+    func result(entity: Entity) -> (any RemoteEvaluateResult)?
 }
 
 extension WorkspaceEvaluation {

--- a/Tests/HackleTests/Core/Evaluation/Mode/Remote/RemoteEvaluatorSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Mode/Remote/RemoteEvaluatorSpecs.swift
@@ -63,7 +63,7 @@ class RemoteEvaluatorSpecs: QuickSpec {
         let record: Bool = false
 
         var entity: Entity { result }
-        var remoteResult: RemoteEvaluateResult { result }
+        var remoteResult: any RemoteEvaluateResult { result }
 
         init(evaluationWorkspace: WorkspaceEvaluation, result: ExperimentRemoteEvaluateResult) {
             self.evaluationWorkspace = evaluationWorkspace

--- a/Tests/HackleTests/Core/Workspace/Evaluation/DefaultWorkspaceEvaluationSpecs.swift
+++ b/Tests/HackleTests/Core/Workspace/Evaluation/DefaultWorkspaceEvaluationSpecs.swift
@@ -43,6 +43,43 @@ class DefaultWorkspaceEvaluationSpecs: QuickSpec {
                 expect(total) == 4
             }
 
+            it("experiment execution.status가 매핑 불가 값이면 해당 결과를 skip한다") {
+                let json = """
+                {
+                  "workspace": {"id": 1, "environment": {"id": 2}},
+                  "results": [
+                    {
+                      "type": "AB_TEST",
+                      "id": 1,
+                      "hash": 1,
+                      "experiment": {
+                        "id": 1,
+                        "key": 1,
+                        "order": 1,
+                        "version": 1,
+                        "execution": {"status": "UNKNOWN", "version": 1},
+                        "variation": {"id": 1, "key": "A", "status": "ACTIVE", "parameterConfigurationId": null},
+                        "config": null,
+                        "reason": "TRAFFIC_ALLOCATED",
+                        "references": []
+                      }
+                    }
+                  ],
+                  "metadata": {
+                    "hash": 1,
+                    "evaluatedAt": 1720000000000,
+                    "user": {"hash": 1},
+                    "config": {"modifiedAt": "Thu, 10 Jul 2026 00:00:00 GMT"}
+                  }
+                }
+                """
+                let data = json.data(using: .utf8)!
+                let dto = try! JSONDecoder().decode(WorkspaceEvaluationDto.self, from: data)
+                let sut = DefaultWorkspaceEvaluation.from(dto: dto, fullEvaluatedAt: 0)
+
+                expect(sut.experimentResults).to(beEmpty())
+            }
+
             it("metadata를 매핑한다") {
                 let dto = decodeResponse().full!
                 let sut = DefaultWorkspaceEvaluation.from(dto: dto, fullEvaluatedAt: 0)
@@ -65,7 +102,7 @@ class DefaultWorkspaceEvaluationSpecs: QuickSpec {
                         "key": \(id),
                         "order": \(order),
                         "version": 1,
-                        "executionVersion": 1,
+                        "execution": {"status": "RUNNING", "version": 1},
                         "variation": {"id": 1, "key": "A", "status": "ACTIVE", "parameterConfigurationId": null},
                         "config": null,
                         "reason": "TRAFFIC_ALLOCATED",

--- a/Tests/HackleTests/Core/Workspace/Evaluation/Entity/RemoteEvaluateResultSpecs.swift
+++ b/Tests/HackleTests/Core/Workspace/Evaluation/Entity/RemoteEvaluateResultSpecs.swift
@@ -12,6 +12,7 @@ class RemoteEvaluateResultSpecs: QuickSpec {
                 id: 1,
                 key: 10,
                 version: 2,
+                status: .paused,
                 order: 4,
                 type: .abTest,
                 executionVersion: 3,
@@ -25,6 +26,7 @@ class RemoteEvaluateResultSpecs: QuickSpec {
                 expect(sut.entityKey).to(equal(EntityKey(serviceType: .abTest, id: 1)))
                 expect(sut.key).to(equal(10))
                 expect(sut.version).to(equal(2))
+                expect(sut.status).to(equal(.paused))
                 expect(sut.order).to(equal(4))
                 expect(sut.type).to(equal(.abTest))
                 expect(sut.executionVersion).to(equal(3))

--- a/Tests/HackleTests/Core/Workspace/Evaluation/Entity/RemoteEvaluateResultSpecs.swift
+++ b/Tests/HackleTests/Core/Workspace/Evaluation/Entity/RemoteEvaluateResultSpecs.swift
@@ -37,12 +37,8 @@ class RemoteEvaluateResultSpecs: QuickSpec {
 
             it("toEvaluation returns ExperimentEvaluation of itself") {
                 let evaluation = sut.toEvaluation()
-                guard let experimentEvaluation = evaluation as? ExperimentEvaluation else {
-                    fail("expected ExperimentEvaluation")
-                    return
-                }
-                expect(experimentEvaluation.entity.entityKey).to(equal(sut.entityKey))
-                expect(experimentEvaluation.experimentResult.variation.key).to(equal("B"))
+                expect(evaluation.entity.entityKey).to(equal(sut.entityKey))
+                expect(evaluation.experimentResult.variation.key).to(equal("B"))
             }
         }
 
@@ -68,12 +64,8 @@ class RemoteEvaluateResultSpecs: QuickSpec {
 
             it("toEvaluation returns RemoteConfigEvaluation of itself") {
                 let evaluation = sut.toEvaluation()
-                guard let rcEvaluation = evaluation as? RemoteConfigEvaluation else {
-                    fail("expected RemoteConfigEvaluation")
-                    return
-                }
-                expect(rcEvaluation.parameter.id).to(equal(2))
-                expect(rcEvaluation.remoteConfigResult.value?.id).to(equal(7))
+                expect(evaluation.parameter.id).to(equal(2))
+                expect(evaluation.remoteConfigResult.value?.id).to(equal(7))
             }
         }
 
@@ -105,8 +97,8 @@ class RemoteEvaluateResultSpecs: QuickSpec {
                 expect(sut.reason).to(equal(DecisionReason.IN_APP_MESSAGE_TARGET))
                 expect(sut.layout.entityKey).to(equal(layout.entityKey))
                 expect(sut.layout).to(beIdenticalTo(layout))
-                expect((sut.toEvaluation() as? InAppMessageEligibilityEvaluation)?.entity.entityKey).to(equal(sut.entityKey))
-                expect((layout.toEvaluation() as? InAppMessageLayoutEvaluation)?.entity.entityKey).to(equal(layout.entityKey))
+                expect(sut.toEvaluation().entity.entityKey).to(equal(sut.entityKey))
+                expect(layout.toEvaluation().entity.entityKey).to(equal(layout.entityKey))
             }
         }
     }

--- a/Tests/HackleTests/Core/Workspace/Evaluation/Model/WorkspaceEvaluationsSpecs.swift
+++ b/Tests/HackleTests/Core/Workspace/Evaluation/Model/WorkspaceEvaluationsSpecs.swift
@@ -40,23 +40,32 @@ class WorkspaceEvaluationsSpecs: QuickSpec {
 
     override class func spec() {
 
-        describe("ExperimentEvaluateResultDto.toResult") {
+        describe("ExperimentEvaluateResultDto.toResultOrNil") {
             it("config가 없으면 parameterConfiguration 없이 매핑한다") {
                 let dto = decodePayload(ExperimentEvaluateResultDto.self, resultType: "AB_TEST", field: "experiment") { it in
                     it["config"] = NSNull()
                 }
-                let result = dto.toResult(type: .abTest)
-                expect(result.key) == 10
-                expect(result.variation.parameterConfiguration).to(beNil())
+                let result = dto.toResultOrNil(type: .abTest)
+                expect(result).toNot(beNil())
+                expect(result?.key) == 10
+                expect(result?.variation.parameterConfiguration).to(beNil())
             }
 
             it("미지의 reference 타입은 그 reference만 제외하고 결과는 유지한다") {
                 let dto = decodePayload(ExperimentEvaluateResultDto.self, resultType: "AB_TEST", field: "experiment")
                 expect(dto.references.count) == 2 // AB_TEST + UNKNOWN_TYPE
 
-                let result = dto.toResult(type: .abTest)
-                expect(result.references.count) == 1
-                expect(result.references[0].serviceType) == ServiceType.abTest
+                let result = dto.toResultOrNil(type: .abTest)
+                expect(result).toNot(beNil())
+                expect(result?.references.count) == 1
+                expect(result?.references[0].serviceType) == ServiceType.abTest
+            }
+
+            it("execution.status가 매핑 불가 값이면 결과를 드랍한다") {
+                let dto = decodePayload(ExperimentEvaluateResultDto.self, resultType: "AB_TEST", field: "experiment") { it in
+                    it["execution"] = ["status": "UNKNOWN", "version": 1]
+                }
+                expect(dto.toResultOrNil(type: .abTest)).to(beNil())
             }
         }
 

--- a/Tests/HackleTests/Mock/MockWorkspaceEvaluation.swift
+++ b/Tests/HackleTests/Mock/MockWorkspaceEvaluation.swift
@@ -26,8 +26,8 @@ class MockWorkspaceEvaluation: WorkspaceEvaluation {
         inAppMessageResults.first { $0.key == inAppMessageKey }
     }
 
-    func result(entity: Entity) -> RemoteEvaluateResult? {
-        var all: [RemoteEvaluateResult] = []
+    func result(entity: Entity) -> (any RemoteEvaluateResult)? {
+        var all: [any RemoteEvaluateResult] = []
         all.append(contentsOf: experimentResults)
         all.append(contentsOf: featureFlagResults)
         all.append(contentsOf: remoteConfigParameterResults)

--- a/Tests/HackleTests/Mock/MockWorkspaceEvaluation.swift
+++ b/Tests/HackleTests/Mock/MockWorkspaceEvaluation.swift
@@ -60,7 +60,7 @@ func experimentRemoteResult(
     references: [Entity] = []
 ) -> ExperimentRemoteEvaluateResult {
     ExperimentRemoteEvaluateResult(
-        id: id, key: key, version: 1, order: order, type: type, executionVersion: 1,
+        id: id, key: key, version: 1, status: .running, order: order, type: type, executionVersion: 1,
         variation: variation, reason: reason, references: references
     )
 }

--- a/Tests/HackleTests/Resources/workspace_evaluation_response.json
+++ b/Tests/HackleTests/Resources/workspace_evaluation_response.json
@@ -17,7 +17,10 @@
           "key": 10,
           "order": 100,
           "version": 1,
-          "executionVersion": 1,
+          "execution": {
+            "status": "RUNNING",
+            "version": 1
+          },
           "variation": {
             "id": 2001,
             "key": "B",
@@ -59,7 +62,10 @@
           "key": 20,
           "order": 200,
           "version": 1,
-          "executionVersion": 1,
+          "execution": {
+            "status": "RUNNING",
+            "version": 1
+          },
           "variation": {
             "id": 2002,
             "key": "A",

--- a/Tests/HackleTests/UI/ExplorerUI/ExplorerExperimentItemLabelSpecs.swift
+++ b/Tests/HackleTests/UI/ExplorerUI/ExplorerExperimentItemLabelSpecs.swift
@@ -11,6 +11,7 @@ class ExplorerExperimentItemLabelSpecs: QuickSpec {
                 id: 1,
                 key: 42,
                 version: 3,
+                status: .running,
                 order: 0,
                 type: type,
                 executionVersion: 1,


### PR DESCRIPTION
## 개요
Remote Evaluation 응답의 experiment execution 정보를 반영하여 experiment status를 함께 매핑하도록 지원합니다.
