### PR TITLE
feat: add remote evaluation error tests

### DIFF
--- a/Sources/Hackle/Core/Http/HttpClient.swift
+++ b/Sources/Hackle/Core/Http/HttpClient.swift
@@ -60,8 +60,11 @@ class DefaultHttpClient: HttpClient {
         req.setValue(sdk.version, forHTTPHeaderField: "X-HACKLE-SDK-VERSION")
         req.setValue(String(Date().epochMillis), forHTTPHeaderField: "X-HACKLE-SDK-TIME")
 
+        Log.debug("--> \(request.method) \(request.url)")
         let task = session.dataTask(with: req) { data, response, error in
-            completion(HttpResponse(request: request, data: data, urlResponse: response, error: error))
+            let httpResponse = HttpResponse(request: request, data: data, urlResponse: response, error: error)
+            Log.debug("<-- \(request.method) \(request.url) status: \(httpResponse.statusCode ?? -1)\(error.map { ", error: \($0)" } ?? "")")
+            completion(httpResponse)
         }
 
         task.resume()

--- a/Sources/Hackle/Invocator/HackleInvokeParameters.swift
+++ b/Sources/Hackle/Invocator/HackleInvokeParameters.swift
@@ -15,20 +15,6 @@ extension HackleInvokeParameters {
         self["user"] as? [String: Any]
     }
 
-    /// id를 사용하는 User 객체를 반환합니다.
-    /// - Returns: User 객체 또는 `nil`
-    func user() -> User? {
-        if let id = self["user"] as? String {
-            return Hackle.user(id: id)
-        }
-
-        guard let data = userAsDictionary() else {
-            return nil
-        }
-
-        return User.from(dto: data)
-    }
-
     /// 사용자 ID를 반환합니다.
     /// - Returns: 사용자 ID 또는 `nil`
     func userId() -> String?? {

--- a/Tests/HackleTests/Core/InAppMessage/Deliver/Evaluator/InAppMessageDeliverRemoteEvaluatorSpecs.swift
+++ b/Tests/HackleTests/Core/InAppMessage/Deliver/Evaluator/InAppMessageDeliverRemoteEvaluatorSpecs.swift
@@ -51,6 +51,7 @@ class InAppMessageDeliverRemoteEvaluatorSpecs: AsyncSpec {
         var evaluateProcessor: EvaluateProcessor!
         var workspaceManager: WorkspaceEvaluationManager!
         var cache: LruWorkspaceEvaluationCache!
+        var hiddenStorage: InAppMessageHiddenStorage!
         var sut: InAppMessageDeliverRemoteEvaluator!
 
         beforeEach {
@@ -64,13 +65,16 @@ class InAppMessageDeliverRemoteEvaluatorSpecs: AsyncSpec {
                 repository: FileWorkspaceEvaluationRepository(fileStorage: nil),
                 cache: cache
             )
+            let hiddenRepository = UserDefaultsKeyValueRepository.of(suiteName: "iam_remote_deliver_hidden")
+            hiddenRepository.clear()
+            hiddenStorage = DefaultInAppMessageHiddenStorage(keyValueRepository: hiddenRepository)
             evaluateProcessor = EvaluateProcessor.create(
                 context: HackleCoreContext(),
                 clock: SystemClock.shared,
                 eventProcessor: MockUserEventProcessor(),
                 overrideStorage: DelegatingManualOverrideStorage(storages: []),
                 impressionStorage: DefaultInAppMessageImpressionStorage.create(suiteName: "iam_remote_deliver_impression"),
-                hiddenStorage: DefaultInAppMessageHiddenStorage.create(suiteName: "iam_remote_deliver_hidden")
+                hiddenStorage: hiddenStorage
             )
             sut = InAppMessageDeliverRemoteEvaluator(workspaceManager: workspaceManager, evaluateProcessor: evaluateProcessor)
         }
@@ -114,6 +118,19 @@ class InAppMessageDeliverRemoteEvaluatorSpecs: AsyncSpec {
                 await expect {
                     try await sut.evaluate(request: deliverRequest(inAppMessageKey: 40), user: user())
                 }.to(throwError())
+            }
+
+            it("선평가(record:false)가 ineligible이면 SPECIFIC 재평가 없이 기존 workspace로 ineligible 처리한다") {
+                cacheWorkspace(dto: evaluationDto())
+                let inAppMessage = DefaultWorkspaceEvaluation.from(dto: evaluationDto(), fullEvaluatedAt: 0)
+                    .getInAppMessageResultOrNil(inAppMessageKey: 40)!
+                hiddenStorage.put(inAppMessage: inAppMessage, expireAt: Date(timeIntervalSinceNow: 60))
+
+                let response = try await sut.evaluate(request: deliverRequest(inAppMessageKey: 40), user: user())
+
+                expect(partialEvaluator.requests.count) == 0
+                expect(response.isEligible) == false
+                expect(response.code) == InAppMessageDeliverResponse.Code.ineligible
             }
         }
 

--- a/Tests/HackleTests/Core/Workspace/Evaluation/Client/RemoteEvaluateClientSpecs.swift
+++ b/Tests/HackleTests/Core/Workspace/Evaluation/Client/RemoteEvaluateClientSpecs.swift
@@ -151,6 +151,26 @@ class RemoteEvaluateClientSpecs: AsyncSpec {
             await expect { try await sut.evaluateIfModified(request: requestDto()) }.to(throwError())
         }
 
+        it("네트워크 오류(response.error)면 workspace-evaluate가 해당 에러를 그대로 throw한다") {
+            let httpClient = MockHttpClient()
+            let sut = RemoteEvaluateClient(sdkUrl: URL(string: "https://sdk-api.hackle.io")!, httpClient: httpClient)
+            every(httpClient.executeMock).answers { request, completion in
+                completion(HttpResponse(request: request, data: nil, urlResponse: nil, error: URLError(.timedOut)))
+            }
+
+            await expect { try await sut.evaluateIfModified(request: requestDto()) }.to(throwError(URLError(.timedOut)))
+        }
+
+        it("네트워크 오류(response.error)면 entity-evaluate가 해당 에러를 그대로 throw한다") {
+            let httpClient = MockHttpClient()
+            let sut = RemoteEvaluateClient(sdkUrl: URL(string: "https://sdk-api.hackle.io")!, httpClient: httpClient)
+            every(httpClient.executeMock).answers { request, completion in
+                completion(HttpResponse(request: request, data: nil, urlResponse: nil, error: URLError(.timedOut)))
+            }
+
+            await expect { try await sut.evaluateEntities(request: entityRequestDto()) }.to(throwError(URLError(.timedOut)))
+        }
+
         it("body가 없으면 throw한다") {
             let httpClient = MockHttpClient()
             let sut = RemoteEvaluateClient(sdkUrl: URL(string: "https://sdk-api.hackle.io")!, httpClient: httpClient)


### PR DESCRIPTION
## 개요
Remote evaluation 경로의 네트워크 오류 전파와 인앱 메시지 deliver 선평가 동작을 검증하는 테스트를 추가합니다.

## 작업 내용
- `DefaultHttpClient`에 request/response debug log 추가
- workspace/entity remote evaluate에서 `response.error`가 그대로 throw되는지 테스트 추가
- 인앱 메시지 선평가가 ineligible이면 SPECIFIC 재평가 없이 기존 workspace 결과로 처리하는 테스트 추가
- 사용되지 않는 `HackleInvokeParameters.user()` dead code 제거