### PR TITLE
fix: serialize current in-app message view DTO

### DIFF
--- a/Sources/Hackle/Invocator/Model/InvocationDto.swift
+++ b/Sources/Hackle/Invocator/Model/InvocationDto.swift
@@ -11,6 +11,8 @@ typealias DecisionDto = [String: Any]
 typealias FeatureFlagDecisionDto = [String: Any]
 typealias PropertyOperationsDto = [String: [String: Any]]
 typealias HackleSubscriptionOperationsDto = [String: String]
+typealias HackleInAppMessageDto = [String: Any]
+typealias HackleInAppMessageViewDto = [String: Any]
 
 extension User {
     func toDto() -> UserDto {
@@ -166,29 +168,20 @@ extension HackleSubscriptionOperations {
     }
 }
 
-struct HackleInAppMessageDto: Codable {
-    let key: Int64
-}
-
-struct HackleInAppMessageViewDto: Codable {
-    let id: String
-    let inAppMessage: HackleInAppMessageDto
-}
-
 extension InAppMessageView {
     nonisolated func toDto() -> HackleInAppMessageViewDto {
-        return HackleInAppMessageViewDto(
-            id: id,
-            inAppMessage: inAppMessage.toDto()
-        )
+        return [
+            "id": id,
+            "inAppMessage": inAppMessage.toDto()
+        ]
     }
 }
 
 extension HackleInAppMessage {
     func toDto() -> HackleInAppMessageDto {
-        return HackleInAppMessageDto(
-            key: key
-        )
+        return [
+            "key": key
+        ]
     }
 }
 

--- a/Tests/HackleTests/Invocator/Invocation/InvocationHandlerSpecs.swift
+++ b/Tests/HackleTests/Invocator/Invocation/InvocationHandlerSpecs.swift
@@ -48,7 +48,23 @@ class InvocationHandlerSpecs: QuickSpec {
                     // then
                     expect(actual.isSuccess).to(equal(true))
                     expect(actual.data).toNot(beNil())
-                    expect(actual.data?.id).to(equal("42"))
+                    expect(actual.data?["id"] as? String).to(equal("42"))
+                }
+
+                it("when current view exists then serializes to success json") {
+                    // given
+                    let view = MockInAppMessageView(id: "42")
+                    core.currentInAppMessageView = view
+                    let request = reqest(command: .getCurrentInAppMessageView)
+
+                    // when
+                    let actual = try sut.handle(request: request).toJsonString()
+
+                    // then
+                    expect(actual).to(contain("\"success\":true"))
+                    expect(actual).to(contain("\"id\":\"42\""))
+                    expect(actual).to(contain("\"inAppMessage\""))
+                    expect(actual).toNot(contain("Error occurs while parsing response."))
                 }
             }
         }


### PR DESCRIPTION
## 개요
현재 인앱 메시지 뷰 조회 응답이 JSON으로 정상 직렬화되지 않는 문제를 수정합니다.
`HackleInAppMessageViewDto`와 `HackleInAppMessageDto`를 dictionary 기반 DTO로 변경하여 invocator 응답 파싱 오류를 방지합니다.

## 작업 내용
- 인앱 메시지 뷰 DTO를 `Codable` struct에서 `[String: Any]` typealias로 변경
- `InAppMessageView.toDto()`와 `HackleInAppMessage.toDto()`가 JSON 직렬화 가능한 dictionary를 반환하도록 수정
