### PR TITLE
feature: update remote evaluation behavior

### DIFF
--- a/Sources/Hackle/Core/Decision/Decisions.swift
+++ b/Sources/Hackle/Core/Decision/Decisions.swift
@@ -16,7 +16,7 @@ extension ExperimentEvaluation {
     func toFeatureFlagDecision() -> FeatureFlagDecision {
         let result = experimentResult
         let config: ParameterConfig = result.variation.parameterConfiguration ?? EmptyParameterConfig.instance
-        return result.variation.key == "A"
+        return result.variation.key == VariationKeys.control
             ? FeatureFlagDecision.off(featureFlag: experiment, reason: result.reason, config: config)
             : FeatureFlagDecision.on(featureFlag: experiment, reason: result.reason, config: config)
     }

--- a/Sources/Hackle/Core/Decision/LocalDecisionProcessor.swift
+++ b/Sources/Hackle/Core/Decision/LocalDecisionProcessor.swift
@@ -12,10 +12,10 @@ final class LocalDecisionProcessor: DecisionProcessor {
 
     func experiment(experimentKey: Experiment.Key, user: HackleUser) throws -> Decision {
         guard let workspace = workspaceFetcher.workspace(user: user) else {
-            return Decision.of(experiment: nil, variation: "A", reason: DecisionReason.SDK_NOT_READY)
+            return Decision.of(experiment: nil, variation: VariationKeys.control, reason: DecisionReason.SDK_NOT_READY)
         }
         guard let experiment = workspace.getExperimentConfigOrNil(experimentKey: experimentKey) else {
-            return Decision.of(experiment: nil, variation: "A", reason: DecisionReason.EXPERIMENT_NOT_FOUND)
+            return Decision.of(experiment: nil, variation: VariationKeys.control, reason: DecisionReason.EXPERIMENT_NOT_FOUND)
         }
 
         let request = ExperimentLocalEvaluateRequest(

--- a/Sources/Hackle/Core/Decision/RemoteDecisionProcessor.swift
+++ b/Sources/Hackle/Core/Decision/RemoteDecisionProcessor.swift
@@ -12,10 +12,10 @@ final class RemoteDecisionProcessor: DecisionProcessor {
 
     func experiment(experimentKey: Experiment.Key, user: HackleUser) throws -> Decision {
         guard let workspace = workspaceFetcher.workspace(user: user) else {
-            return Decision.of(experiment: nil, variation: "A", reason: DecisionReason.SDK_NOT_READY)
+            return Decision.of(experiment: nil, variation: VariationKeys.control, reason: DecisionReason.SDK_NOT_READY)
         }
         guard let experiment = workspace.getExperimentResultOrNil(experimentKey: experimentKey) else {
-            return Decision.of(experiment: nil, variation: "A", reason: DecisionReason.EXPERIMENT_NOT_FOUND)
+            return Decision.of(experiment: nil, variation: VariationKeys.control, reason: DecisionReason.EXPERIMENT_NOT_FOUND)
         }
 
         let request = ExperimentRemoteEvaluateRequest.of(workspace: workspace, entity: experiment, user: user)

--- a/Sources/Hackle/Core/Evaluation/Match/ExperimentConditionMatcher.swift
+++ b/Sources/Hackle/Core/Evaluation/Match/ExperimentConditionMatcher.swift
@@ -103,7 +103,7 @@ class FeatureFlagConditionMatcher: ExperimentEvaluatorMatcher {
     }
 
     func matches(evaluation: ExperimentEvaluation, condition: Target.Condition) -> Bool {
-        let on = evaluation.experimentResult.variation.key != "A"
+        let on = evaluation.experimentResult.variation.key != VariationKeys.control
         return valueOperatorMatcher.matches(userValue: on, match: condition.match)
     }
 }

--- a/Sources/Hackle/Core/HackleAppCore.swift
+++ b/Sources/Hackle/Core/HackleAppCore.swift
@@ -295,7 +295,7 @@ class DefaultHackleAppCore: HackleAppCore, @unchecked Sendable {
             )
         } catch {
             Log.error("Unexpected error while deciding variation for experiment[\(experimentKey)]: \(String(describing: error))")
-            decision = Decision.of(experiment: nil, variation: "A", reason: DecisionReason.EXCEPTION)
+            decision = Decision.of(experiment: nil, variation: VariationKeys.control, reason: DecisionReason.EXCEPTION)
         }
         DecisionMetrics.experiment(sample: sample, key: experimentKey, decision: decision)
         return decision

--- a/Sources/Hackle/Core/HackleAppCore.swift
+++ b/Sources/Hackle/Core/HackleAppCore.swift
@@ -46,7 +46,7 @@ protocol HackleAppCore: AnyObject {
 
     func unsetPhoneNumber(hackleAppContext: HackleAppContext)
 
-    func variationDetail(experimentKey: Int, defaultVariation: String, hackleAppContext: HackleAppContext) -> Decision
+    func variationDetail(experimentKey: Int, hackleAppContext: HackleAppContext) -> Decision
 
     func allVariationDetails(hackleAppContext: HackleAppContext) -> [Int: Decision]
 
@@ -284,7 +284,7 @@ class DefaultHackleAppCore: HackleAppCore, @unchecked Sendable {
         eventProcessor.flush()
     }
 
-    func variationDetail(experimentKey: Int, defaultVariation: String, hackleAppContext: HackleAppContext) -> Decision {
+    func variationDetail(experimentKey: Int, hackleAppContext: HackleAppContext) -> Decision {
         let sample = TimerSample.start()
         let decision: Decision
         do {
@@ -295,7 +295,7 @@ class DefaultHackleAppCore: HackleAppCore, @unchecked Sendable {
             )
         } catch {
             Log.error("Unexpected error while deciding variation for experiment[\(experimentKey)]: \(String(describing: error))")
-            decision = Decision.of(experiment: nil, variation: defaultVariation, reason: DecisionReason.EXCEPTION)
+            decision = Decision.of(experiment: nil, variation: "A", reason: DecisionReason.EXCEPTION)
         }
         DecisionMetrics.experiment(sample: sample, key: experimentKey, decision: decision)
         return decision

--- a/Sources/Hackle/Core/Model/Variation.swift
+++ b/Sources/Hackle/Core/Model/Variation.swift
@@ -15,6 +15,10 @@ protocol Variation: Sendable {
     var parameterConfiguration: ParameterConfiguration? { get }
 }
 
+enum VariationKeys {
+    static let control: Variation.Key = "A"
+}
+
 final class VariationEntity: Variation, @unchecked Sendable {
 
     let id: Id

--- a/Sources/Hackle/Core/Workspace/Config/Entity/ExperimentConfig.swift
+++ b/Sources/Hackle/Core/Workspace/Config/Entity/ExperimentConfig.swift
@@ -19,7 +19,7 @@ protocol ExperimentConfig: Experiment, ConfigEntity {
 extension ExperimentConfig {
     var controlVariation: Variation {
         get throws {
-            guard let variation = getVariationOrNil(variationKey: "A") else {
+            guard let variation = getVariationOrNil(variationKey: VariationKeys.control) else {
                 throw HackleError.error("ControlVariation[\(id)]")
             }
             return variation

--- a/Sources/Hackle/Core/Workspace/Evaluation/Client/RemoteEvaluateClient.swift
+++ b/Sources/Hackle/Core/Workspace/Evaluation/Client/RemoteEvaluateClient.swift
@@ -2,8 +2,8 @@ import Foundation
 
 class RemoteEvaluateClient {
 
-    private static let WORKSPACE_EVALUATE_PATH = "/api/v1/workspace-evaluate"
-    private static let ENTITY_EVALUATE_PATH = "/api/v1/entity-evaluate"
+    private static let WORKSPACE_EVALUATE_PATH = "/api/v1/evaluate/workspace"
+    private static let ENTITY_EVALUATE_PATH = "/api/v1/evaluate/entities"
     // 초기 sync 중 coreQueue가 suspend되므로(813404f) 기본 60초 폴백 금지. iOS 관례(UserCohortFetcher) 10초.
     private static let TIMEOUT_INTERVAL: TimeInterval = 10
 
@@ -18,12 +18,12 @@ class RemoteEvaluateClient {
     }
 
     func evaluateIfModified(request: WorkspaceEvaluateRequestDto) async throws -> WorkspaceEvaluateResponseDto? {
-        let response = try await execute(url: workspaceEndpoint, body: request.toBody(), operation: "workspace.remote.evaluate")
+        let response = try await execute(url: workspaceEndpoint, body: request.toBody(), operation: "evaluate.workspace")
         return try handleWorkspaceResponse(response: response)
     }
 
     func evaluateEntities(request: EntityEvaluateRequestDto) async throws -> EntityEvaluateResponseDto {
-        let response = try await execute(url: entityEndpoint, body: request.toBody(), operation: "entity.remote.evaluate")
+        let response = try await execute(url: entityEndpoint, body: request.toBody(), operation: "evaluate.entities")
         return try handleResponse(response: response)
     }
 

--- a/Sources/Hackle/HackleApp+Deprecate.swift
+++ b/Sources/Hackle/HackleApp+Deprecate.swift
@@ -37,7 +37,7 @@ extension HackleApp {
     /// - Parameters:
     ///   - key: the key of the property
     ///   - value: the value of the property
-    @available(*, deprecated, message: "Use async setUserProperty(key:value:) or setUserProperty(key:value:completion:) instead.")
+    @available(*, deprecated, message: "Use updateUserProperties(operations:) instead.")
     @objc public func setUserProperty(key: String, value: Any?) {
         let operations = PropertyOperations.builder()
             .set(key, value)
@@ -77,22 +77,22 @@ extension HackleApp {
     ///
     /// - Parameters:
     ///   - experimentKey: the unique key of the experiment
-    ///   - defaultVariation: the default variation to return if the experiment cannot be decided
-    /// - Returns: the decided variation for the user, or defaultVariation
+    ///   - defaultVariation: ignored. `"A"` is always used when the experiment cannot be decided
+    /// - Returns: the decided variation for the user, or `"A"` if the experiment cannot be decided
     @available(*, deprecated, message: "Use variation(experimentKey) without defaultVariation instead.")
     @objc public func variation(experimentKey: Int, defaultVariation: String) -> String {
-        variationDetail(experimentKey: experimentKey, defaultVariation: defaultVariation).variation
+        variation(experimentKey: experimentKey)
     }
 
     /// Decide the variation to expose to the user for experiment and returns an object that describes the way the variation was decided.
     ///
     /// - Parameters:
     ///   - experimentKey: the unique key for the experiment
-    ///   - defaultVariation: the default variation to return if the experiment cannot be decided
+    ///   - defaultVariation: ignored. `"A"` is always used when the experiment cannot be decided
     /// - Returns: a ``Decision`` object
     @available(*, deprecated, message: "Use variationDetail(experimentKey) without defaultVariation instead.")
     @objc public func variationDetail(experimentKey: Int, defaultVariation: String) -> Decision {
-        hackleAppCore.variationDetail(experimentKey: experimentKey, defaultVariation: defaultVariation, hackleAppContext: .default)
+        variationDetail(experimentKey: experimentKey)
     }
 
     /// Updates push notification subscription status.

--- a/Sources/Hackle/HackleApp.swift
+++ b/Sources/Hackle/HackleApp.swift
@@ -124,6 +124,7 @@ import WebKit
     ///   - key: the key of the property
     ///   - value: the value of the property
     ///   - completion: callback to be executed when the operation is complete
+    @available(*, deprecated, message: "Use updateUserProperties(operations:completion:) instead.")
     @preconcurrency @objc public func setUserProperty(key: String, value: Any?, completion: @escaping @Sendable () -> ()) {
         let operations = PropertyOperations.builder()
             .set(key, value)
@@ -196,7 +197,7 @@ import WebKit
     ///
     /// - Parameters:
     ///   - experimentKey: the unique key of the experiment
-    /// - Returns: the decided variation for the user, or defaultVariation
+    /// - Returns: the decided variation for the user, or `"A"` if the experiment cannot be decided
     @objc public func variation(experimentKey: Int) -> String {
         variationDetail(experimentKey: experimentKey).variation
     }
@@ -207,7 +208,7 @@ import WebKit
     ///   - experimentKey: the unique key for the experiment
     /// - Returns: a ``Decision`` object
     @objc public func variationDetail(experimentKey: Int) -> Decision {
-        hackleAppCore.variationDetail(experimentKey: experimentKey, defaultVariation: "A", hackleAppContext: .default)
+        hackleAppCore.variationDetail(experimentKey: experimentKey, hackleAppContext: .default)
     }
 
     /// Decide the variations for all experiments and returns a map of decision results.
@@ -330,6 +331,7 @@ extension HackleApp {
     /// - Parameters:
     ///   - key: the key of the property
     ///   - value: the value of the property
+    @available(*, deprecated, message: "Use updateUserProperties(operations:) instead.")
     public func setUserProperty(key: String, value: Any?) async {
         let operations = PropertyOperations.builder()
             .set(key, value)

--- a/Sources/Hackle/Invocator/HackleInvokeParameters.swift
+++ b/Sources/Hackle/Invocator/HackleInvokeParameters.swift
@@ -63,12 +63,6 @@ extension HackleInvokeParameters {
         self["experimentKey"] as? Int
     }
 
-    /// A/B 테스트의 기본 그룹(variation) 키를 반환합니다.
-    /// - Returns: 기본 그룹 키. `nil`이 아님.
-    func defaultVariation() -> String {
-        (self["defaultVariation"] as? String) ?? "A"
-    }
-
     /// 기능 플래그 키(Feature Key)를 `Int` 타입으로 반환합니다.
     /// - Returns: 기능 플래그 키 또는 `nil`
     func featureKey() -> Int? {

--- a/Sources/Hackle/Invocator/Invocation/InvocationHandlers.swift
+++ b/Sources/Hackle/Invocator/Invocation/InvocationHandlers.swift
@@ -239,10 +239,8 @@ extension AbTestInvocationHandler {
         guard let experimentKey = request.parameters.experimentKey() else {
             throw HackleError.error("parameters.experimentKey must be provided.")
         }
-        let defaultVariation = request.parameters.defaultVariation()
         let decision = core.variationDetail(
             experimentKey: experimentKey,
-            defaultVariation: defaultVariation,
             hackleAppContext: request.appContext
         )
         let data = transform(decision: decision)

--- a/Sources/Hackle/UI/ExplorerUI/View/Experiment/FeatureFlagListView.swift
+++ b/Sources/Hackle/UI/ExplorerUI/View/Experiment/FeatureFlagListView.swift
@@ -69,6 +69,6 @@ extension HackleFeatureFlagItem {
 
 private extension Variation {
     var isOn: Bool {
-        key != "A"
+        key != VariationKeys.control
     }
 }

--- a/Tests/HackleTests/Core/Evaluation/Evaluator/Experiment/ExperimentFlowEvaluatorSpecs.swift
+++ b/Tests/HackleTests/Core/Evaluation/Evaluator/Experiment/ExperimentFlowEvaluatorSpecs.swift
@@ -415,7 +415,7 @@ class ExperimentFlowEvaluatorSpecs: QuickSpec {
                     .to(throwError(HackleError.error("Experiment type must be featureFlag [42]")))
             }
 
-            it("identifierType에 해당하는 식별자가 없으면 defaultVariation을 리턴한다") {
+            it("identifierType에 해당하는 식별자가 없으면 컨트롤 그룹 A를 리턴한다") {
                 // given
                 let experiment = experiment(id: 42, type: .featureFlag, identifierType: "custom", status: .running)
                 let request = experimentRequest(experiment: experiment)

--- a/Tests/HackleTests/Core/Workspace/Evaluation/Client/RemoteEvaluateClientSpecs.swift
+++ b/Tests/HackleTests/Core/Workspace/Evaluation/Client/RemoteEvaluateClientSpecs.swift
@@ -67,7 +67,7 @@ class RemoteEvaluateClientSpecs: AsyncSpec {
             )
         }
 
-        it("POST {sdkUrl}/api/v1/workspace-evaluate 로 요청 body를 직렬화해 보낸다") {
+        it("POST {sdkUrl}/api/v1/evaluate/workspace 로 요청 body를 직렬화해 보낸다") {
             let httpClient = MockHttpClient()
             let sut = RemoteEvaluateClient(sdkUrl: URL(string: "https://sdk-api.hackle.io")!, httpClient: httpClient)
             var capturedRequest: HttpRequest?
@@ -78,7 +78,7 @@ class RemoteEvaluateClientSpecs: AsyncSpec {
 
             _ = try await sut.evaluateIfModified(request: requestDto())
 
-            expect(capturedRequest?.url.absoluteString) == "https://sdk-api.hackle.io/api/v1/workspace-evaluate"
+            expect(capturedRequest?.url.absoluteString) == "https://sdk-api.hackle.io/api/v1/evaluate/workspace"
             expect(capturedRequest?.method.lowercased()) == "post"
 
             let body = try! JSONSerialization.jsonObject(with: capturedRequest!.body!) as! [String: Any]
@@ -94,7 +94,7 @@ class RemoteEvaluateClientSpecs: AsyncSpec {
             expect(entities[0]["hash"] as? Int) == 10
         }
 
-        it("workspace-evaluate 204 응답이면 nil을 반환한다") {
+        it("evaluate/workspace 204 응답이면 nil을 반환한다") {
             let httpClient = MockHttpClient()
             let sut = RemoteEvaluateClient(sdkUrl: URL(string: "https://sdk-api.hackle.io")!, httpClient: httpClient)
             every(httpClient.executeMock).answers { request, completion in
@@ -106,7 +106,7 @@ class RemoteEvaluateClientSpecs: AsyncSpec {
             expect(response).to(beNil())
         }
 
-        it("workspace-evaluate 2xx 응답 body를 신 포맷으로 디코딩한다") {
+        it("evaluate/workspace 2xx 응답 body를 신 포맷으로 디코딩한다") {
             let httpClient = MockHttpClient()
             let sut = RemoteEvaluateClient(sdkUrl: URL(string: "https://sdk-api.hackle.io")!, httpClient: httpClient)
             every(httpClient.executeMock).answers { request, completion in
@@ -120,7 +120,7 @@ class RemoteEvaluateClientSpecs: AsyncSpec {
             expect(response?.delta).to(beNil())
         }
 
-        it("POST {sdkUrl}/api/v1/entity-evaluate 로 entities를 보낸다") {
+        it("POST {sdkUrl}/api/v1/evaluate/entities 로 entities를 보낸다") {
             let httpClient = MockHttpClient()
             let sut = RemoteEvaluateClient(sdkUrl: URL(string: "https://sdk-api.hackle.io")!, httpClient: httpClient)
             var capturedRequest: HttpRequest?
@@ -131,7 +131,7 @@ class RemoteEvaluateClientSpecs: AsyncSpec {
 
             let response = try await sut.evaluateEntities(request: entityRequestDto())
 
-            expect(capturedRequest?.url.absoluteString) == "https://sdk-api.hackle.io/api/v1/entity-evaluate"
+            expect(capturedRequest?.url.absoluteString) == "https://sdk-api.hackle.io/api/v1/evaluate/entities"
             expect(capturedRequest?.method.lowercased()) == "post"
             let body = try! JSONSerialization.jsonObject(with: capturedRequest!.body!) as! [String: Any]
             let entities = body["entities"] as! [[String: Any]]
@@ -151,7 +151,7 @@ class RemoteEvaluateClientSpecs: AsyncSpec {
             await expect { try await sut.evaluateIfModified(request: requestDto()) }.to(throwError())
         }
 
-        it("네트워크 오류(response.error)면 workspace-evaluate가 해당 에러를 그대로 throw한다") {
+        it("네트워크 오류(response.error)면 evaluate/workspace가 해당 에러를 그대로 throw한다") {
             let httpClient = MockHttpClient()
             let sut = RemoteEvaluateClient(sdkUrl: URL(string: "https://sdk-api.hackle.io")!, httpClient: httpClient)
             every(httpClient.executeMock).answers { request, completion in
@@ -161,7 +161,7 @@ class RemoteEvaluateClientSpecs: AsyncSpec {
             await expect { try await sut.evaluateIfModified(request: requestDto()) }.to(throwError(URLError(.timedOut)))
         }
 
-        it("네트워크 오류(response.error)면 entity-evaluate가 해당 에러를 그대로 throw한다") {
+        it("네트워크 오류(response.error)면 evaluate/entities가 해당 에러를 그대로 throw한다") {
             let httpClient = MockHttpClient()
             let sut = RemoteEvaluateClient(sdkUrl: URL(string: "https://sdk-api.hackle.io")!, httpClient: httpClient)
             every(httpClient.executeMock).answers { request, completion in

--- a/Tests/HackleTests/Core/Workspace/Evaluation/Evaluator/Partial/PartialWorkspaceRemoteEvaluatorSpecs.swift
+++ b/Tests/HackleTests/Core/Workspace/Evaluation/Evaluator/Partial/PartialWorkspaceRemoteEvaluatorSpecs.swift
@@ -36,7 +36,7 @@ class PartialWorkspaceRemoteEvaluatorSpecs: AsyncSpec {
             )
         }
 
-        it("entity-evaluate 엔드포인트로 entities를 직렬화해 보낸다") {
+        it("evaluate/entities 엔드포인트로 entities를 직렬화해 보낸다") {
             let httpClient = MockHttpClient()
             let sut = PartialWorkspaceRemoteEvaluator(client: RemoteEvaluateClient(sdkUrl: URL(string: "https://sdk-api.hackle.io")!, httpClient: httpClient))
             var capturedRequest: HttpRequest?
@@ -51,7 +51,7 @@ class PartialWorkspaceRemoteEvaluatorSpecs: AsyncSpec {
             )
             _ = try await sut.evaluate(request: request)
 
-            expect(capturedRequest?.url.absoluteString) == "https://sdk-api.hackle.io/api/v1/entity-evaluate"
+            expect(capturedRequest?.url.absoluteString) == "https://sdk-api.hackle.io/api/v1/evaluate/entities"
             let body = try! JSONSerialization.jsonObject(with: capturedRequest!.body!) as! [String: Any]
             let entities = body["entities"] as! [[String: Any]]
             expect(entities.count) == 1

--- a/Tests/HackleTests/Invocator/HackleInvocationSpec.swift
+++ b/Tests/HackleTests/Invocator/HackleInvocationSpec.swift
@@ -408,10 +408,7 @@ class HackleInvocationSpec: QuickSpec {
             describe("variation") {
                 context("normal") {
                     it("happy case") {
-                        let parameters = [
-                            "experimentKey": 123,
-                            "defaultVariation": "D"
-                        ] as [String: Any]
+                        let parameters = ["experimentKey": 123] as [String: Any]
                         let jsonString = createJsonString(command: "variation", parameters: parameters)
                         every(core.variationDetailRef)
                             .returns(Decision.of(experiment: nil, variation: "C", reason: "DEFAULT_RULE"))
@@ -422,7 +419,6 @@ class HackleInvocationSpec: QuickSpec {
                         let firstInvokation = core.variationDetailRef.firstInvokation()
                         let arguments = firstInvokation.arguments
                         expect(arguments.0) == 123
-                        expect(arguments.1) == "D"
 
                         let dict = result.jsonObject()!
                         expect(dict["success"] as? Bool) == true
@@ -430,8 +426,11 @@ class HackleInvocationSpec: QuickSpec {
                         expect(dict["data"] as? String) == "C"
                         expect(core.hackleAppContext?.browserProperties["mock"] as? String) == "mocks"
                     }
-                    it("expect 'A' default variation parameter") {
-                        let parameters = ["experimentKey": 123] as [String: Any]
+                    it("defaultVariation 파라미터는 무시된다") {
+                        let parameters = [
+                            "experimentKey": 123,
+                            "defaultVariation": "D"
+                        ] as [String: Any]
                         let jsonString = createJsonString(command: "variation", parameters: parameters)
                         every(core.variationDetailRef)
                             .returns(Decision.of(experiment: nil, variation: "A", reason: "DEFAULT_RULE"))
@@ -442,7 +441,6 @@ class HackleInvocationSpec: QuickSpec {
                         let firstInvokation = core.variationDetailRef.firstInvokation()
                         let arguments = firstInvokation.arguments
                         expect(arguments.0) == 123
-                        expect(arguments.1) == "A"
 
                         let dict = result.jsonObject()!
                         expect(dict["success"] as? Bool) == true
@@ -465,10 +463,7 @@ class HackleInvocationSpec: QuickSpec {
             describe("variation detail") {
                 context("normal") {
                     it("happy case") {
-                        let parameters = [
-                            "experimentKey": 123,
-                            "defaultVariation": "D"
-                        ] as [String: Any]
+                        let parameters = ["experimentKey": 123] as [String: Any]
                         let jsonString = createJsonString(command: "variationDetail", parameters: parameters)
                         every(core.variationDetailRef)
                             .returns(Decision.of(experiment: nil, variation: "C", reason: "DEFAULT_RULE"))
@@ -479,7 +474,6 @@ class HackleInvocationSpec: QuickSpec {
                         let firstInvokation = core.variationDetailRef.firstInvokation()
                         let arguments = firstInvokation.arguments
                         expect(arguments.0) == 123
-                        expect(arguments.1) == "D"
 
                         let dict = result.jsonObject()!
                         expect(dict["success"] as? Bool) == true
@@ -493,9 +487,10 @@ class HackleInvocationSpec: QuickSpec {
                         expect(config["parameters"]).toNot(beNil())
                         expect(core.hackleAppContext?.browserProperties["mock"] as? String) == "mocks"
                     }
-                    it("expect 'A' default variation parameter") {
+                    it("defaultVariation 파라미터는 무시된다") {
                         let parameters = [
-                            "experimentKey": 123
+                            "experimentKey": 123,
+                            "defaultVariation": "D"
                         ] as [String: Any]
                         let jsonString = createJsonString(command: "variationDetail", parameters: parameters)
                         every(core.variationDetailRef)
@@ -507,7 +502,6 @@ class HackleInvocationSpec: QuickSpec {
                         let firstInvokation = core.variationDetailRef.firstInvokation()
                         let arguments = firstInvokation.arguments
                         expect(arguments.0) == 123
-                        expect(arguments.1) == "A"
 
                         let dict = result.jsonObject()!
                         expect(dict["success"] as? Bool) == true

--- a/Tests/HackleTests/Mock/MockHackleApp.swift
+++ b/Tests/HackleTests/Mock/MockHackleApp.swift
@@ -105,10 +105,10 @@ class MockHackleAppCore: Mock, HackleAppCore {
         call(unsetPhoneNumberRef, args: hackleAppContext)
     }
     
-    lazy var variationDetailRef = MockFunction(self, variationDetail as (Int, String, HackleAppContext) -> Decision)
-    func variationDetail(experimentKey: Int, defaultVariation: String, hackleAppContext: HackleAppContext) -> Decision {
+    lazy var variationDetailRef = MockFunction(self, variationDetail as (Int, HackleAppContext) -> Decision)
+    func variationDetail(experimentKey: Int, hackleAppContext: HackleAppContext) -> Decision {
         self.hackleAppContext = hackleAppContext
-        return call(variationDetailRef, args: (experimentKey, defaultVariation, hackleAppContext))
+        return call(variationDetailRef, args: (experimentKey, hackleAppContext))
     }
 
     lazy var featureFlagDetailRef = MockFunction(self, featureFlagDetail as (Int, HackleAppContext) -> FeatureFlagDecision)


### PR DESCRIPTION
## 개요
Remote evaluation API 경로와 metric operation 이름을 최신 규격에 맞게 변경합니다.
실험 평가 실패 시 caller가 전달한 `defaultVariation` 대신 컨트롤 그룹 `A`를 일관되게 반환하도록 정리합니다.
