### PR TITLE
refactor: deprecate webview wrapper mode

### DIFF
--- a/Sources/Hackle/Core/Workspace/Config/DefaultWorkspaceConfig.swift
+++ b/Sources/Hackle/Core/Workspace/Config/DefaultWorkspaceConfig.swift
@@ -161,6 +161,7 @@ class DefaultWorkspaceConfig: WorkspaceConfig {
 extension DefaultWorkspaceConfig {
     func toProperties() -> [String: Any] {
         PropertiesBuilder()
+            .add("evaluation_mode", "LOCAL")
             .add("config_modified_at", modifiedAt)
             .build()
     }

--- a/Sources/Hackle/Core/Workspace/Evaluation/DefaultWorkspaceEvaluation.swift
+++ b/Sources/Hackle/Core/Workspace/Evaluation/DefaultWorkspaceEvaluation.swift
@@ -93,6 +93,7 @@ final class DefaultWorkspaceEvaluation: WorkspaceEvaluation, @unchecked Sendable
 
     func toProperties() -> [String: Any] {
         PropertiesBuilder()
+            .add("evaluation_mode", "REMOTE")
             .add("config_modified_at", modifiedAt)
             .add("remote_evaluated_at", evaluatedAt)
             .add("remote_full_evaluated_at", fullEvaluatedAt)

--- a/Sources/Hackle/HackleConfig+Deprecate.swift
+++ b/Sources/Hackle/HackleConfig+Deprecate.swift
@@ -1,0 +1,37 @@
+//
+//  HackleConfig+Deprecate.swift
+//  Hackle
+//
+//  Created by sungwoo.yeo on 7/30/26.
+//
+
+import Foundation
+
+extension HackleConfig {
+    @available(*, deprecated, message: "Use sessionPolicy.timeoutCondition.timeoutIntervalSeconds instead.")
+    var sessionTimeoutInterval: TimeInterval {
+        sessionPolicy.timeoutCondition.timeoutIntervalSeconds
+    }
+}
+
+extension HackleConfigBuilder {
+    /// Sets the application mode.
+    ///
+    /// - Parameter mode: The ``HackleAppMode`` to use
+    /// - Returns: This builder instance for method chaining
+    @available(*, deprecated, message: "WebView wrapper mode is deprecated and no longer recommended for new integrations.")
+    @objc public func mode(_ mode: HackleAppMode) -> HackleConfigBuilder {
+        self.appMode = mode
+        return self
+    }
+
+    /// Sets the session timeout interval in seconds.
+    ///
+    /// - Parameter sessionTimeoutInterval: The timeout interval after which a session expires
+    /// - Returns: This builder instance for method chaining
+    @available(*, deprecated, message: "Use sessionPolicy(_:) instead.")
+    @objc public func sessionTimeoutIntervalSeconds(_ sessionTimeoutInterval: TimeInterval) -> HackleConfigBuilder {
+        self.sessionPolicy = sessionPolicy.withTimeoutInterval(sessionTimeoutInterval)
+        return self
+    }
+}

--- a/Sources/Hackle/HackleConfig.swift
+++ b/Sources/Hackle/HackleConfig.swift
@@ -51,11 +51,6 @@ public final class HackleConfig: NSObject, Sendable {
         super.init()
     }
 
-    @available(*, deprecated, message: "Use sessionPolicy.timeoutCondition.timeoutIntervalSeconds instead.")
-    var sessionTimeoutInterval: TimeInterval {
-        sessionPolicy.timeoutCondition.timeoutIntervalSeconds
-    }
-
     static let NO_POLLING: TimeInterval = -1
     static let NO_DEDUP: TimeInterval = -1
     static let DEFAULT_EVENT_FLUSH_INTERVAL: TimeInterval = 10
@@ -153,15 +148,6 @@ public class HackleConfigBuilder: NSObject {
         return self
     }
 
-    /// Sets the application mode.
-    ///
-    /// - Parameter mode: The ``HackleAppMode`` to use
-    /// - Returns: This builder instance for method chaining
-    @objc public func mode(_ mode: HackleAppMode) -> HackleConfigBuilder {
-        self.appMode = mode
-        return self
-    }
-
     /// Sets the evaluation mode.
     ///
     /// - Parameter evaluationMode: The ``EvaluationMode`` to use
@@ -186,16 +172,6 @@ public class HackleConfigBuilder: NSObject {
     /// - Returns: This builder instance for method chaining
     @objc public func automaticAppLifecycleTracking(_ automaticAppLifecycleTracking: Bool) -> HackleConfigBuilder {
         self.automaticAppLifecycleTracking = automaticAppLifecycleTracking
-        return self
-    }
-
-    /// Sets the session timeout interval in seconds.
-    ///
-    /// - Parameter sessionTimeoutInterval: The timeout interval after which a session expires
-    /// - Returns: This builder instance for method chaining
-    @available(*, deprecated, message: "Use sessionPolicy(_:) instead.")
-    @objc public func sessionTimeoutIntervalSeconds(_ sessionTimeoutInterval: TimeInterval) -> HackleConfigBuilder {
-        self.sessionPolicy = sessionPolicy.withTimeoutInterval(sessionTimeoutInterval)
         return self
     }
 

--- a/Sources/Hackle/HackleConfig.swift
+++ b/Sources/Hackle/HackleConfig.swift
@@ -166,7 +166,7 @@ public class HackleConfigBuilder: NSObject {
     ///
     /// - Parameter evaluationMode: The ``EvaluationMode`` to use
     /// - Returns: This builder instance for method chaining
-    @objc(evaluationMode:) public func mode(_ evaluationMode: EvaluationMode) -> HackleConfigBuilder {
+    @objc public func evaluationMode(_ evaluationMode: EvaluationMode) -> HackleConfigBuilder {
         self.evaluationMode = evaluationMode
         return self
     }

--- a/Tests/HackleTests/Core/Workspace/Evaluation/DefaultWorkspaceEvaluationSpecs.swift
+++ b/Tests/HackleTests/Core/Workspace/Evaluation/DefaultWorkspaceEvaluationSpecs.swift
@@ -265,10 +265,11 @@ class DefaultWorkspaceEvaluationSpecs: QuickSpec {
         }
 
         describe("toProperties") {
-            it("config_modified_at과 remote_evaluated_at을 포함한다") {
+            it("evaluation_mode, config_modified_at과 remote_evaluated_at을 포함한다") {
                 let sut = DefaultWorkspaceEvaluation.from(dto: decodeResponse().full!, fullEvaluatedAt: 0)
                 let properties = sut.toProperties()
 
+                expect(properties["evaluation_mode"] as? String) == "REMOTE"
                 expect(properties["config_modified_at"] as? String) == "Thu, 10 Jul 2026 00:00:00 GMT"
                 expect(properties["remote_evaluated_at"] as? Int64) == 1720000000000
             }

--- a/Tests/HackleTests/Core/Workspace/WorkspaceSpecs.swift
+++ b/Tests/HackleTests/Core/Workspace/WorkspaceSpecs.swift
@@ -59,6 +59,14 @@ class WorkspaceSpecs: QuickSpec {
             expect(variation.parameterConfiguration?.id) != variation.id
         }
 
+        it("toProperties는 evaluation_mode LOCAL과 config_modified_at을 포함한다") {
+            let workspace = DefaultWorkspaceConfig.create(modifiedAt: "Thu, 10 Jul 2026 00:00:00 GMT")
+            let properties = workspace.toProperties()
+
+            expect(properties["evaluation_mode"] as? String) == "LOCAL"
+            expect(properties["config_modified_at"] as? String) == "Thu, 10 Jul 2026 00:00:00 GMT"
+        }
+
         it("experiments와 featureFlags를 order 오름차순으로 정렬한다") {
             func experimentJson(id: Int64, order: Int64) -> String {
                 """

--- a/Tests/HackleTests/HackleConfigSpec.swift
+++ b/Tests/HackleTests/HackleConfigSpec.swift
@@ -76,7 +76,7 @@ class HackleConfigSpec: QuickSpec {
 
         it("builder로 evaluationMode를 remote로 설정할 수 있다") {
             let config = HackleConfigBuilder()
-                .mode(.remote)
+                .evaluationMode(.remote)
                 .build()
             expect(config.evaluationMode) == EvaluationMode.remote
         }
@@ -84,7 +84,7 @@ class HackleConfigSpec: QuickSpec {
         it("appMode와 evaluationMode는 독립적으로 설정된다") {
             let config = HackleConfigBuilder()
                 .mode(HackleAppMode.web_view_wrapper)
-                .mode(EvaluationMode.remote)
+                .evaluationMode(EvaluationMode.remote)
                 .build()
             expect(config.appMode) == HackleAppMode.web_view_wrapper
             expect(config.evaluationMode) == EvaluationMode.remote

--- a/Tests/HackleTests/RemoteEvaluationModeSpecs.swift
+++ b/Tests/HackleTests/RemoteEvaluationModeSpecs.swift
@@ -14,7 +14,7 @@ class RemoteEvaluationModeSpecs: AsyncSpec {
 
         it("HackleApp.create가 REMOTE mode로 생성된다") {
             let config = HackleConfigBuilder()
-                .mode(EvaluationMode.remote)
+                .evaluationMode(EvaluationMode.remote)
                 .build()
 
             let app = await MainActor.run {


### PR DESCRIPTION
## 개요
WebView wrapper mode 관련 설정을 deprecated API로 분리하고, evaluation mode 설정 API를 명확하게 변경합니다.
workspace properties에 `evaluation_mode`를 추가하여 local/remote evaluation 상태를 구분할 수 있도록 했습니다.

## 작업 내용
- `HackleConfig+Deprecate.swift`를 추가해 deprecated 설정 API를 별도 extension으로 분리
- `HackleConfigBuilder.mode(_:)`의 `EvaluationMode` overload를 `evaluationMode(_:)`로 변경
- local workspace properties에 `evaluation_mode: LOCAL` 추가
- remote workspace evaluation properties에 `evaluation_mode: REMOTE` 추가
- 관련 테스트 업데이트

## 사용 예제
```swift
let config = HackleConfigBuilder()
    .evaluationMode(.remote)
    .build()
```